### PR TITLE
Use MemoryMarshal.Cast<byte, _> on 64-bit Android

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SafeBitConverter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SafeBitConverter.cs
@@ -10,7 +10,7 @@ namespace MessagePack
     {
         internal static unsafe long ToInt64(ReadOnlySpan<byte> value)
         {
-#if UNITY_ANDROID
+#if UNITY_ANDROID && !UNITY_EDITOR
             if (sizeof(int*) == 4)
             {
                 uint i1 = (uint)(value[0] | (value[1] << 8) | (value[2] << 16) | (value[3] << 24));
@@ -25,7 +25,7 @@ namespace MessagePack
 
         internal static unsafe ushort ToUInt16(ReadOnlySpan<byte> value)
         {
-#if UNITY_ANDROID
+#if UNITY_ANDROID && !UNITY_EDITOR
             if (sizeof(int*) == 4)
             {
                 return (ushort)(value[0] | (value[1] << 8));
@@ -36,7 +36,7 @@ namespace MessagePack
 
         internal static unsafe uint ToUInt32(ReadOnlySpan<byte> value)
         {
-#if UNITY_ANDROID
+#if UNITY_ANDROID && !UNITY_EDITOR
             if (sizeof(int*) == 4)
             {
                 return (uint)(value[0] | (value[1] << 8) | (value[2] << 16) | (value[3] << 24));

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SafeBitConverter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SafeBitConverter.cs
@@ -13,18 +13,9 @@ namespace MessagePack
 #if UNITY_ANDROID
             if (sizeof(int*) == 4)
             {
-                if (BitConverter.IsLittleEndian)
-                {
-                    uint i1 = (uint)(value[0] | (value[1] << 8) | (value[2] << 16) | (value[3] << 24));
-                    uint i2 = (uint)(value[4] | (value[5] << 8) | (value[6] << 16) | (value[7] << 24));
-                    return i1 | ((long)i2 << 32);
-                }
-                else
-                {
-                    uint i1 = (uint)((value[0] << 24) | (value[1] << 16) | (value[2] << 8) | value[3]);
-                    uint i2 = (uint)((value[4] << 24) | (value[5] << 16) | (value[6] << 8) | value[7]);
-                    return i2 | ((long)i1 << 32);
-                }
+                uint i1 = (uint)(value[0] | (value[1] << 8) | (value[2] << 16) | (value[3] << 24));
+                uint i2 = (uint)(value[4] | (value[5] << 8) | (value[6] << 16) | (value[7] << 24));
+                return i1 | ((long)i2 << 32);
             }
 #endif
             return MemoryMarshal.Cast<byte, long>(value)[0];
@@ -37,14 +28,7 @@ namespace MessagePack
 #if UNITY_ANDROID
             if (sizeof(int*) == 4)
             {
-                if (BitConverter.IsLittleEndian)
-                {
-                    return (ushort)(value[0] | (value[1] << 8));
-                }
-                else
-                {
-                    return (ushort)((value[0] << 8) | value[1]);
-                }
+                return (ushort)(value[0] | (value[1] << 8));
             }
 #endif
             return MemoryMarshal.Cast<byte, ushort>(value)[0];
@@ -55,14 +39,7 @@ namespace MessagePack
 #if UNITY_ANDROID
             if (sizeof(int*) == 4)
             {
-                if (BitConverter.IsLittleEndian)
-                {
-                    return (uint)(value[0] | (value[1] << 8) | (value[2] << 16) | (value[3] << 24));
-                }
-                else
-                {
-                    return (uint)((value[0] << 24) | (value[1] << 16) | (value[2] << 8) | value[3]);
-                }
+                return (uint)(value[0] | (value[1] << 8) | (value[2] << 16) | (value[3] << 24));
             }
 #endif
             return MemoryMarshal.Cast<byte, uint>(value)[0];

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SafeBitConverter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SafeBitConverter.cs
@@ -8,58 +8,64 @@ namespace MessagePack
 {
     internal static class SafeBitConverter
     {
-        internal static long ToInt64(ReadOnlySpan<byte> value)
+        internal static unsafe long ToInt64(ReadOnlySpan<byte> value)
         {
 #if UNITY_ANDROID
-            if (BitConverter.IsLittleEndian)
+            if (sizeof(int*) == 4)
             {
-                uint i1 = (uint)(value[0] | (value[1] << 8) | (value[2] << 16) | (value[3] << 24));
-                uint i2 = (uint)(value[4] | (value[5] << 8) | (value[6] << 16) | (value[7] << 24));
-                return i1 | ((long)i2 << 32);
+                if (BitConverter.IsLittleEndian)
+                {
+                    uint i1 = (uint)(value[0] | (value[1] << 8) | (value[2] << 16) | (value[3] << 24));
+                    uint i2 = (uint)(value[4] | (value[5] << 8) | (value[6] << 16) | (value[7] << 24));
+                    return i1 | ((long)i2 << 32);
+                }
+                else
+                {
+                    uint i1 = (uint)((value[0] << 24) | (value[1] << 16) | (value[2] << 8) | value[3]);
+                    uint i2 = (uint)((value[4] << 24) | (value[5] << 16) | (value[6] << 8) | value[7]);
+                    return i2 | ((long)i1 << 32);
+                }
             }
-            else
-            {
-                uint i1 = (uint)((value[0] << 24) | (value[1] << 16) | (value[2] << 8) | value[3]);
-                uint i2 = (uint)((value[4] << 24) | (value[5] << 16) | (value[6] << 8) | value[7]);
-                return i2 | ((long)i1 << 32);
-            }
-#else
-            return MemoryMarshal.Cast<byte, long>(value)[0];
 #endif
+            return MemoryMarshal.Cast<byte, long>(value)[0];
         }
 
         internal static ulong ToUInt64(ReadOnlySpan<byte> value) => unchecked((ulong)ToInt64(value));
 
-        internal static ushort ToUInt16(ReadOnlySpan<byte> value)
+        internal static unsafe ushort ToUInt16(ReadOnlySpan<byte> value)
         {
 #if UNITY_ANDROID
-            if (BitConverter.IsLittleEndian)
+            if (sizeof(int*) == 4)
             {
-                return (ushort)(value[0] | (value[1] << 8));
+                if (BitConverter.IsLittleEndian)
+                {
+                    return (ushort)(value[0] | (value[1] << 8));
+                }
+                else
+                {
+                    return (ushort)((value[0] << 8) | value[1]);
+                }
             }
-            else
-            {
-                return (ushort)((value[0] << 8) | value[1]);
-            }
-#else
-            return MemoryMarshal.Cast<byte, ushort>(value)[0];
 #endif
+            return MemoryMarshal.Cast<byte, ushort>(value)[0];
         }
 
-        internal static uint ToUInt32(ReadOnlySpan<byte> value)
+        internal static unsafe uint ToUInt32(ReadOnlySpan<byte> value)
         {
 #if UNITY_ANDROID
-            if (BitConverter.IsLittleEndian)
+            if (sizeof(int*) == 4)
             {
-                return (uint)(value[0] | (value[1] << 8) | (value[2] << 16) | (value[3] << 24));
+                if (BitConverter.IsLittleEndian)
+                {
+                    return (uint)(value[0] | (value[1] << 8) | (value[2] << 16) | (value[3] << 24));
+                }
+                else
+                {
+                    return (uint)((value[0] << 24) | (value[1] << 16) | (value[2] << 8) | value[3]);
+                }
             }
-            else
-            {
-                return (uint)((value[0] << 24) | (value[1] << 16) | (value[2] << 8) | value[3]);
-            }
-#else
-            return MemoryMarshal.Cast<byte, uint>(value)[0];
 #endif
+            return MemoryMarshal.Cast<byte, uint>(value)[0];
         }
     }
 }


### PR DESCRIPTION
The original issue that SafeBitConverter tries to solve only happens on ARMv7 devices. But in current code, both 32-bit and 64-bit Android devices execute the non-efficient path. 

This PR makes 64-bit Android can execute the efficent path. Due to the optimization of c++ compiler, `if (sizeof(int*) == 4)` and the unreachable branch will be eliminated, so they won't be in the compiled code.