### PR TITLE
Union type collect

### DIFF
--- a/sandbox/TestData2/UnionInterface.cs
+++ b/sandbox/TestData2/UnionInterface.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1307 // Accessible fields should begin with upper-case letter
+#pragma warning disable SA1401 // Fields should be private
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
+namespace TestData2
+{
+    [Union(0, typeof(UnionInterfaceImplementation))]
+    public interface IUnionInterface
+    {
+        float Value { get; }
+    }
+
+    [MessagePackObject(true)]
+    public class UnionInterfaceImplementation : IUnionInterface
+    {
+        public float Value { get; set; }
+    }
+}

--- a/src/MessagePack.Analyzers/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.Analyzers/CodeAnalysis/TypeCollector.cs
@@ -400,6 +400,8 @@ public class TypeCollector
                 return null;
             }
 
+            CollectCore(typeSymbol);
+
             var typeName = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
             return new UnionSubTypeInfo(key, typeName);
         }


### PR DESCRIPTION
If there is an interface declaration with Union attributes, types that are specified aren't collected for formatter generation. But, in the same time, if there is Union attributes above generic type declaration, types from them will be collected (**CollectGenericUnion**).