### PR TITLE
Configure the analyzer to be debuggable with Visual Studio 2022

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <!-- Workaround https://github.com/dotnet/wpf/issues/1718 -->
     <EmbedUntrackedSources Condition=" '$(UseWPF)' == 'true' ">false</EmbedUntrackedSources>
+
+    <!-- set to make analyzer debugable https://github.com/dotnet/roslyn-sdk/issues/850 -->
+    <IsRoslynComponent Condition="'$(IsAnalyzerProject)' == 'true'">true</IsRoslynComponent>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/MessagePack.SourceGenerator.Tests/MessagePack.SourceGenerator.Tests.csproj
+++ b/tests/MessagePack.SourceGenerator.Tests/MessagePack.SourceGenerator.Tests.csproj
@@ -24,7 +24,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\MessagePack.SourceGenerator\MessagePack.SourceGenerator.csproj" />
+    <ProjectReference Include="..\..\src\MessagePack.SourceGenerator\MessagePack.SourceGenerator.csproj">
+      <!-- https://github.com/dotnet/roslyn-sdk/issues/850 -->
+      <OutputItemType>Analyzer</OutputItemType>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\MessagePack.Analyzers\MessagePack.Analyzers.csproj" />
     <ProjectReference Include="..\..\src\MessagePack\MessagePack.csproj" />
   </ItemGroup>

--- a/tests/MessagePack.SourceGenerator.Unity.Tests/MessagePack.SourceGenerator.Unity.Tests.csproj
+++ b/tests/MessagePack.SourceGenerator.Unity.Tests/MessagePack.SourceGenerator.Unity.Tests.csproj
@@ -29,7 +29,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\MessagePack.SourceGenerator.Unity\MessagePack.SourceGenerator.Unity.csproj" />
+    <ProjectReference Include="..\..\src\MessagePack.SourceGenerator.Unity\MessagePack.SourceGenerator.Unity.csproj">
+      <!-- https://github.com/dotnet/roslyn-sdk/issues/850 -->
+      <OutputItemType>Analyzer</OutputItemType>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\MessagePack.Analyzers\MessagePack.Analyzers.csproj" />
     <ProjectReference Include="..\..\src\MessagePack\MessagePack.csproj" />
   </ItemGroup>


### PR DESCRIPTION
I think this will make it easier to debug Analyzer

referenced the following:  
https://github.com/dotnet/roslyn-sdk/issues/850#issuecomment-1038725567