### PR TITLE
Fix analyzer when only MessagePack.Annotations is referenced

### DIFF
--- a/src/MessagePack.Analyzers/CodeAnalysis/ReferenceSymbols.cs
+++ b/src/MessagePack.Analyzers/CodeAnalysis/ReferenceSymbols.cs
@@ -13,7 +13,7 @@ public record ReferenceSymbols(
     INamedTypeSymbol KeyAttribute,
     INamedTypeSymbol IgnoreAttribute,
     INamedTypeSymbol FormatterAttribute,
-    INamedTypeSymbol MessagePackFormatter,
+    INamedTypeSymbol? MessagePackFormatter,
     INamedTypeSymbol? IgnoreDataMemberAttribute,
     INamedTypeSymbol IMessagePackSerializationCallbackReceiver)
 {
@@ -58,10 +58,6 @@ public record ReferenceSymbols(
         }
 
         INamedTypeSymbol? messageFormatter = compilation.GetTypeByMetadataName("MessagePack.Formatters.IMessagePackFormatter");
-        if (messageFormatter is null)
-        {
-            return false;
-        }
 
         INamedTypeSymbol? ignoreDataMemberAttribute = compilation.GetTypeByMetadataName("System.Runtime.Serialization.IgnoreDataMemberAttribute");
 

--- a/tests/MessagePack.Analyzers.Tests/Helpers/ReferencesHelper.cs
+++ b/tests/MessagePack.Analyzers.Tests/Helpers/ReferencesHelper.cs
@@ -9,4 +9,8 @@ internal static class ReferencesHelper
     internal static ReferenceAssemblies DefaultReferences = ReferenceAssemblies.NetFramework.Net472.Default
         .AddPackages(ImmutableArray.Create(
             new PackageIdentity("MessagePack", "2.0.335")));
+
+    internal static ReferenceAssemblies AnnotationsOnly = ReferenceAssemblies.NetFramework.Net472.Default
+        .AddPackages(ImmutableArray.Create(
+            new PackageIdentity("MessagePack.Annotations", "2.0.335")));
 }

--- a/tests/MessagePack.Analyzers.Tests/MessagePackAnalyzerTests.cs
+++ b/tests/MessagePack.Analyzers.Tests/MessagePackAnalyzerTests.cs
@@ -190,6 +190,7 @@ public class Bar : Foo
 
         await new VerifyCS.Test
         {
+            ReferenceAssemblies = ReferencesHelper.AnnotationsOnly,
             CodeFixTestBehaviors = CodeFixTestBehaviors.SkipLocalDiagnosticCheck, // BUGBUG: move diagnostic to `Foo` reference in Bar's base type list.
             TestState =
             {


### PR DESCRIPTION
Fixes #1672