### PR TITLE
Allow applying `[MessagePackFormatter]` on parameters

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Annotations/Attributes.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Annotations/Attributes.cs
@@ -83,7 +83,7 @@ namespace MessagePack
     {
     }
 
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface | AttributeTargets.Enum | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface | AttributeTargets.Enum | AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
     public class MessagePackFormatterAttribute : Attribute
     {
         public Type FormatterType { get; private set; }


### PR DESCRIPTION
This enables RPC libraries such as StreamJsonRpc to support this attribute being applied to RPC method parameters and invoking the correct formatter in such cases.