### PR TITLE
Better constrain dictionary detection

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicGenericResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicGenericResolver.cs
@@ -309,7 +309,7 @@ namespace MessagePack.Internal
             {
                 // generic dictionary
                 var dictionaryDef = ti.ImplementedInterfaces.FirstOrDefault(x => x.GetTypeInfo().IsConstructedGenericType() && x.GetGenericTypeDefinition() == typeof(IDictionary<,>));
-                if (dictionaryDef != null && ti.DeclaredConstructors.Any(x => x.GetParameters().Length == 0))
+                if (dictionaryDef != null && ti.DeclaredConstructors.Any(x => !x.IsStatic && x.GetParameters().Length == 0))
                 {
                     Type keyType = dictionaryDef.GenericTypeArguments[0];
                     Type valueType = dictionaryDef.GenericTypeArguments[1];
@@ -318,7 +318,7 @@ namespace MessagePack.Internal
 
                 // generic dictionary with collection ctor
                 var dictionaryInterfaceDef = ti.ImplementedInterfaces.FirstOrDefault(x => x.GetTypeInfo().IsConstructedGenericType() &&
-                    (x.GetGenericTypeDefinition() == typeof(IDictionary<,>) || x.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>)));
+                    (x.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>)));
                 if (dictionaryInterfaceDef != null)
                 {
                     Type keyType = dictionaryInterfaceDef.GenericTypeArguments[0];
@@ -342,7 +342,7 @@ namespace MessagePack.Internal
 
                 // generic collection
                 var collectionDef = ti.ImplementedInterfaces.FirstOrDefault(x => x.GetTypeInfo().IsConstructedGenericType() && x.GetGenericTypeDefinition() == typeof(ICollection<>));
-                if (collectionDef != null && ti.DeclaredConstructors.Any(x => x.GetParameters().Length == 0))
+                if (collectionDef != null && ti.DeclaredConstructors.Any(x => !x.IsStatic && x.GetParameters().Length == 0))
                 {
                     Type elemType = collectionDef.GenericTypeArguments[0];
                     return CreateInstance(typeof(GenericCollectionFormatter<,>), new[] { elemType, t });

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverConstructorTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverConstructorTest.cs
@@ -2,6 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Xunit;
 
 namespace MessagePack.Tests
@@ -277,6 +281,101 @@ namespace MessagePack.Tests
                 Y = y;
                 Z = z;
             }
+        }
+
+        [MessagePackObject]
+        public class DeviceCommands : IDictionary<int, string>
+        {
+            [IgnoreMember]
+            public static readonly DeviceCommands Empty = new(new Dictionary<int, string>());
+
+            [Key(0)]
+            public IDictionary<int, string> Commands { get; }
+
+            [IgnoreMember]
+            public ICollection<int> Keys => throw new NotImplementedException();
+
+            [IgnoreMember]
+            public ICollection<string> Values => throw new NotImplementedException();
+
+            [IgnoreMember]
+            public int Count => 0;
+
+            [IgnoreMember]
+            public bool IsReadOnly => throw new NotImplementedException();
+
+            public string this[int key]
+            {
+                get => throw new NotImplementedException();
+                set => throw new NotImplementedException();
+            }
+
+            [SerializationConstructor]
+            public DeviceCommands(IDictionary<int, string> commands)
+            {
+                Commands = commands;
+            }
+
+            public void Add(int key, string value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool ContainsKey(int key)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool Remove(int key)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool TryGetValue(int key, [MaybeNullWhen(false)] out string value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Add(KeyValuePair<int, string> item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Clear()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool Contains(KeyValuePair<int, string> item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void CopyTo(KeyValuePair<int, string>[] array, int arrayIndex)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool Remove(KeyValuePair<int, string> item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IEnumerator<KeyValuePair<int, string>> GetEnumerator()
+            {
+                return Enumerable.Empty<KeyValuePair<int, string>>().GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [Fact]
+        public void DictionaryWithStaticCtor()
+        {
+            MessagePackSerializer.Serialize(new DeviceCommands(new Dictionary<int, string>()), MessagePackSerializerOptions.Standard);
         }
 
         [Fact]


### PR DESCRIPTION
- Searches for constructors should _not_ match on static constructors
- It is not enough for a class to implement `IDictionary<K, V>` to use `GenericCollectionFormatter`, which has a generic type constraint that requires `IReadOnlyDictionary<K, V>`.

Fixes #1686