### PR TITLE
Support to analyze records and record structs

### DIFF
--- a/src/MessagePackAnalyzer/MessagePackAnalyzer.cs
+++ b/src/MessagePackAnalyzer/MessagePackAnalyzer.cs
@@ -80,7 +80,7 @@ namespace MessagePackAnalyzer
             {
                 if (ReferenceSymbols.TryCreate(ctxt.Compilation, out ReferenceSymbols? typeReferences))
                 {
-                    ctxt.RegisterSyntaxNodeAction(c => Analyze(c, typeReferences), SyntaxKind.ClassDeclaration, SyntaxKind.StructDeclaration, SyntaxKind.InterfaceDeclaration);
+                    ctxt.RegisterSyntaxNodeAction(c => Analyze(c, typeReferences), SyntaxKind.ClassDeclaration, SyntaxKind.StructDeclaration, SyntaxKind.InterfaceDeclaration, SyntaxKind.RecordDeclaration, SyntaxKind.RecordStructDeclaration);
                 }
             });
         }

--- a/tests/MessagePackAnalyzer.Tests/Helpers/CSharpCodeFixVerifier`2+Test.cs
+++ b/tests/MessagePackAnalyzer.Tests/Helpers/CSharpCodeFixVerifier`2+Test.cs
@@ -25,7 +25,7 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
             {
                 var parseOptions = (CSharpParseOptions?)solution.GetProject(projectId)?.ParseOptions;
                 Assert.NotNull(parseOptions);
-                solution = solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion.CSharp7_3));
+                solution = solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion.CSharp10));
 
                 return solution;
             });

--- a/tests/MessagePackAnalyzer.Tests/MessagePackAnalyzerTests.cs
+++ b/tests/MessagePackAnalyzer.Tests/MessagePackAnalyzerTests.cs
@@ -153,6 +153,80 @@ public class Bar
     }
 
     [Fact]
+    public async Task AddAttributeToTypeForRecord()
+    {
+        // Don't use Preamble because we want to test that it works without a using statement at the top.
+        string input = @"
+public class Foo
+{
+    public string Member { get; set; }
+}
+
+[MessagePack.MessagePackObject]
+public record Bar
+{
+    [MessagePack.Key(0)]
+    public Foo {|MsgPack003:Member|} { get; set; }
+}
+";
+
+        string output = @"
+[MessagePack.MessagePackObject]
+public class Foo
+{
+    [MessagePack.Key(0)]
+    public string Member { get; set; }
+}
+
+[MessagePack.MessagePackObject]
+public record Bar
+{
+    [MessagePack.Key(0)]
+    public Foo Member { get; set; }
+}
+";
+
+        await VerifyCS.VerifyCodeFixAsync(input, output);
+    }
+
+    [Fact]
+    public async Task AddAttributeToTypeForRecordStruct()
+    {
+        // Don't use Preamble because we want to test that it works without a using statement at the top.
+        string input = @"
+public class Foo
+{
+    public string Member { get; set; }
+}
+
+[MessagePack.MessagePackObject]
+public record struct Bar
+{
+    [MessagePack.Key(0)]
+    public Foo {|MsgPack003:Member|} { get; set; }
+}
+";
+
+        string output = @"
+[MessagePack.MessagePackObject]
+public class Foo
+{
+    [MessagePack.Key(0)]
+    public string Member { get; set; }
+}
+
+[MessagePack.MessagePackObject]
+public record struct Bar
+{
+    [MessagePack.Key(0)]
+    public Foo Member { get; set; }
+}
+";
+
+        await VerifyCS.VerifyCodeFixAsync(input, output);
+    }
+
+    [Fact]
     public async Task CodeFixAppliesAcrossFiles()
     {
         var inputs = new string[]


### PR DESCRIPTION
Currently, MessagePackAnalyzer does not analyze records, so adding a `[MessagePackObject]` attribute to the type used in the field is forgotten and may cause a runtime error.

![image](https://github.com/MessagePack-CSharp/MessagePack-CSharp/assets/27144255/6516b4af-0240-4bcb-af7e-e77bac64ae64)
