### PR TITLE
Handle DataContract(Order=N) across class hierarchies?

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1860,71 +1860,85 @@ namespace MessagePack.Internal
                 // Public members with KeyAttribute except [Ignore] member.
                 var searchFirst = true;
                 var hiddenIntKey = 0;
-
-                var memberInfos = GetAllProperties(type).Cast<MemberInfo>().Concat(GetAllFields(type));
-                foreach (var member in memberInfos.Select(CreateEmittableMember))
+                var memberInfoGroups = GetAllFieldsAndProperties(type)
+                    .OrderByDescending(group => group.Key);
+                var level = (offset: 0, max: -1);
+                foreach (var memberInfos in memberInfoGroups)
                 {
-                    if (member is null)
-                    {
-                        continue;
-                    }
+                    level.offset = level.max + 1;
 
-                    MemberInfo memberInfo = (MemberInfo?)member.PropertyInfo ?? member.FieldInfo!;
-
-                    KeyAttribute key;
-                    if (contractAttr != null)
+                    foreach (var member in memberInfos.Select(CreateEmittableMember))
                     {
-                        // MessagePackObjectAttribute. KeyAttribute must be marked, and IntKey or StringKey must be set.
-                        key = memberInfo.GetCustomAttribute<KeyAttribute>(true) ??
-                            throw new MessagePackDynamicObjectResolverException($"all public members must mark KeyAttribute or IgnoreMemberAttribute. type:{type.FullName} member:{memberInfo.Name}");
-                        if (key.IntKey == null && key.StringKey == null)
-                        {
-                            throw new MessagePackDynamicObjectResolverException($"both IntKey and StringKey are null. type: {type.FullName} member:{memberInfo.Name}");
-                        }
-                    }
-                    else
-                    {
-                        // DataContractAttribute. Try to use the DataMemberAttribute to fake KeyAttribute.
-                        // This member has no DataMemberAttribute nor IgnoreMemberAttribute.
-                        // But the type *did* have a DataContractAttribute on it, so no attribute implies the member should not be serialized.
-                        var pseudokey = memberInfo.GetCustomAttribute<DataMemberAttribute>(true);
-                        if (pseudokey == null)
+                        if (member is null)
                         {
                             continue;
                         }
 
-                        key =
-                            pseudokey.Order != -1 ? new KeyAttribute(pseudokey.Order) :
-                            pseudokey.Name != null ? new KeyAttribute(pseudokey.Name) :
-                            new KeyAttribute(memberInfo.Name);
-                    }
+                        MemberInfo memberInfo = (MemberInfo?)member.PropertyInfo ?? member.FieldInfo!;
 
-                    member.IsExplicitContract = true;
+                        KeyAttribute key;
+                        if (contractAttr != null)
+                        {
+                            // MessagePackObjectAttribute. KeyAttribute must be marked, and IntKey or StringKey must be set.
+                            key = memberInfo.GetCustomAttribute<KeyAttribute>(true) ??
+                                throw new MessagePackDynamicObjectResolverException($"all public members must mark KeyAttribute or IgnoreMemberAttribute. type:{type.FullName} member:{memberInfo.Name}");
+                            if (key.IntKey == null && key.StringKey == null)
+                            {
+                                throw new MessagePackDynamicObjectResolverException($"both IntKey and StringKey are null. type: {type.FullName} member:{memberInfo.Name}");
+                            }
+                        }
+                        else
+                        {
+                            // DataContractAttribute. Try to use the DataMemberAttribute to fake KeyAttribute.
+                            // This member has no DataMemberAttribute nor IgnoreMemberAttribute.
+                            // But the type *did* have a DataContractAttribute on it, so no attribute implies the member should not be serialized.
+                            var pseudokey = memberInfo.GetCustomAttribute<DataMemberAttribute>(true);
+                            if (pseudokey == null)
+                            {
+                                continue;
+                            }
 
-                    // Cannot assign StringKey and IntKey at the same time.
-                    if (searchFirst)
-                    {
-                        searchFirst = false;
-                        isIntKey = key.IntKey != null;
-                    }
-                    else if ((isIntKey && key.IntKey == null) || (!isIntKey && key.StringKey == null))
-                    {
-                        throw new MessagePackDynamicObjectResolverException($"all members key type must be same. type: {type.FullName} member:{memberInfo.Name}");
-                    }
+                            if (pseudokey.Order != -1)
+                            {
+                                var calculatedOrder = pseudokey.Order + level.offset;
+                                level.max = Math.Max(level.max, calculatedOrder);
+                                key = new KeyAttribute(calculatedOrder);
+                            }
+                            else
+                            {
+                                key =
+                                    pseudokey.Name != null ? new KeyAttribute(pseudokey.Name) :
+                                    new KeyAttribute(memberInfo.Name);
+                            }
+                        }
 
-                    if (isIntKey)
-                    {
-                        member.IntKey = key.IntKey!.Value;
-                    }
-                    else
-                    {
-                        member.StringKey = key.StringKey;
-                        member.IntKey = hiddenIntKey++;
-                    }
+                        member.IsExplicitContract = true;
 
-                    if (!AddEmittableMemberOrIgnore(isIntKey, member, true))
-                    {
-                        continue;
+                        // Cannot assign StringKey and IntKey at the same time.
+                        if (searchFirst)
+                        {
+                            searchFirst = false;
+                            isIntKey = key.IntKey != null;
+                        }
+                        else if ((isIntKey && key.IntKey == null) || (!isIntKey && key.StringKey == null))
+                        {
+                            throw new MessagePackDynamicObjectResolverException($"all members key type must be same. type: {type.FullName} member:{memberInfo.Name}");
+                        }
+
+                        if (isIntKey)
+                        {
+                            member.IntKey = key.IntKey!.Value;
+                        }
+                        else
+                        {
+                            member.StringKey = key.StringKey;
+                            member.IntKey = hiddenIntKey++;
+                        }
+
+                        if (!AddEmittableMemberOrIgnore(isIntKey, member, true))
+                        {
+                            continue;
+                        }
                     }
                 }
             }
@@ -2162,37 +2176,28 @@ namespace MessagePack.Internal
                 ;
         }
 
-        private static IEnumerable<FieldInfo> GetAllFields(Type type)
+        private static IEnumerable<IGrouping<int, MemberInfo>> GetAllFieldsAndProperties(Type type, int level = 0)
         {
             if (type.BaseType is object)
             {
-                foreach (var item in GetAllFields(type.BaseType))
+                foreach (var item in GetAllFieldsAndProperties(type.BaseType, level + 1))
                 {
                     yield return item;
                 }
             }
 
             // with declared only
-            foreach (var item in type.GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
-            {
-                yield return item;
-            }
-        }
+            var fields = type.GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+            var properties = type.GetProperties(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
 
-        private static IEnumerable<PropertyInfo> GetAllProperties(Type type)
-        {
-            if (type.BaseType is object)
-            {
-                foreach (var item in GetAllProperties(type.BaseType))
-                {
-                    yield return item;
-                }
-            }
+            var grouping = (properties.Any() ? properties : Enumerable.Empty<MemberInfo>())
+                .Concat(fields.Any() ? fields.Cast<MemberInfo>() : Enumerable.Empty<MemberInfo>())
+                .GroupBy(_ => level)
+                .FirstOrDefault();
 
-            // with declared only
-            foreach (var item in type.GetProperties(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            if (grouping != null)
             {
-                yield return item;
+                yield return grouping;
             }
         }
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs
@@ -323,6 +323,44 @@ namespace MessagePack.Tests
             Assert.Equal(-98, instance.Prop2);
         }
 
+        [Fact]
+        public void OrdinalOrderingWithInheritance()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteArrayHeader(4);
+            writer.Write("One");
+            writer.Write("Two");
+            writer.Write("Three");
+            writer.Write("Four");
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<InheritanceOrdinalKeyOrdering>(seq);
+            Assert.Equal("One", instance.Prop1);
+            Assert.Equal("Two", instance.Prop2);
+            Assert.Equal("Three", instance.ChildProp1);
+            Assert.Equal("Four", instance.ChildProp2);
+        }
+
+        [Fact]
+        public void OrdinalOrderingWithInheritance_RoundTrip()
+        {
+            var initialInstance = new InheritanceOrdinalKeyOrdering()
+            {
+                Prop1 = "1",
+                Prop2 = "2",
+                ChildProp1 = "3",
+                ChildProp2 = "4",
+            };
+            var options = StandardResolver.Options;
+            byte[] msgpack = MessagePackSerializer.Serialize(initialInstance, options);
+            var deserialized = MessagePackSerializer.Deserialize<InheritanceOrdinalKeyOrdering>(msgpack, options);
+            Assert.Equal(initialInstance.Prop1, deserialized.Prop1);
+            Assert.Equal(initialInstance.Prop2, deserialized.Prop2);
+            Assert.Equal(initialInstance.ChildProp1, deserialized.ChildProp1);
+            Assert.Equal(initialInstance.ChildProp2, deserialized.ChildProp2);
+        }
+
 #if !UNITY_2018_3_OR_NEWER
 
         [Fact]
@@ -581,6 +619,16 @@ namespace MessagePack.Tests
 
             [DataMember(Order = 1)]
             public string Prop2 { get; set; } = "Uninitialized";
+        }
+
+        [DataContract]
+        public class InheritanceOrdinalKeyOrdering : TwoPropertiesOrdinalKey
+        {
+            [DataMember(Order = 0)]
+            public string ChildProp1 { get; set; } = "Uninitialized";
+
+            [DataMember(Order = 1)]
+            public string ChildProp2 { get; set; } = "Uninitialized";
         }
 
         [MessagePackObject]


### PR DESCRIPTION
Hi,
I'm new to message pack, c sharp and this library so I may have made some mistakes or failed to understand things.  It's possible the entire problem this pull request is made to solve is either invalid or handled in some other way, I'm not sure.  I'm happy to make changes or delete this pull request as you feel is appropriate.

Here is my problem situation:
```c#
[DataContract]
class SomeParent {
  [DataMember(Order = 0)]
  public int ParentField1 { get; set; }
  [DataMember(Order = 1)]
  public int ParentField2 { get; set; }
}

[DataContract]
class SomeChild : SomeParent {
  [DataMember(Order = 0)]
  public int MyField1 { get; set; }
  [DataMember(Order = 1)]
  public int MyField2 { get; set; }
}
``` 

In this case the library will fail to serialize/deserialize the SomeChild object as it claims there are duplicate integer ordering keys on the properties.  This is true, there are.  However, I'm not entirely sure this should be an error and it would seem that Microsoft WCF handles this case via the rules [here](https://learn.microsoft.com/en-us/dotnet/framework/wcf/feature-details/data-member-order#basic-rules).  Specifically the parent class stuff should go first, then child class, then child^2 class and so on.  Given that WCF handles this, and therefore code with such annotations are valid... should message pack handle this??

The code change here will address rule :1 in the "Basic Rules" section.  It does not endeavor to handle rules :2 and :3 (the commingling of integer ordered and non-integer ordered fields). 

🤷 is this a bug?