### PR TITLE
Support to analyze records

### DIFF
--- a/src/MessagePack.Analyzers.CodeFixes/MessagePackCodeFixProvider.cs
+++ b/src/MessagePack.Analyzers.CodeFixes/MessagePackCodeFixProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) All contributors. All rights reserved.
+// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -161,7 +161,7 @@ public class MessagePackCodeFixProvider : CodeFixProvider
 
         foreach (ISymbol member in targets)
         {
-            if (member.GetAttributes().FindAttributeShortName(MsgPack00xMessagePackAnalyzer.KeyAttributeShortName) is null)
+            if (!member.IsImplicitlyDeclared && member.GetAttributes().FindAttributeShortName(MsgPack00xMessagePackAnalyzer.KeyAttributeShortName) is null)
             {
                 SyntaxNode node = await member.DeclaringSyntaxReferences[0].GetSyntaxAsync(cancellationToken).ConfigureAwait(false);
                 var documentEditor = await solutionEditor.GetDocumentEditorAsync(document.Project.Solution.GetDocumentId(node.SyntaxTree), cancellationToken).ConfigureAwait(false);

--- a/src/MessagePack.Analyzers/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.Analyzers/CodeAnalysis/TypeCollector.cs
@@ -833,13 +833,13 @@ public class TypeCollector
                     {
                         var syntax = item.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax();
 
-                        var location = (syntax as PropertyDeclarationSyntax)?.Type
+                        var typeSyntax = (syntax as PropertyDeclarationSyntax)?.Type
                             ?? (syntax as ParameterSyntax)?.Type; // for primary constructor
 
                         // TODO: add the declaration of the referenced type as an additional location.
                         this.reportDiagnostic?.Invoke(Diagnostic.Create(
                             MsgPack00xMessagePackAnalyzer.TypeMustBeMessagePackObject,
-                            location?.GetLocation(),
+                            typeSyntax?.GetLocation(),
                             item.Type.ToDisplayString(ShortTypeNameFormat)));
                     }
                 }

--- a/src/MessagePack.Analyzers/MsgPack00xMessagePackAnalyzer.cs
+++ b/src/MessagePack.Analyzers/MsgPack00xMessagePackAnalyzer.cs
@@ -202,7 +202,7 @@ public class MsgPack00xMessagePackAnalyzer : DiagnosticAnalyzer
             CodeAnalysis.AnalyzerOptions options = CodeAnalysis.AnalyzerOptions.Parse(ctxt.Options.AnalyzerConfigOptionsProvider.GlobalOptions, ctxt.Options.AdditionalFiles, ctxt.CancellationToken);
             if (ReferenceSymbols.TryCreate(ctxt.Compilation, out ReferenceSymbols? typeReferences))
             {
-                ctxt.RegisterSyntaxNodeAction(c => Analyze(c, typeReferences, options), SyntaxKind.ClassDeclaration, SyntaxKind.StructDeclaration, SyntaxKind.InterfaceDeclaration);
+                ctxt.RegisterSyntaxNodeAction(c => Analyze(c, typeReferences, options), SyntaxKind.ClassDeclaration, SyntaxKind.StructDeclaration, SyntaxKind.InterfaceDeclaration, SyntaxKind.RecordDeclaration);
             }
         });
     }

--- a/tests/MessagePack.Analyzers.Tests/MessagePackAnalyzerTests.cs
+++ b/tests/MessagePack.Analyzers.Tests/MessagePackAnalyzerTests.cs
@@ -32,8 +32,8 @@ public class Foo
         string input = Preamble + @"using MessagePack.Formatters;
 
 public class FooFormatter : IMessagePackFormatter<Foo> {
-	public void Serialize(ref MessagePackWriter writer, Foo value, MessagePackSerializerOptions options) {}
-	public Foo Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options) => default;
+    public void Serialize(ref MessagePackWriter writer, Foo value, MessagePackSerializerOptions options) {}
+    public Foo Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options) => default;
 }
 
 
@@ -146,6 +146,86 @@ public class Bar
 {
     [MessagePack.Key(0)]
     public Foo Member { get; set; }
+}
+";
+
+        await VerifyCS.VerifyCodeFixAsync(input, output);
+    }
+
+    [Fact]
+    public async Task AddAttributeToTypeForRecord()
+    {
+        // Don't use Preamble because we want to test that it works without a using statement at the top.
+        string input = @"
+public class Foo
+{
+    public string Member { get; set; }
+}
+
+[MessagePack.MessagePackObject]
+public record Bar
+{
+    [MessagePack.Key(0)]
+    public {|MsgPack003:Foo|} Member { get; set; }
+}
+";
+
+        string output = @"
+[MessagePack.MessagePackObject]
+public class Foo
+{
+    [MessagePack.Key(0)]
+    public string Member { get; set; }
+}
+
+[MessagePack.MessagePackObject]
+public record Bar
+{
+    [MessagePack.Key(0)]
+    public Foo Member { get; set; }
+}
+";
+
+        await VerifyCS.VerifyCodeFixAsync(input, output);
+    }
+
+    [Fact]
+    public async Task AddAttributeToTypeForRecordPrimaryConstructor()
+    {
+        // Don't use Preamble because we want to test that it works without a using statement at the top.
+        string input = @"
+public class Foo
+{
+    public string Member { get; set; }
+}
+
+[MessagePack.MessagePackObject]
+public record Bar([property: MessagePack.Key(0)] {|MsgPack003:Foo|} Member);
+
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit
+    {
+    }
+}
+";
+
+        string output = @"
+[MessagePack.MessagePackObject]
+public class Foo
+{
+    [MessagePack.Key(0)]
+    public string Member { get; set; }
+}
+
+[MessagePack.MessagePackObject]
+public record Bar([property: MessagePack.Key(0)] Foo Member);
+
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit
+    {
+    }
 }
 ";
 

--- a/tests/MessagePack.Analyzers.Tests/MessagePackAnalyzerTests.cs
+++ b/tests/MessagePack.Analyzers.Tests/MessagePackAnalyzerTests.cs
@@ -153,7 +153,7 @@ public class Bar
     }
 
     [Fact]
-    public async Task AddAttributeToTypeForRecord()
+    public async Task AddAttributeToTypeForRecord1()
     {
         // Don't use Preamble because we want to test that it works without a using statement at the top.
         string input = @"
@@ -173,6 +173,43 @@ public record Bar
         string output = @"
 [MessagePack.MessagePackObject]
 public class Foo
+{
+    [MessagePack.Key(0)]
+    public string Member { get; set; }
+}
+
+[MessagePack.MessagePackObject]
+public record Bar
+{
+    [MessagePack.Key(0)]
+    public Foo Member { get; set; }
+}
+";
+
+        await VerifyCS.VerifyCodeFixAsync(input, output);
+    }
+
+    [Fact]
+    public async Task AddAttributeToTypeForRecord2()
+    {
+        // Don't use Preamble because we want to test that it works without a using statement at the top.
+        string input = @"
+public record Foo
+{
+    public string Member { get; set; }
+}
+
+[MessagePack.MessagePackObject]
+public record Bar
+{
+    [MessagePack.Key(0)]
+    public {|MsgPack003:Foo|} Member { get; set; }
+}
+";
+
+        string output = @"
+[MessagePack.MessagePackObject]
+public record Foo
 {
     [MessagePack.Key(0)]
     public string Member { get; set; }


### PR DESCRIPTION
Continued from #1694 to support some additional use cases, such as primary constructor.

Note: SyntaxKind.RecordStructDeclaration is not defined because the version of Roslyn specified in CodeAnalysisVersionForUnity is 3.8.0. Therefore, record structs cannot be supported.