### PR TITLE
Add MESSAGEPACK_FORCE_AOT preprocessor directive

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/StandardResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/StandardResolver.cs
@@ -28,7 +28,7 @@ namespace MessagePack.Resolvers
 
         private static readonly IFormatterResolver[] Resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
         {
-#if !ENABLE_IL2CPP && !NET_STANDARD_2_0
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP) && !NET_STANDARD_2_0
             DynamicObjectResolver.Instance, // Try Object
 #endif
         }).ToArray();
@@ -57,7 +57,7 @@ namespace MessagePack.Resolvers
                 if (typeof(T) == typeof(object))
                 {
                     // final fallback
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
                     Formatter = (IMessagePackFormatter<T>)DynamicObjectTypeFallbackFormatter.Instance;
 #else
                     Formatter = PrimitiveObjectResolver.Instance.GetFormatter<T>();
@@ -93,7 +93,7 @@ namespace MessagePack.Resolvers
 
         private static readonly IFormatterResolver[] Resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
         {
-#if !ENABLE_IL2CPP && !NET_STANDARD_2_0
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP) && !NET_STANDARD_2_0
             DynamicObjectResolver.Instance, // Try Object
             DynamicContractlessObjectResolver.Instance, // Serializes keys as strings
 #endif
@@ -123,7 +123,7 @@ namespace MessagePack.Resolvers
                 if (typeof(T) == typeof(object))
                 {
                     // final fallback
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
                     Formatter = (IMessagePackFormatter<T>)DynamicObjectTypeFallbackFormatter.Instance;
 #else
                     Formatter = PrimitiveObjectResolver.Instance.GetFormatter<T>();
@@ -159,7 +159,7 @@ namespace MessagePack.Resolvers
 
         private static readonly IFormatterResolver[] Resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
         {
-#if !ENABLE_IL2CPP && !NET_STANDARD_2_0
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP) && !NET_STANDARD_2_0
             DynamicObjectResolverAllowPrivate.Instance, // Try Object
 #endif
         }).ToArray();
@@ -188,7 +188,7 @@ namespace MessagePack.Resolvers
                 if (typeof(T) == typeof(object))
                 {
                     // final fallback
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
                     Formatter = (IMessagePackFormatter<T>)DynamicObjectTypeFallbackFormatter.Instance;
 #else
                     Formatter = PrimitiveObjectResolver.Instance.GetFormatter<T>();
@@ -224,7 +224,7 @@ namespace MessagePack.Resolvers
 
         private static readonly IFormatterResolver[] Resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
         {
-#if !ENABLE_IL2CPP && !NET_STANDARD_2_0
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP) && !NET_STANDARD_2_0
             DynamicObjectResolverAllowPrivate.Instance, // Try Object
             DynamicContractlessObjectResolverAllowPrivate.Instance, // Serializes keys as strings
 #endif
@@ -254,7 +254,7 @@ namespace MessagePack.Resolvers
                 if (typeof(T) == typeof(object))
                 {
                     // final fallback
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
                     Formatter = (IMessagePackFormatter<T>)DynamicObjectTypeFallbackFormatter.Instance;
 #else
                     Formatter = PrimitiveObjectResolver.Instance.GetFormatter<T>();
@@ -293,11 +293,11 @@ namespace MessagePack.Internal
             CompositeResolver.Create(ExpandoObjectFormatter.Instance),
 #endif
 
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
             DynamicGenericResolver.Instance, // Try Array, Tuple, Collection, Enum(Generic Fallback)
 #endif
 
-#if !ENABLE_IL2CPP && !NET_STANDARD_2_0
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP) && !NET_STANDARD_2_0
             DynamicUnionResolver.Instance, // Try Union(Interface)
 #endif
         };

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/StandardResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/StandardResolver.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#define DYNAMIC_GENERATION
+#endif
+
 using System.Linq;
 using MessagePack.Formatters;
 using MessagePack.Internal;
@@ -28,7 +32,7 @@ namespace MessagePack.Resolvers
 
         private static readonly IFormatterResolver[] Resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
         {
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP) && !NET_STANDARD_2_0
+#if DYNAMIC_GENERATION && !NET_STANDARD_2_0
             DynamicObjectResolver.Instance, // Try Object
 #endif
         }).ToArray();
@@ -57,7 +61,7 @@ namespace MessagePack.Resolvers
                 if (typeof(T) == typeof(object))
                 {
                     // final fallback
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
                     Formatter = (IMessagePackFormatter<T>)DynamicObjectTypeFallbackFormatter.Instance;
 #else
                     Formatter = PrimitiveObjectResolver.Instance.GetFormatter<T>();
@@ -93,7 +97,7 @@ namespace MessagePack.Resolvers
 
         private static readonly IFormatterResolver[] Resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
         {
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP) && !NET_STANDARD_2_0
+#if DYNAMIC_GENERATION && !NET_STANDARD_2_0
             DynamicObjectResolver.Instance, // Try Object
             DynamicContractlessObjectResolver.Instance, // Serializes keys as strings
 #endif
@@ -123,7 +127,7 @@ namespace MessagePack.Resolvers
                 if (typeof(T) == typeof(object))
                 {
                     // final fallback
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
                     Formatter = (IMessagePackFormatter<T>)DynamicObjectTypeFallbackFormatter.Instance;
 #else
                     Formatter = PrimitiveObjectResolver.Instance.GetFormatter<T>();
@@ -159,7 +163,7 @@ namespace MessagePack.Resolvers
 
         private static readonly IFormatterResolver[] Resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
         {
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP) && !NET_STANDARD_2_0
+#if DYNAMIC_GENERATION && !NET_STANDARD_2_0
             DynamicObjectResolverAllowPrivate.Instance, // Try Object
 #endif
         }).ToArray();
@@ -188,7 +192,7 @@ namespace MessagePack.Resolvers
                 if (typeof(T) == typeof(object))
                 {
                     // final fallback
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
                     Formatter = (IMessagePackFormatter<T>)DynamicObjectTypeFallbackFormatter.Instance;
 #else
                     Formatter = PrimitiveObjectResolver.Instance.GetFormatter<T>();
@@ -224,7 +228,7 @@ namespace MessagePack.Resolvers
 
         private static readonly IFormatterResolver[] Resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
         {
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP) && !NET_STANDARD_2_0
+#if DYNAMIC_GENERATION && !NET_STANDARD_2_0
             DynamicObjectResolverAllowPrivate.Instance, // Try Object
             DynamicContractlessObjectResolverAllowPrivate.Instance, // Serializes keys as strings
 #endif
@@ -254,7 +258,7 @@ namespace MessagePack.Resolvers
                 if (typeof(T) == typeof(object))
                 {
                     // final fallback
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
                     Formatter = (IMessagePackFormatter<T>)DynamicObjectTypeFallbackFormatter.Instance;
 #else
                     Formatter = PrimitiveObjectResolver.Instance.GetFormatter<T>();
@@ -293,11 +297,11 @@ namespace MessagePack.Internal
             CompositeResolver.Create(ExpandoObjectFormatter.Instance),
 #endif
 
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
             DynamicGenericResolver.Instance, // Try Array, Tuple, Collection, Enum(Generic Fallback)
 #endif
 
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP) && !NET_STANDARD_2_0
+#if DYNAMIC_GENERATION && !NET_STANDARD_2_0
             DynamicUnionResolver.Instance, // Try Union(Interface)
 #endif
         };

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/TypelessContractlessStandardResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/TypelessContractlessStandardResolver.cs
@@ -36,7 +36,7 @@ namespace MessagePack.Resolvers
             ForceSizePrimitiveObjectResolver.Instance, // Preserve particular integer types
             BuiltinResolver.Instance, // Try Builtin
             AttributeFormatterResolver.Instance, // Try use [MessagePackFormatter]
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
             DynamicEnumResolver.Instance, // Try Enum
             DynamicGenericResolver.Instance, // Try Array, Tuple, Collection
             DynamicUnionResolver.Instance, // Try Union(Interface)

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/TypelessContractlessStandardResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/TypelessContractlessStandardResolver.cs
@@ -3,6 +3,10 @@
 
 #if !UNITY_2018_3_OR_NEWER
 
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#define DYNAMIC_GENERATION
+#endif
+
 using System;
 using System.Collections.Generic;
 using MessagePack.Formatters;
@@ -36,7 +40,7 @@ namespace MessagePack.Resolvers
             ForceSizePrimitiveObjectResolver.Instance, // Preserve particular integer types
             BuiltinResolver.Instance, // Try Builtin
             AttributeFormatterResolver.Instance, // Try use [MessagePackFormatter]
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
             DynamicEnumResolver.Instance, // Try Enum
             DynamicGenericResolver.Instance, // Try Array, Tuple, Collection
             DynamicUnionResolver.Instance, // Try Union(Interface)

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/AllowPrivateTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/AllowPrivateTest.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
 
 using System;
 using System.Collections.Generic;
@@ -179,7 +179,7 @@ namespace MessagePack.Tests
             public string Field => field;
         }
 
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
 
         [MessagePackObject]
         public class ImmutablePrivateClass
@@ -360,7 +360,7 @@ namespace MessagePack.Tests
             Assert.Equal("not null", deserialized.Field);
         }
 
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
 
         [Fact]
         public void PrivateConstructor()

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/AllowPrivateTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/AllowPrivateTest.cs
@@ -2,6 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#define DYNAMIC_GENERATION
+#endif
+
+#if DYNAMIC_GENERATION
 
 using System;
 using System.Collections.Generic;
@@ -179,7 +183,7 @@ namespace MessagePack.Tests
             public string Field => field;
         }
 
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
 
         [MessagePackObject]
         public class ImmutablePrivateClass
@@ -360,7 +364,7 @@ namespace MessagePack.Tests
             Assert.Equal("not null", deserialized.Field);
         }
 
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
 
         [Fact]
         public void PrivateConstructor()

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/AnonymousTypeTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/AnonymousTypeTest.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
 
 using System;
 using System.Collections.Generic;

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/AnonymousTypeTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/AnonymousTypeTest.cs
@@ -2,6 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#define DYNAMIC_GENERATION
+#endif
+
+#if DYNAMIC_GENERATION
 
 using System;
 using System.Collections.Generic;

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs
@@ -2,7 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#define DYNAMIC_GENERATION
+#endif
 
+#if DYNAMIC_GENERATION
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
 
 using System;
 using System.Collections;

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DataContractTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DataContractTest.cs
@@ -14,7 +14,7 @@ using Xunit.Abstractions;
 
 namespace MessagePack.Tests
 {
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
     public class DataContractTest
     {
         private readonly ITestOutputHelper logger;

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DataContractTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DataContractTest.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#define DYNAMIC_GENERATION
+#endif
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -14,7 +18,7 @@ using Xunit.Abstractions;
 
 namespace MessagePack.Tests
 {
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
     public class DataContractTest
     {
         private readonly ITestOutputHelper logger;

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverDerivedAttributeInheritanceTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverDerivedAttributeInheritanceTest.cs
@@ -1,12 +1,16 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#define DYNAMIC_GENERATION
+#endif
+
 using System;
 using Xunit;
 
 namespace MessagePack.Tests
 {
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
 
     public class DynamicObjectResolverDerivedAttributeInheritanceTest
     {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverDerivedAttributeInheritanceTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverDerivedAttributeInheritanceTest.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace MessagePack.Tests
 {
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
 
     public class DynamicObjectResolverDerivedAttributeInheritanceTest
     {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverInterfaceTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverInterfaceTest.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace MessagePack.Tests
 {
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
 
     public class DynamicObjectResolverInterfaceTest
     {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverInterfaceTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverInterfaceTest.cs
@@ -1,13 +1,17 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#define DYNAMIC_GENERATION
+#endif
+
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
 namespace MessagePack.Tests
 {
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
 
     public class DynamicObjectResolverInterfaceTest
     {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverOrderTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverOrderTest.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#define DYNAMIC_GENERATION
+#endif
+
 using System;
 using System.Buffers;
 using System.Collections.Generic;
@@ -45,7 +49,7 @@ namespace MessagePack.Tests
             return result;
         }
 
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
 
         [Fact]
         public void OrderTest()

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverOrderTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverOrderTest.cs
@@ -45,7 +45,7 @@ namespace MessagePack.Tests
             return result;
         }
 
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
 
         [Fact]
         public void OrderTest()

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
 
 using System;
 using System.Runtime.Serialization;

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs
@@ -2,6 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#define DYNAMIC_GENERATION
+#endif
+
+#if DYNAMIC_GENERATION
 
 using System;
 using System.Runtime.Serialization;

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/EnumAsStringTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/EnumAsStringTest.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#define DYNAMIC_GENERATION
+#endif
+
 using System;
 using System.Runtime.Serialization;
 using MessagePack.Resolvers;
@@ -69,7 +73,7 @@ namespace MessagePack.Tests
         FooBarBaz = 32,
     }
 
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
 
     public class EnumAsStringTest
     {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/EnumAsStringTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/EnumAsStringTest.cs
@@ -69,7 +69,7 @@ namespace MessagePack.Tests
         FooBarBaz = 32,
     }
 
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
 
     public class EnumAsStringTest
     {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/GenericFormatters.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/GenericFormatters.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#define DYNAMIC_GENERATION
+#endif
+
 using System;
 using System.Buffers;
 using System.Collections.Generic;
@@ -11,7 +15,7 @@ using Xunit;
 
 namespace MessagePack.Tests
 {
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
 
     public class GenericFormatters
     {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/GenericFormatters.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/GenericFormatters.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace MessagePack.Tests
 {
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
 
     public class GenericFormatters
     {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackBinaryTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackBinaryTest.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#define DYNAMIC_GENERATION
+#endif
+
 using System;
 using System.Buffers;
 using System.IO;
@@ -324,7 +328,7 @@ namespace MessagePack.Tests
         [Theory]
         [InlineData(long.MinValue, 9)]
         [InlineData((long)-3372036854775807, 9)]
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
         [InlineData((long)-2147483648, 5)]
 #endif
         [InlineData((long)-50000, 5)]
@@ -660,7 +664,7 @@ namespace MessagePack.Tests
         [InlineData('a')]
         [InlineData('あ')]
         [InlineData('c')]
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
         [InlineData(char.MinValue)]
         [InlineData(char.MaxValue)]
 #endif

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackBinaryTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackBinaryTest.cs
@@ -324,7 +324,7 @@ namespace MessagePack.Tests
         [Theory]
         [InlineData(long.MinValue, 9)]
         [InlineData((long)-3372036854775807, 9)]
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
         [InlineData((long)-2147483648, 5)]
 #endif
         [InlineData((long)-50000, 5)]
@@ -660,7 +660,7 @@ namespace MessagePack.Tests
         [InlineData('a')]
         [InlineData('あ')]
         [InlineData('c')]
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
         [InlineData(char.MinValue)]
         [InlineData(char.MaxValue)]
 #endif

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerTest.cs
@@ -42,7 +42,7 @@ namespace MessagePack.Tests
             ms.Position = 0;
             var data4 = MessagePackSerializer.Deserialize(t, ms, MessagePackSerializer.DefaultOptions) as FirstSimpleData;
 
-#if ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
             var data5 = data4;
 #else
             MessagePackSerializer.Serialize(t, ref writer, data, MessagePackSerializer.DefaultOptions);
@@ -241,7 +241,7 @@ namespace MessagePack.Tests
             }
         }
 
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
 
         [Fact]
         public void StackDepthCheck_DynamicObjectResolver()

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerTest.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#define DYNAMIC_GENERATION
+#endif
+
 using System;
 using System.Buffers;
 using System.Collections.Generic;
@@ -42,7 +46,7 @@ namespace MessagePack.Tests
             ms.Position = 0;
             var data4 = MessagePackSerializer.Deserialize(t, ms, MessagePackSerializer.DefaultOptions) as FirstSimpleData;
 
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
             var data5 = data4;
 #else
             MessagePackSerializer.Serialize(t, ref writer, data, MessagePackSerializer.DefaultOptions);
@@ -241,7 +245,7 @@ namespace MessagePack.Tests
             }
         }
 
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
 
         [Fact]
         public void StackDepthCheck_DynamicObjectResolver()

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/NonGenericCollectionTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/NonGenericCollectionTest.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#define DYNAMIC_GENERATION
+#endif
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -13,7 +17,7 @@ namespace MessagePack.Tests
 {
     public class NonGenericCollectionTest
     {
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
         [Fact]
         public void List()
         {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/NonGenericCollectionTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/NonGenericCollectionTest.cs
@@ -13,7 +13,7 @@ namespace MessagePack.Tests
 {
     public class NonGenericCollectionTest
     {
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
         [Fact]
         public void List()
         {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ObjectResolverTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ObjectResolverTest.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#define DYNAMIC_GENERATION
+#endif
+
 using System;
 using System.Buffers;
 using System.Collections.Generic;
@@ -252,7 +256,7 @@ namespace MessagePack.Tests
             }
         }
 
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
 
         [Fact]
         public void GenericClassTest()
@@ -326,7 +330,7 @@ namespace MessagePack.Tests
             v.IsStructuralEqual(o);
         }
 
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
 
         [Fact]
         public void Contractless()

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ObjectResolverTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ObjectResolverTest.cs
@@ -252,7 +252,7 @@ namespace MessagePack.Tests
             }
         }
 
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
 
         [Fact]
         public void GenericClassTest()
@@ -326,7 +326,7 @@ namespace MessagePack.Tests
             v.IsStructuralEqual(o);
         }
 
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
 
         [Fact]
         public void Contractless()

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/OldSpecBinaryFormatterTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/OldSpecBinaryFormatterTest.cs
@@ -49,7 +49,7 @@ namespace MessagePack.Tests
             Assert.Null(deserializedBytes);
         }
 
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
 
         [Theory]
         [InlineData(10)] // fixstr
@@ -95,7 +95,7 @@ namespace MessagePack.Tests
             Assert.Null(deserializedObj);
         }
 
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
 
         [Theory]
         [InlineData(10)] // fixstr

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/OldSpecBinaryFormatterTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/OldSpecBinaryFormatterTest.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#define DYNAMIC_GENERATION
+#endif
+
 using System;
 using System.Buffers;
 using System.Collections.Generic;
@@ -49,7 +53,7 @@ namespace MessagePack.Tests
             Assert.Null(deserializedBytes);
         }
 
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
 
         [Theory]
         [InlineData(10)] // fixstr
@@ -95,7 +99,7 @@ namespace MessagePack.Tests
             Assert.Null(deserializedObj);
         }
 
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
 
         [Theory]
         [InlineData(10)] // fixstr

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/PrimitiveResolverTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/PrimitiveResolverTest.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#define DYNAMIC_GENERATION
+#endif
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,7 +16,7 @@ namespace MessagePack.Tests
 {
     public class PrimitiveResolverTest
     {
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
 
         [Fact]
         public void PrimitiveTest2()

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/PrimitiveResolverTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/PrimitiveResolverTest.cs
@@ -12,7 +12,7 @@ namespace MessagePack.Tests
 {
     public class PrimitiveResolverTest
     {
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
 
         [Fact]
         public void PrimitiveTest2()

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/PrimitivelikeFormatterTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/PrimitivelikeFormatterTest.cs
@@ -16,7 +16,7 @@ namespace MessagePack.Tests
 {
     public class PrimitivelikeFormatterTest
     {
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
         [Fact]
         public void CanResolve()
         {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/PrimitivelikeFormatterTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/PrimitivelikeFormatterTest.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#define DYNAMIC_GENERATION
+#endif
+
 using System;
 using System.Buffers;
 using System.Collections.Generic;
@@ -16,7 +20,7 @@ namespace MessagePack.Tests
 {
     public class PrimitivelikeFormatterTest
     {
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
         [Fact]
         public void CanResolve()
         {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ValueTupleTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ValueTupleTest.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#define DYNAMIC_GENERATION
+#endif
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,7 +14,7 @@ using Xunit;
 
 namespace MessagePack.Tests
 {
-#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#if DYNAMIC_GENERATION
 
     public class ValueTupleTest
     {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ValueTupleTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ValueTupleTest.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace MessagePack.Tests
 {
-#if !ENABLE_IL2CPP
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
 
     public class ValueTupleTest
     {


### PR DESCRIPTION
Adds a MESSAGEPACK_FORCE_AOT preprocessor directive which forces the same behaviour as IL2CPP under Unity, requiring formatters to be generated ahead of time via MPC/Source Generators.

This is useful when working in the editor, since at the moment a project running in the Editor runs under Mono, so will generate IL, but then building to IL2CPP can result in failures if the formatters haven't been generated. Setting this directive will result in this failing in the editor, providing consistent results against IL2CPP builds