### PR TITLE
.Net 8 Update(2): TargetFrameworks

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:7.0.302-jammy
+FROM mcr.microsoft.com/dotnet/sdk:8.0.100-1-jammy
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,7 @@
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(RepoRootPath)bin\$(MSBuildProjectName)\</BaseOutputPath>
     <PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\</PackageOutputPath>
     <LangVersion>10</LangVersion>
+    <LangVersion Condition=" '$(TargetFramework)' == 'net8.0' ">12</LangVersion>
     <AnalysisLevel>latest</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -71,7 +71,7 @@
     <PackageVersion Include="xunit.runner.console" Version="2.6.5" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageVersion Include="xunit" Version="2.6.5" />
+    <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="ZeroFormatter" Version="1.6.4" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsAnalyzerProject)'=='true'">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <!-- https://learn.microsoft.com/en-us/visualstudio/extensibility/roslyn-version-support?view=vs-2022 -->
     <MicrosoftCodeAnalysisVersion>4.3.0</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisVersion Condition="'$(IsAnalyzerProject)'!='true'">4.3.0</MicrosoftCodeAnalysisVersion>
-    <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.23163.2</MicrosoftCodeAnalysisTestingVersion>
+    <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.23509.1</MicrosoftCodeAnalysisTestingVersion>
 
     <!-- Unity 2021.3 has Roslyn 3.8.0 (https://docs.unity3d.com/Manual/roslyn-analyzers.html) -->
     <CodeAnalysisVersionForUnity>3.8.0</CodeAnalysisVersionForUnity>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -93,7 +93,7 @@
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" />
     <GlobalPackageReference Include="Nullable" Version="1.3.1" />
-    <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.435" />
+    <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,8 +48,8 @@
     <PackageVersion Include="MsgPack.Cli" Version="1.0.1" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.9.112" />
     <PackageVersion Include="Newtonsoft.Json.Bson" Version="1.0.2" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageVersion Include="NuGet.Protocol" Version="6.5.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="NuGet.Protocol" Version="6.8.0" />
     <PackageVersion Include="nunit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageVersion Include="protobuf-net" Version="3.1.25" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 
-    <BenchmarkDotNetVersion>0.13.5</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.13.12</BenchmarkDotNetVersion>
 
     <!-- https://learn.microsoft.com/en-us/visualstudio/extensibility/roslyn-version-support?view=vs-2022 -->
     <MicrosoftCodeAnalysisVersion>4.3.0</MicrosoftCodeAnalysisVersion>
@@ -19,14 +19,14 @@
     <PackageVersion Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
     <PackageVersion Include="Ceras" Version="4.1.7" />
     <PackageVersion Include="ConsoleAppFramework" Version="4.2.4" />
-    <PackageVersion Include="FluentAssertions" Version="6.8.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FsPickler" Version="5.3.2" />
     <PackageVersion Include="Hyperion" Version="0.12.2" />
     <PackageVersion Include="IsExternalInit" Version="1.0.3" />
     <PackageVersion Include="Jil" version="2.17.0" />
     <PackageVersion Include="MessagePack" Version="2.1.90" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="16.5.0" ExcludeAssets="runtime" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.5.5" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="16.5.0" />
@@ -41,25 +41,25 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit" Version="$(MicrosoftCodeAnalysisTestingVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisVersion)" />
-    <PackageVersion Include="Microsoft.NET.StringTools" Version="17.6.3" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageVersion Include="Microsoft.NET.StringTools" Version="17.8.3" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="Moq" Version="4.20.70" />
     <PackageVersion Include="MsgPack.Cli" Version="1.0.1" />
-    <PackageVersion Include="Nerdbank.Streams" Version="2.9.112" />
+    <PackageVersion Include="Nerdbank.Streams" Version="2.10.72" />
     <PackageVersion Include="Newtonsoft.Json.Bson" Version="1.0.2" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NuGet.Protocol" Version="6.8.0" />
-    <PackageVersion Include="nunit" Version="3.13.3" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.4.2" />
-    <PackageVersion Include="protobuf-net" Version="3.1.25" />
+    <PackageVersion Include="nunit" Version="3.14.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageVersion Include="protobuf-net" Version="3.2.30" />
     <PackageVersion Include="RandomFixtureKit" Version="1.0.1" />
-    <PackageVersion Include="ReactiveProperty" Version="9.1.2" />
+    <PackageVersion Include="ReactiveProperty" Version="9.3.4" />
     <PackageVersion Include="Required" Version="1.0.0" />
     <PackageVersion Include="Sigil" version="5.0.0" />
-    <PackageVersion Include="SpanJson" Version="4.0.0" />
-    <PackageVersion Include="System.CodeDom" Version="7.0.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
+    <PackageVersion Include="SpanJson" Version="4.0.1" />
+    <PackageVersion Include="System.CodeDom" Version="8.0.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
@@ -67,11 +67,11 @@
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="Utf8Json" Version="1.3.7" />
-    <PackageVersion Include="Xunit.Combinatorial" Version="1.5.25" />
-    <PackageVersion Include="xunit.runner.console" Version="2.4.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageVersion Include="Xunit.Combinatorial" Version="1.6.24" />
+    <PackageVersion Include="xunit.runner.console" Version="2.6.5" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageVersion Include="xunit" Version="2.4.2" />
+    <PackageVersion Include="xunit" Version="2.6.5" />
     <PackageVersion Include="ZeroFormatter" Version="1.6.4" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsAnalyzerProject)'=='true'">
@@ -96,6 +96,6 @@
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.435" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,7 +26,7 @@
     <PackageVersion Include="Jil" version="2.17.0" />
     <PackageVersion Include="MessagePack" Version="2.1.90" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="16.5.0" ExcludeAssets="runtime" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.5.5" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="16.5.0" />
@@ -64,6 +64,7 @@
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageVersion Include="System.Text.Json" Version="6.0.0" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="6.0.0" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="Utf8Json" Version="1.3.7" />

--- a/benchmark/ExperimentalBenchmark/ExperimentalBenchmark.csproj
+++ b/benchmark/ExperimentalBenchmark/ExperimentalBenchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <RootNamespace>Benchmark</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);MSB3243</NoWarn>

--- a/benchmark/SerializerBenchmark/SerializerBenchmark.csproj
+++ b/benchmark/SerializerBenchmark/SerializerBenchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>SerializerBenchmark</AssemblyName>
     <RootNamespace>Benchmark</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.302",
+    "version": "8.0.100",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/sandbox/MessagePack.Internal/MessagePack.Internal.csproj
+++ b/sandbox/MessagePack.Internal/MessagePack.Internal.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <DefineConstants>$(DefineConstants);SPAN_BUILTIN;MESSAGEPACK_INTERNAL</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/sandbox/PerfBenchmarkDotNet/PerfBenchmarkDotNet.csproj
+++ b/sandbox/PerfBenchmarkDotNet/PerfBenchmarkDotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/sandbox/PerfNetFramework/PerfNetFramework.csproj
+++ b/sandbox/PerfNetFramework/PerfNetFramework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>

--- a/sandbox/Sandbox/Sandbox.csproj
+++ b/sandbox/Sandbox/Sandbox.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/src/MessagePack.Analyzers/CodeAnalysis/AnalyzerOptions.cs
+++ b/src/MessagePack.Analyzers/CodeAnalysis/AnalyzerOptions.cs
@@ -42,22 +42,15 @@ public record AnalyzerOptions
 
         if (additionalTexts.FirstOrDefault(x => string.Equals(Path.GetFileName(x.Path), JsonOptionsFileName, StringComparison.OrdinalIgnoreCase))?.GetText(cancellationToken)?.ToString() is string configJson)
         {
-            try
-            {
-                result = JsonSerializer.Deserialize<AnalyzerOptions>(
-                    configJson,
-                    new JsonSerializerOptions
-                    {
-                        AllowTrailingCommas = true,
-                        MaxDepth = 5,
-                        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                        ReadCommentHandling = JsonCommentHandling.Skip,
-                    }) ?? Default;
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine("Can't load MessagePackAnalyzer.json: " + ex);
-            }
+            result = JsonSerializer.Deserialize<AnalyzerOptions>(
+                configJson,
+                new JsonSerializerOptions
+                {
+                    AllowTrailingCommas = true,
+                    MaxDepth = 5,
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    ReadCommentHandling = JsonCommentHandling.Skip,
+                }) ?? Default;
         }
 
         if (result.Generator.Resolver.Namespace is null)

--- a/src/MessagePack.Analyzers/CodeAnalysis/AnalyzerOptions.cs
+++ b/src/MessagePack.Analyzers/CodeAnalysis/AnalyzerOptions.cs
@@ -9,6 +9,8 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MessagePack.Analyzers.CodeAnalysis;
 
+#pragma warning disable SA1402 // File may only contain a single type
+
 /// <summary>
 /// Options for the analyzer and source generator, which may be deserialized from a MessagePackAnalyzer.json file.
 /// </summary>
@@ -143,3 +145,4 @@ public record GeneratorOptions
     /// </summary>
     public FormattersOptions Formatters { get; init; } = new();
 }
+#pragma warning restore SA1402 // File may only contain a single type

--- a/src/MessagePack.Analyzers/CodeAnalysis/AnalyzerOptions.cs
+++ b/src/MessagePack.Analyzers/CodeAnalysis/AnalyzerOptions.cs
@@ -145,4 +145,3 @@ public record GeneratorOptions
     /// </summary>
     public FormattersOptions Formatters { get; init; } = new();
 }
-#pragma warning restore SA1402 // File may only contain a single type

--- a/src/MessagePack.AspNetCoreMvcFormatter/MessagePack.AspNetCoreMvcFormatter.csproj
+++ b/src/MessagePack.AspNetCoreMvcFormatter/MessagePack.AspNetCoreMvcFormatter.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <Title>ASP.NET Core MVC Input/Output MessagePack formatter</Title>
     <Description>ASP.NET Core MVC Input/Output MessagePack formatter.</Description>
     <PackageTags>MsgPack;MessagePack;Serialization;Formatter;Serializer;aspnetcore;aspnetcoremvc</PackageTags>
   </PropertyGroup>
 
   <Choose>
-    <When Condition="'$(TargetFramework)'=='net6.0'">
+    <When Condition="'$(TargetFramework)'=='netstandard2.0'">
       <ItemGroup>
-        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" />
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/MessagePack.Experimental/MessagePack.Experimental.csproj
+++ b/src/MessagePack.Experimental/MessagePack.Experimental.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <Title>MessagePack for C#, Experimental Plugins</Title>

--- a/src/MessagePack.Experimental/UnsafeUnmanagedStructFormatter/UnsafeUnmanagedStructFormatter.cs
+++ b/src/MessagePack.Experimental/UnsafeUnmanagedStructFormatter/UnsafeUnmanagedStructFormatter.cs
@@ -45,7 +45,7 @@ namespace MessagePack.Formatters
             var sequence = reader.ReadRaw(sizeof(T));
             if (sequence.IsSingleSegment)
             {
-                return Unsafe.As<byte, T>(ref Unsafe.AsRef(sequence.FirstSpan[0]));
+                return Unsafe.As<byte, T>(ref Unsafe.AsRef(in sequence.FirstSpan[0]));
             }
 
             T answer;

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/IFormatterResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/IFormatterResolver.cs
@@ -122,6 +122,9 @@ namespace MessagePack
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete]
+#endif
         protected FormatterNotRegisteredException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/CodeGenHelpers.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/CodeGenHelpers.cs
@@ -88,7 +88,18 @@ namespace MessagePack.Internal
         {
             if (!reader.TryReadStringSpan(out ReadOnlySpan<byte> result))
             {
-                return GetSpanFromSequence(reader.ReadStringSequence());
+                ReadOnlySequence<byte>? sequence = reader.ReadStringSequence();
+                if (sequence.HasValue)
+                {
+                    if (sequence.Value.IsSingleSegment)
+                    {
+                        return sequence.Value.First.Span;
+                    }
+
+                    return sequence.Value.ToArray();
+                }
+
+                return default;
             }
 
             return result;
@@ -100,10 +111,5 @@ namespace MessagePack.Internal
         /// <param name="sequence">The sequence.</param>
         /// <returns>The byte array or <see langword="null" /> .</returns>
         public static byte[]? GetArrayFromNullableSequence(in ReadOnlySequence<byte>? sequence) => sequence?.ToArray();
-
-        private static ReadOnlySpan<byte> GetSpanFromSequence(in ReadOnlySequence<byte>? sequence)
-        {
-            return sequence.HasValue ? GetSpanFromSequence(sequence.Value) : default;
-        }
     }
 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/TinyJsonReader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/TinyJsonReader.cs
@@ -49,6 +49,9 @@ namespace MessagePack
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete]
+#endif
         protected TinyJsonException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializationException.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializationException.cs
@@ -48,6 +48,9 @@ namespace MessagePack
         /// </summary>
         /// <param name="info">Serialization info.</param>
         /// <param name="context">Serialization context.</param>
+#if NET8_0_OR_GREATER
+        [Obsolete]
+#endif
         protected MessagePackSerializationException(
           System.Runtime.Serialization.SerializationInfo info,
           System.Runtime.Serialization.StreamingContext context)

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -2438,6 +2438,9 @@ namespace MessagePack.Internal
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete]
+#endif
         protected InitAccessorInGenericClassNotSupportedException(
           SerializationInfo info,
           StreamingContext context)

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackBinaryTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackBinaryTest.cs
@@ -828,8 +828,8 @@ namespace MessagePack.Tests
                 smallWriter = new MessagePackWriter(small);
                 smallWriter.Write(ushort.MaxValue);
                 smallWriter.Flush();
-                smallReader = new MessagePackReader(small.AsReadOnlySequence);
-                smallReader.ReadInt32().Is(ushort.MaxValue);
+                var smallReader2 = new MessagePackReader(small.AsReadOnlySequence);
+                smallReader2.ReadInt32().Is(ushort.MaxValue);
 
                 target.Reset();
                 targetWriter = new MessagePackWriter(target);
@@ -856,8 +856,8 @@ namespace MessagePack.Tests
                 smallWriter = new MessagePackWriter(small);
                 smallWriter.Write(ushort.MaxValue);
                 smallWriter.Flush();
-                smallReader = new MessagePackReader(small.AsReadOnlySequence);
-                smallReader.ReadInt64().Is(ushort.MaxValue);
+                var smallReader2 = new MessagePackReader(small.AsReadOnlySequence);
+                smallReader2.ReadInt64().Is(ushort.MaxValue);
 
                 target.Reset();
                 targetWriter = new MessagePackWriter(target);
@@ -869,8 +869,8 @@ namespace MessagePack.Tests
                 smallWriter = new MessagePackWriter(small);
                 smallWriter.Write(uint.MaxValue);
                 smallWriter.Flush();
-                smallReader = new MessagePackReader(small.AsReadOnlySequence);
-                smallReader.ReadInt64().Is(uint.MaxValue);
+                var smallReader3 = new MessagePackReader(small.AsReadOnlySequence);
+                smallReader3.ReadInt64().Is(uint.MaxValue);
 
                 target.Reset();
                 targetWriter = new MessagePackWriter(target);

--- a/src/MessagePack/MessagePack.csproj
+++ b/src/MessagePack/MessagePack.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0649</NoWarn>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants Condition=" '$(TargetFramework)' != 'netstandard2.0' ">$(DefineConstants);SPAN_BUILTIN</DefineConstants>

--- a/src/MessagePack/net8.0/PublicAPI.Shipped.txt
+++ b/src/MessagePack/net8.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1181 @@
+#nullable enable
+MessagePack.ExtensionHeader
+MessagePack.ExtensionHeader.ExtensionHeader(sbyte typeCode, int length) -> void
+MessagePack.ExtensionHeader.ExtensionHeader(sbyte typeCode, uint length) -> void
+MessagePack.ExtensionHeader.Length.get -> uint
+MessagePack.ExtensionHeader.TypeCode.get -> sbyte
+MessagePack.ExtensionResult
+MessagePack.ExtensionResult.Data.get -> System.Buffers.ReadOnlySequence<byte>
+MessagePack.ExtensionResult.ExtensionResult(sbyte typeCode, System.Buffers.ReadOnlySequence<byte> data) -> void
+MessagePack.ExtensionResult.ExtensionResult(sbyte typeCode, System.Memory<byte> data) -> void
+MessagePack.ExtensionResult.Header.get -> MessagePack.ExtensionHeader
+MessagePack.ExtensionResult.TypeCode.get -> sbyte
+MessagePack.FormatterNotRegisteredException
+MessagePack.FormatterNotRegisteredException.FormatterNotRegisteredException(string? message) -> void
+MessagePack.FormatterResolverExtensions
+MessagePack.Formatters.ArrayFormatter<T>
+MessagePack.Formatters.ArrayFormatter<T>.ArrayFormatter() -> void
+MessagePack.Formatters.ArrayFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T[]?
+MessagePack.Formatters.ArrayFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ArraySegmentFormatter<T>
+MessagePack.Formatters.ArraySegmentFormatter<T>.ArraySegmentFormatter() -> void
+MessagePack.Formatters.ArraySegmentFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.ArraySegment<T>
+MessagePack.Formatters.ArraySegmentFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, System.ArraySegment<T> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.BigIntegerFormatter
+MessagePack.Formatters.BigIntegerFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Numerics.BigInteger
+MessagePack.Formatters.BigIntegerFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Numerics.BigInteger value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.BitArrayFormatter
+MessagePack.Formatters.BitArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Collections.BitArray?
+MessagePack.Formatters.BitArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Collections.BitArray? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.BooleanArrayFormatter
+MessagePack.Formatters.BooleanArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> bool[]?
+MessagePack.Formatters.BooleanArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, bool[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.BooleanFormatter
+MessagePack.Formatters.BooleanFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> bool
+MessagePack.Formatters.BooleanFormatter.Serialize(ref MessagePack.MessagePackWriter writer, bool value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ByteArrayFormatter
+MessagePack.Formatters.ByteArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> byte[]?
+MessagePack.Formatters.ByteArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, byte[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ByteArraySegmentFormatter
+MessagePack.Formatters.ByteArraySegmentFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.ArraySegment<byte>
+MessagePack.Formatters.ByteArraySegmentFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.ArraySegment<byte> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ByteFormatter
+MessagePack.Formatters.ByteFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> byte
+MessagePack.Formatters.ByteFormatter.Serialize(ref MessagePack.MessagePackWriter writer, byte value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.CharArrayFormatter
+MessagePack.Formatters.CharArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> char[]?
+MessagePack.Formatters.CharArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, char[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.CharFormatter
+MessagePack.Formatters.CharFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> char
+MessagePack.Formatters.CharFormatter.Serialize(ref MessagePack.MessagePackWriter writer, char value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.CollectionFormatterBase<TElement, TCollection>
+MessagePack.Formatters.CollectionFormatterBase<TElement, TCollection>.CollectionFormatterBase() -> void
+MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TCollection>
+MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TCollection>.CollectionFormatterBase() -> void
+MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TEnumerator, TCollection>
+MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TEnumerator, TCollection>.CollectionFormatterBase() -> void
+MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TEnumerator, TCollection>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> TCollection?
+MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TEnumerator, TCollection>.Serialize(ref MessagePack.MessagePackWriter writer, TCollection? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ComplexFormatter
+MessagePack.Formatters.ComplexFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Numerics.Complex
+MessagePack.Formatters.ComplexFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Numerics.Complex value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ConcurrentBagFormatter<T>
+MessagePack.Formatters.ConcurrentBagFormatter<T>.ConcurrentBagFormatter() -> void
+MessagePack.Formatters.ConcurrentDictionaryFormatter<TKey, TValue>
+MessagePack.Formatters.ConcurrentDictionaryFormatter<TKey, TValue>.ConcurrentDictionaryFormatter() -> void
+MessagePack.Formatters.ConcurrentQueueFormatter<T>
+MessagePack.Formatters.ConcurrentQueueFormatter<T>.ConcurrentQueueFormatter() -> void
+MessagePack.Formatters.ConcurrentStackFormatter<T>
+MessagePack.Formatters.ConcurrentStackFormatter<T>.ConcurrentStackFormatter() -> void
+MessagePack.Formatters.DateTimeArrayFormatter
+MessagePack.Formatters.DateTimeArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.DateTime[]?
+MessagePack.Formatters.DateTimeArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.DateTime[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.DateTimeFormatter
+MessagePack.Formatters.DateTimeFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.DateTime
+MessagePack.Formatters.DateTimeFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.DateTime value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.DateTimeOffsetFormatter
+MessagePack.Formatters.DateTimeOffsetFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.DateTimeOffset
+MessagePack.Formatters.DateTimeOffsetFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.DateTimeOffset value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.DecimalFormatter
+MessagePack.Formatters.DecimalFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> decimal
+MessagePack.Formatters.DecimalFormatter.Serialize(ref MessagePack.MessagePackWriter writer, decimal value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.DictionaryFormatter<TKey, TValue>
+MessagePack.Formatters.DictionaryFormatter<TKey, TValue>.DictionaryFormatter() -> void
+MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TDictionary>
+MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TDictionary>.DictionaryFormatterBase() -> void
+MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TDictionary>
+MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TDictionary>.DictionaryFormatterBase() -> void
+MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TEnumerator, TDictionary>
+MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TEnumerator, TDictionary>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> TDictionary?
+MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TEnumerator, TDictionary>.DictionaryFormatterBase() -> void
+MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TEnumerator, TDictionary>.Serialize(ref MessagePack.MessagePackWriter writer, TDictionary? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.DoubleArrayFormatter
+MessagePack.Formatters.DoubleArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> double[]?
+MessagePack.Formatters.DoubleArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, double[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.DoubleFormatter
+MessagePack.Formatters.DoubleFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> double
+MessagePack.Formatters.DoubleFormatter.Serialize(ref MessagePack.MessagePackWriter writer, double value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.DynamicObjectTypeFallbackFormatter
+MessagePack.Formatters.DynamicObjectTypeFallbackFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> object?
+MessagePack.Formatters.DynamicObjectTypeFallbackFormatter.Serialize(ref MessagePack.MessagePackWriter writer, object? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.EnumAsStringFormatter<T>
+MessagePack.Formatters.EnumAsStringFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T
+MessagePack.Formatters.EnumAsStringFormatter<T>.EnumAsStringFormatter() -> void
+MessagePack.Formatters.EnumAsStringFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceByteBlockFormatter
+MessagePack.Formatters.ForceByteBlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> byte
+MessagePack.Formatters.ForceByteBlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, byte value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceInt16BlockArrayFormatter
+MessagePack.Formatters.ForceInt16BlockArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> short[]?
+MessagePack.Formatters.ForceInt16BlockArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, short[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceInt16BlockFormatter
+MessagePack.Formatters.ForceInt16BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> short
+MessagePack.Formatters.ForceInt16BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, short value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceInt32BlockArrayFormatter
+MessagePack.Formatters.ForceInt32BlockArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> int[]?
+MessagePack.Formatters.ForceInt32BlockArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, int[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceInt32BlockFormatter
+MessagePack.Formatters.ForceInt32BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> int
+MessagePack.Formatters.ForceInt32BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, int value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceInt64BlockArrayFormatter
+MessagePack.Formatters.ForceInt64BlockArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> long[]?
+MessagePack.Formatters.ForceInt64BlockArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, long[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceInt64BlockFormatter
+MessagePack.Formatters.ForceInt64BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> long
+MessagePack.Formatters.ForceInt64BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, long value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceSByteBlockArrayFormatter
+MessagePack.Formatters.ForceSByteBlockArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> sbyte[]?
+MessagePack.Formatters.ForceSByteBlockArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, sbyte[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceSByteBlockFormatter
+MessagePack.Formatters.ForceSByteBlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> sbyte
+MessagePack.Formatters.ForceSByteBlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, sbyte value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceUInt16BlockArrayFormatter
+MessagePack.Formatters.ForceUInt16BlockArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ushort[]?
+MessagePack.Formatters.ForceUInt16BlockArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, ushort[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceUInt16BlockFormatter
+MessagePack.Formatters.ForceUInt16BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ushort
+MessagePack.Formatters.ForceUInt16BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, ushort value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceUInt32BlockArrayFormatter
+MessagePack.Formatters.ForceUInt32BlockArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> uint[]?
+MessagePack.Formatters.ForceUInt32BlockArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, uint[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceUInt32BlockFormatter
+MessagePack.Formatters.ForceUInt32BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> uint
+MessagePack.Formatters.ForceUInt32BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, uint value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceUInt64BlockArrayFormatter
+MessagePack.Formatters.ForceUInt64BlockArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ulong[]?
+MessagePack.Formatters.ForceUInt64BlockArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, ulong[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceUInt64BlockFormatter
+MessagePack.Formatters.ForceUInt64BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ulong
+MessagePack.Formatters.ForceUInt64BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, ulong value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.FourDimensionalArrayFormatter<T>
+MessagePack.Formatters.FourDimensionalArrayFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T[,,,]?
+MessagePack.Formatters.FourDimensionalArrayFormatter<T>.FourDimensionalArrayFormatter() -> void
+MessagePack.Formatters.FourDimensionalArrayFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T[,,,]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.GenericCollectionFormatter<TElement, TCollection>
+MessagePack.Formatters.GenericCollectionFormatter<TElement, TCollection>.GenericCollectionFormatter() -> void
+MessagePack.Formatters.GenericDictionaryFormatter<TKey, TValue, TDictionary>
+MessagePack.Formatters.GenericDictionaryFormatter<TKey, TValue, TDictionary>.GenericDictionaryFormatter() -> void
+MessagePack.Formatters.GenericEnumFormatter<T>
+MessagePack.Formatters.GenericEnumFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T
+MessagePack.Formatters.GenericEnumFormatter<T>.GenericEnumFormatter() -> void
+MessagePack.Formatters.GenericEnumFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.GuidFormatter
+MessagePack.Formatters.GuidFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Guid
+MessagePack.Formatters.GuidFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Guid value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.HashSetFormatter<T>
+MessagePack.Formatters.HashSetFormatter<T>.HashSetFormatter() -> void
+MessagePack.Formatters.IMessagePackFormatter
+MessagePack.Formatters.IMessagePackFormatter<T>
+MessagePack.Formatters.IMessagePackFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T
+MessagePack.Formatters.IMessagePackFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.IgnoreFormatter<T>
+MessagePack.Formatters.IgnoreFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T?
+MessagePack.Formatters.IgnoreFormatter<T>.IgnoreFormatter() -> void
+MessagePack.Formatters.IgnoreFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.Int16ArrayFormatter
+MessagePack.Formatters.Int16ArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> short[]?
+MessagePack.Formatters.Int16ArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, short[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.Int16Formatter
+MessagePack.Formatters.Int16Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> short
+MessagePack.Formatters.Int16Formatter.Serialize(ref MessagePack.MessagePackWriter writer, short value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.Int32ArrayFormatter
+MessagePack.Formatters.Int32ArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> int[]?
+MessagePack.Formatters.Int32ArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, int[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.Int32Formatter
+MessagePack.Formatters.Int32Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> int
+MessagePack.Formatters.Int32Formatter.Serialize(ref MessagePack.MessagePackWriter writer, int value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.Int64ArrayFormatter
+MessagePack.Formatters.Int64ArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> long[]?
+MessagePack.Formatters.Int64ArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, long[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.Int64Formatter
+MessagePack.Formatters.Int64Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> long
+MessagePack.Formatters.Int64Formatter.Serialize(ref MessagePack.MessagePackWriter writer, long value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.InterfaceCollectionFormatter<T>
+MessagePack.Formatters.InterfaceCollectionFormatter<T>.InterfaceCollectionFormatter() -> void
+MessagePack.Formatters.InterfaceDictionaryFormatter<TKey, TValue>
+MessagePack.Formatters.InterfaceDictionaryFormatter<TKey, TValue>.InterfaceDictionaryFormatter() -> void
+MessagePack.Formatters.InterfaceEnumerableFormatter<T>
+MessagePack.Formatters.InterfaceEnumerableFormatter<T>.InterfaceEnumerableFormatter() -> void
+MessagePack.Formatters.InterfaceGroupingFormatter<TKey, TElement>
+MessagePack.Formatters.InterfaceGroupingFormatter<TKey, TElement>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Linq.IGrouping<TKey, TElement>?
+MessagePack.Formatters.InterfaceGroupingFormatter<TKey, TElement>.InterfaceGroupingFormatter() -> void
+MessagePack.Formatters.InterfaceGroupingFormatter<TKey, TElement>.Serialize(ref MessagePack.MessagePackWriter writer, System.Linq.IGrouping<TKey, TElement>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.InterfaceListFormatter<T>
+MessagePack.Formatters.InterfaceListFormatter<T>.InterfaceListFormatter() -> void
+MessagePack.Formatters.InterfaceLookupFormatter<TKey, TElement>
+MessagePack.Formatters.InterfaceLookupFormatter<TKey, TElement>.InterfaceLookupFormatter() -> void
+MessagePack.Formatters.InterfaceReadOnlyCollectionFormatter<T>
+MessagePack.Formatters.InterfaceReadOnlyCollectionFormatter<T>.InterfaceReadOnlyCollectionFormatter() -> void
+MessagePack.Formatters.InterfaceReadOnlyDictionaryFormatter<TKey, TValue>
+MessagePack.Formatters.InterfaceReadOnlyDictionaryFormatter<TKey, TValue>.InterfaceReadOnlyDictionaryFormatter() -> void
+MessagePack.Formatters.InterfaceReadOnlyListFormatter<T>
+MessagePack.Formatters.InterfaceReadOnlyListFormatter<T>.InterfaceReadOnlyListFormatter() -> void
+MessagePack.Formatters.InterfaceSetFormatter<T>
+MessagePack.Formatters.InterfaceSetFormatter<T>.InterfaceSetFormatter() -> void
+MessagePack.Formatters.KeyValuePairFormatter<TKey, TValue>
+MessagePack.Formatters.KeyValuePairFormatter<TKey, TValue>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Collections.Generic.KeyValuePair<TKey, TValue>
+MessagePack.Formatters.KeyValuePairFormatter<TKey, TValue>.KeyValuePairFormatter() -> void
+MessagePack.Formatters.KeyValuePairFormatter<TKey, TValue>.Serialize(ref MessagePack.MessagePackWriter writer, System.Collections.Generic.KeyValuePair<TKey, TValue> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.LazyFormatter<T>
+MessagePack.Formatters.LazyFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Lazy<T>?
+MessagePack.Formatters.LazyFormatter<T>.LazyFormatter() -> void
+MessagePack.Formatters.LazyFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, System.Lazy<T>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.LinkedListFormatter<T>
+MessagePack.Formatters.LinkedListFormatter<T>.LinkedListFormatter() -> void
+MessagePack.Formatters.ListFormatter<T>
+MessagePack.Formatters.ListFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Collections.Generic.List<T>?
+MessagePack.Formatters.ListFormatter<T>.ListFormatter() -> void
+MessagePack.Formatters.ListFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, System.Collections.Generic.List<T>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NativeDateTimeArrayFormatter
+MessagePack.Formatters.NativeDateTimeArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.DateTime[]?
+MessagePack.Formatters.NativeDateTimeArrayFormatter.NativeDateTimeArrayFormatter() -> void
+MessagePack.Formatters.NativeDateTimeArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.DateTime[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NativeDateTimeFormatter
+MessagePack.Formatters.NativeDateTimeFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.DateTime
+MessagePack.Formatters.NativeDateTimeFormatter.NativeDateTimeFormatter() -> void
+MessagePack.Formatters.NativeDateTimeFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.DateTime value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NativeDecimalFormatter
+MessagePack.Formatters.NativeDecimalFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> decimal
+MessagePack.Formatters.NativeDecimalFormatter.Serialize(ref MessagePack.MessagePackWriter writer, decimal value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NativeGuidFormatter
+MessagePack.Formatters.NativeGuidFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Guid
+MessagePack.Formatters.NativeGuidFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Guid value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NilFormatter
+MessagePack.Formatters.NilFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> MessagePack.Nil
+MessagePack.Formatters.NilFormatter.Serialize(ref MessagePack.MessagePackWriter writer, MessagePack.Nil value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NonGenericDictionaryFormatter<T>
+MessagePack.Formatters.NonGenericDictionaryFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T?
+MessagePack.Formatters.NonGenericDictionaryFormatter<T>.NonGenericDictionaryFormatter() -> void
+MessagePack.Formatters.NonGenericDictionaryFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NonGenericInterfaceDictionaryFormatter
+MessagePack.Formatters.NonGenericInterfaceDictionaryFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Collections.IDictionary?
+MessagePack.Formatters.NonGenericInterfaceDictionaryFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Collections.IDictionary? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NonGenericInterfaceListFormatter
+MessagePack.Formatters.NonGenericInterfaceListFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Collections.IList?
+MessagePack.Formatters.NonGenericInterfaceListFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Collections.IList? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NonGenericListFormatter<T>
+MessagePack.Formatters.NonGenericListFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T?
+MessagePack.Formatters.NonGenericListFormatter<T>.NonGenericListFormatter() -> void
+MessagePack.Formatters.NonGenericListFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableBooleanFormatter
+MessagePack.Formatters.NullableBooleanFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> bool?
+MessagePack.Formatters.NullableBooleanFormatter.Serialize(ref MessagePack.MessagePackWriter writer, bool? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableByteFormatter
+MessagePack.Formatters.NullableByteFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> byte?
+MessagePack.Formatters.NullableByteFormatter.Serialize(ref MessagePack.MessagePackWriter writer, byte? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableCharFormatter
+MessagePack.Formatters.NullableCharFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> char?
+MessagePack.Formatters.NullableCharFormatter.Serialize(ref MessagePack.MessagePackWriter writer, char? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableDateTimeFormatter
+MessagePack.Formatters.NullableDateTimeFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.DateTime?
+MessagePack.Formatters.NullableDateTimeFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.DateTime? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableDoubleFormatter
+MessagePack.Formatters.NullableDoubleFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> double?
+MessagePack.Formatters.NullableDoubleFormatter.Serialize(ref MessagePack.MessagePackWriter writer, double? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableForceByteBlockFormatter
+MessagePack.Formatters.NullableForceByteBlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> byte?
+MessagePack.Formatters.NullableForceByteBlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, byte? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableForceInt16BlockFormatter
+MessagePack.Formatters.NullableForceInt16BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> short?
+MessagePack.Formatters.NullableForceInt16BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, short? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableForceInt32BlockFormatter
+MessagePack.Formatters.NullableForceInt32BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> int?
+MessagePack.Formatters.NullableForceInt32BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, int? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableForceInt64BlockFormatter
+MessagePack.Formatters.NullableForceInt64BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> long?
+MessagePack.Formatters.NullableForceInt64BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, long? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableForceSByteBlockFormatter
+MessagePack.Formatters.NullableForceSByteBlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> sbyte?
+MessagePack.Formatters.NullableForceSByteBlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, sbyte? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableForceUInt16BlockFormatter
+MessagePack.Formatters.NullableForceUInt16BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ushort?
+MessagePack.Formatters.NullableForceUInt16BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, ushort? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableForceUInt32BlockFormatter
+MessagePack.Formatters.NullableForceUInt32BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> uint?
+MessagePack.Formatters.NullableForceUInt32BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, uint? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableForceUInt64BlockFormatter
+MessagePack.Formatters.NullableForceUInt64BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ulong?
+MessagePack.Formatters.NullableForceUInt64BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, ulong? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableFormatter<T>
+MessagePack.Formatters.NullableFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T?
+MessagePack.Formatters.NullableFormatter<T>.NullableFormatter() -> void
+MessagePack.Formatters.NullableFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableInt16Formatter
+MessagePack.Formatters.NullableInt16Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> short?
+MessagePack.Formatters.NullableInt16Formatter.Serialize(ref MessagePack.MessagePackWriter writer, short? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableInt32Formatter
+MessagePack.Formatters.NullableInt32Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> int?
+MessagePack.Formatters.NullableInt32Formatter.Serialize(ref MessagePack.MessagePackWriter writer, int? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableInt64Formatter
+MessagePack.Formatters.NullableInt64Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> long?
+MessagePack.Formatters.NullableInt64Formatter.Serialize(ref MessagePack.MessagePackWriter writer, long? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableNilFormatter
+MessagePack.Formatters.NullableNilFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> MessagePack.Nil?
+MessagePack.Formatters.NullableNilFormatter.Serialize(ref MessagePack.MessagePackWriter writer, MessagePack.Nil? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableSByteFormatter
+MessagePack.Formatters.NullableSByteFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> sbyte?
+MessagePack.Formatters.NullableSByteFormatter.Serialize(ref MessagePack.MessagePackWriter writer, sbyte? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableSingleFormatter
+MessagePack.Formatters.NullableSingleFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> float?
+MessagePack.Formatters.NullableSingleFormatter.Serialize(ref MessagePack.MessagePackWriter writer, float? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableStringArrayFormatter
+MessagePack.Formatters.NullableStringArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> string?[]?
+MessagePack.Formatters.NullableStringArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, string?[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableStringFormatter
+MessagePack.Formatters.NullableStringFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> string?
+MessagePack.Formatters.NullableStringFormatter.Serialize(ref MessagePack.MessagePackWriter writer, string? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableUInt16Formatter
+MessagePack.Formatters.NullableUInt16Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ushort?
+MessagePack.Formatters.NullableUInt16Formatter.Serialize(ref MessagePack.MessagePackWriter writer, ushort? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableUInt32Formatter
+MessagePack.Formatters.NullableUInt32Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> uint?
+MessagePack.Formatters.NullableUInt32Formatter.Serialize(ref MessagePack.MessagePackWriter writer, uint? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableUInt64Formatter
+MessagePack.Formatters.NullableUInt64Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ulong?
+MessagePack.Formatters.NullableUInt64Formatter.Serialize(ref MessagePack.MessagePackWriter writer, ulong? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ObservableCollectionFormatter<T>
+MessagePack.Formatters.ObservableCollectionFormatter<T>.ObservableCollectionFormatter() -> void
+MessagePack.Formatters.PrimitiveObjectFormatter
+MessagePack.Formatters.PrimitiveObjectFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> object?
+MessagePack.Formatters.PrimitiveObjectFormatter.Serialize(ref MessagePack.MessagePackWriter writer, object? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.QueueFormatter<T>
+MessagePack.Formatters.QueueFormatter<T>.QueueFormatter() -> void
+MessagePack.Formatters.ReadOnlyCollectionFormatter<T>
+MessagePack.Formatters.ReadOnlyCollectionFormatter<T>.ReadOnlyCollectionFormatter() -> void
+MessagePack.Formatters.ReadOnlyDictionaryFormatter<TKey, TValue>
+MessagePack.Formatters.ReadOnlyDictionaryFormatter<TKey, TValue>.ReadOnlyDictionaryFormatter() -> void
+MessagePack.Formatters.ReadOnlyObservableCollectionFormatter<T>
+MessagePack.Formatters.ReadOnlyObservableCollectionFormatter<T>.ReadOnlyObservableCollectionFormatter() -> void
+MessagePack.Formatters.SByteArrayFormatter
+MessagePack.Formatters.SByteArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> sbyte[]?
+MessagePack.Formatters.SByteArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, sbyte[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.SByteFormatter
+MessagePack.Formatters.SByteFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> sbyte
+MessagePack.Formatters.SByteFormatter.Serialize(ref MessagePack.MessagePackWriter writer, sbyte value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.SingleArrayFormatter
+MessagePack.Formatters.SingleArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> float[]?
+MessagePack.Formatters.SingleArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, float[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.SingleFormatter
+MessagePack.Formatters.SingleFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> float
+MessagePack.Formatters.SingleFormatter.Serialize(ref MessagePack.MessagePackWriter writer, float value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.SortedDictionaryFormatter<TKey, TValue>
+MessagePack.Formatters.SortedDictionaryFormatter<TKey, TValue>.SortedDictionaryFormatter() -> void
+MessagePack.Formatters.SortedListFormatter<TKey, TValue>
+MessagePack.Formatters.SortedListFormatter<TKey, TValue>.SortedListFormatter() -> void
+MessagePack.Formatters.StackFormatter<T>
+MessagePack.Formatters.StackFormatter<T>.StackFormatter() -> void
+MessagePack.Formatters.StaticNullableFormatter<T>
+MessagePack.Formatters.StaticNullableFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T?
+MessagePack.Formatters.StaticNullableFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.StaticNullableFormatter<T>.StaticNullableFormatter(MessagePack.Formatters.IMessagePackFormatter<T>! underlyingFormatter) -> void
+MessagePack.Formatters.StringBuilderFormatter
+MessagePack.Formatters.StringBuilderFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Text.StringBuilder?
+MessagePack.Formatters.StringBuilderFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Text.StringBuilder? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ThreeDimensionalArrayFormatter<T>
+MessagePack.Formatters.ThreeDimensionalArrayFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T[,,]?
+MessagePack.Formatters.ThreeDimensionalArrayFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T[,,]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ThreeDimensionalArrayFormatter<T>.ThreeDimensionalArrayFormatter() -> void
+MessagePack.Formatters.TimeSpanFormatter
+MessagePack.Formatters.TimeSpanFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.TimeSpan
+MessagePack.Formatters.TimeSpanFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.TimeSpan value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest>
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Tuple<T1, T2, T3, T4, T5, T6, T7, TRest>?
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest>.Serialize(ref MessagePack.MessagePackWriter writer, System.Tuple<T1, T2, T3, T4, T5, T6, T7, TRest>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest>.TupleFormatter() -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6, T7>
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6, T7>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Tuple<T1, T2, T3, T4, T5, T6, T7>?
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6, T7>.Serialize(ref MessagePack.MessagePackWriter writer, System.Tuple<T1, T2, T3, T4, T5, T6, T7>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6, T7>.TupleFormatter() -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6>
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Tuple<T1, T2, T3, T4, T5, T6>?
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6>.Serialize(ref MessagePack.MessagePackWriter writer, System.Tuple<T1, T2, T3, T4, T5, T6>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6>.TupleFormatter() -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5>
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Tuple<T1, T2, T3, T4, T5>?
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5>.Serialize(ref MessagePack.MessagePackWriter writer, System.Tuple<T1, T2, T3, T4, T5>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5>.TupleFormatter() -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4>
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Tuple<T1, T2, T3, T4>?
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4>.Serialize(ref MessagePack.MessagePackWriter writer, System.Tuple<T1, T2, T3, T4>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4>.TupleFormatter() -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3>
+MessagePack.Formatters.TupleFormatter<T1, T2, T3>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Tuple<T1, T2, T3>?
+MessagePack.Formatters.TupleFormatter<T1, T2, T3>.Serialize(ref MessagePack.MessagePackWriter writer, System.Tuple<T1, T2, T3>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3>.TupleFormatter() -> void
+MessagePack.Formatters.TupleFormatter<T1, T2>
+MessagePack.Formatters.TupleFormatter<T1, T2>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Tuple<T1, T2>?
+MessagePack.Formatters.TupleFormatter<T1, T2>.Serialize(ref MessagePack.MessagePackWriter writer, System.Tuple<T1, T2>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TupleFormatter<T1, T2>.TupleFormatter() -> void
+MessagePack.Formatters.TupleFormatter<T1>
+MessagePack.Formatters.TupleFormatter<T1>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Tuple<T1>?
+MessagePack.Formatters.TupleFormatter<T1>.Serialize(ref MessagePack.MessagePackWriter writer, System.Tuple<T1>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TupleFormatter<T1>.TupleFormatter() -> void
+MessagePack.Formatters.TwoDimensionalArrayFormatter<T>
+MessagePack.Formatters.TwoDimensionalArrayFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T[,]?
+MessagePack.Formatters.TwoDimensionalArrayFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T[,]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TwoDimensionalArrayFormatter<T>.TwoDimensionalArrayFormatter() -> void
+MessagePack.Formatters.TypelessFormatter
+MessagePack.Formatters.TypelessFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> object?
+MessagePack.Formatters.TypelessFormatter.Serialize(ref MessagePack.MessagePackWriter writer, object? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.UInt16ArrayFormatter
+MessagePack.Formatters.UInt16ArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ushort[]?
+MessagePack.Formatters.UInt16ArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, ushort[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.UInt16Formatter
+MessagePack.Formatters.UInt16Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ushort
+MessagePack.Formatters.UInt16Formatter.Serialize(ref MessagePack.MessagePackWriter writer, ushort value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.UInt32ArrayFormatter
+MessagePack.Formatters.UInt32ArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> uint[]?
+MessagePack.Formatters.UInt32ArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, uint[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.UInt32Formatter
+MessagePack.Formatters.UInt32Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> uint
+MessagePack.Formatters.UInt32Formatter.Serialize(ref MessagePack.MessagePackWriter writer, uint value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.UInt64ArrayFormatter
+MessagePack.Formatters.UInt64ArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ulong[]?
+MessagePack.Formatters.UInt64ArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, ulong[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.UInt64Formatter
+MessagePack.Formatters.UInt64Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ulong
+MessagePack.Formatters.UInt64Formatter.Serialize(ref MessagePack.MessagePackWriter writer, ulong value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.UriFormatter
+MessagePack.Formatters.UriFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Uri?
+MessagePack.Formatters.UriFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Uri? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest>
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest>.Serialize(ref MessagePack.MessagePackWriter writer, System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest>.ValueTupleFormatter() -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7>
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> (T1, T2, T3, T4, T5, T6, T7)
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7>.Serialize(ref MessagePack.MessagePackWriter writer, (T1, T2, T3, T4, T5, T6, T7) value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7>.ValueTupleFormatter() -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6>
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> (T1, T2, T3, T4, T5, T6)
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6>.Serialize(ref MessagePack.MessagePackWriter writer, (T1, T2, T3, T4, T5, T6) value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6>.ValueTupleFormatter() -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5>
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> (T1, T2, T3, T4, T5)
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5>.Serialize(ref MessagePack.MessagePackWriter writer, (T1, T2, T3, T4, T5) value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5>.ValueTupleFormatter() -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4>
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> (T1, T2, T3, T4)
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4>.Serialize(ref MessagePack.MessagePackWriter writer, (T1, T2, T3, T4) value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4>.ValueTupleFormatter() -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3>
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> (T1, T2, T3)
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3>.Serialize(ref MessagePack.MessagePackWriter writer, (T1, T2, T3) value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3>.ValueTupleFormatter() -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2>
+MessagePack.Formatters.ValueTupleFormatter<T1, T2>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> (T1, T2)
+MessagePack.Formatters.ValueTupleFormatter<T1, T2>.Serialize(ref MessagePack.MessagePackWriter writer, (T1, T2) value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2>.ValueTupleFormatter() -> void
+MessagePack.Formatters.ValueTupleFormatter<T1>
+MessagePack.Formatters.ValueTupleFormatter<T1>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.ValueTuple<T1>
+MessagePack.Formatters.ValueTupleFormatter<T1>.Serialize(ref MessagePack.MessagePackWriter writer, System.ValueTuple<T1> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ValueTupleFormatter<T1>.ValueTupleFormatter() -> void
+MessagePack.Formatters.VersionFormatter
+MessagePack.Formatters.VersionFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Version?
+MessagePack.Formatters.VersionFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Version? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.IFormatterResolver
+MessagePack.IFormatterResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Internal.AutomataDictionary
+MessagePack.Internal.AutomataDictionary.Add(string! str, int value) -> void
+MessagePack.Internal.AutomataDictionary.AutomataDictionary() -> void
+MessagePack.Internal.AutomataDictionary.EmitMatch(System.Reflection.Emit.ILGenerator! il, System.Reflection.Emit.LocalBuilder! bytesSpan, System.Reflection.Emit.LocalBuilder! key, System.Action<System.Collections.Generic.KeyValuePair<string?, int>>! onFound, System.Action! onNotFound) -> void
+MessagePack.Internal.AutomataDictionary.GetEnumerator() -> System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string?, int>>!
+MessagePack.Internal.AutomataDictionary.TryGetValue(System.ReadOnlySpan<byte> bytes, out int value) -> bool
+MessagePack.Internal.AutomataDictionary.TryGetValue(in System.Buffers.ReadOnlySequence<byte> bytes, out int value) -> bool
+MessagePack.Internal.AutomataKeyGen
+MessagePack.Internal.ByteArrayStringHashTable
+MessagePack.Internal.ByteArrayStringHashTable.Add(byte[]! key, int value) -> void
+MessagePack.Internal.ByteArrayStringHashTable.Add(string! key, int value) -> void
+MessagePack.Internal.ByteArrayStringHashTable.ByteArrayStringHashTable(int capacity) -> void
+MessagePack.Internal.ByteArrayStringHashTable.ByteArrayStringHashTable(int capacity, float loadFactor) -> void
+MessagePack.Internal.ByteArrayStringHashTable.GetEnumerator() -> System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string!, int>>!
+MessagePack.Internal.ByteArrayStringHashTable.TryGetValue(System.ReadOnlySpan<byte> key, out int value) -> bool
+MessagePack.Internal.ByteArrayStringHashTable.TryGetValue(in System.Buffers.ReadOnlySequence<byte> key, out int value) -> bool
+MessagePack.Internal.CodeGenHelpers
+MessagePack.Internal.RuntimeTypeHandleEqualityComparer
+MessagePack.Internal.RuntimeTypeHandleEqualityComparer.Equals(System.RuntimeTypeHandle x, System.RuntimeTypeHandle y) -> bool
+MessagePack.Internal.RuntimeTypeHandleEqualityComparer.GetHashCode(System.RuntimeTypeHandle obj) -> int
+MessagePack.Internal.UnsafeMemory
+MessagePack.Internal.UnsafeMemory32
+MessagePack.Internal.UnsafeMemory64
+MessagePack.MessagePackCode
+MessagePack.MessagePackCompression
+MessagePack.MessagePackCompression.Lz4Block = 1 -> MessagePack.MessagePackCompression
+MessagePack.MessagePackCompression.Lz4BlockArray = 2 -> MessagePack.MessagePackCompression
+MessagePack.MessagePackCompression.None = 0 -> MessagePack.MessagePackCompression
+MessagePack.MessagePackRange
+MessagePack.MessagePackReader
+MessagePack.MessagePackReader.CancellationToken.get -> System.Threading.CancellationToken
+MessagePack.MessagePackReader.CancellationToken.set -> void
+MessagePack.MessagePackReader.Clone(in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> MessagePack.MessagePackReader
+MessagePack.MessagePackReader.Consumed.get -> long
+MessagePack.MessagePackReader.CreatePeekReader() -> MessagePack.MessagePackReader
+MessagePack.MessagePackReader.End.get -> bool
+MessagePack.MessagePackReader.IsNil.get -> bool
+MessagePack.MessagePackReader.MessagePackReader(System.ReadOnlyMemory<byte> memory) -> void
+MessagePack.MessagePackReader.MessagePackReader(in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> void
+MessagePack.MessagePackReader.NextCode.get -> byte
+MessagePack.MessagePackReader.NextMessagePackType.get -> MessagePack.MessagePackType
+MessagePack.MessagePackReader.Position.get -> System.SequencePosition
+MessagePack.MessagePackReader.ReadArrayHeader() -> int
+MessagePack.MessagePackReader.ReadBoolean() -> bool
+MessagePack.MessagePackReader.ReadByte() -> byte
+MessagePack.MessagePackReader.ReadBytes() -> System.Buffers.ReadOnlySequence<byte>?
+MessagePack.MessagePackReader.ReadChar() -> char
+MessagePack.MessagePackReader.ReadDateTime() -> System.DateTime
+MessagePack.MessagePackReader.ReadDouble() -> double
+MessagePack.MessagePackReader.ReadExtensionFormat() -> MessagePack.ExtensionResult
+MessagePack.MessagePackReader.ReadExtensionFormatHeader() -> MessagePack.ExtensionHeader
+MessagePack.MessagePackReader.ReadInt16() -> short
+MessagePack.MessagePackReader.ReadInt32() -> int
+MessagePack.MessagePackReader.ReadInt64() -> long
+MessagePack.MessagePackReader.ReadMapHeader() -> int
+MessagePack.MessagePackReader.ReadNil() -> MessagePack.Nil
+MessagePack.MessagePackReader.ReadRaw() -> System.Buffers.ReadOnlySequence<byte>
+MessagePack.MessagePackReader.ReadRaw(long length) -> System.Buffers.ReadOnlySequence<byte>
+MessagePack.MessagePackReader.ReadSByte() -> sbyte
+MessagePack.MessagePackReader.ReadSingle() -> float
+MessagePack.MessagePackReader.ReadString() -> string?
+MessagePack.MessagePackReader.ReadStringSequence() -> System.Buffers.ReadOnlySequence<byte>?
+MessagePack.MessagePackReader.ReadUInt16() -> ushort
+MessagePack.MessagePackReader.ReadUInt32() -> uint
+MessagePack.MessagePackReader.ReadUInt64() -> ulong
+MessagePack.MessagePackReader.Sequence.get -> System.Buffers.ReadOnlySequence<byte>
+MessagePack.MessagePackReader.Skip() -> void
+MessagePack.MessagePackReader.TryReadNil() -> bool
+MessagePack.MessagePackReader.TryReadStringSpan(out System.ReadOnlySpan<byte> span) -> bool
+MessagePack.MessagePackSerializationException
+MessagePack.MessagePackSerializationException.MessagePackSerializationException() -> void
+MessagePack.MessagePackSerializationException.MessagePackSerializationException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+MessagePack.MessagePackSerializationException.MessagePackSerializationException(string? message) -> void
+MessagePack.MessagePackSerializationException.MessagePackSerializationException(string? message, System.Exception? inner) -> void
+MessagePack.MessagePackSerializer
+MessagePack.MessagePackSerializer.Typeless
+MessagePack.MessagePackSerializerOptions
+MessagePack.MessagePackSerializerOptions.AllowAssemblyVersionMismatch.get -> bool
+MessagePack.MessagePackSerializerOptions.Compression.get -> MessagePack.MessagePackCompression
+MessagePack.MessagePackSerializerOptions.MessagePackSerializerOptions(MessagePack.IFormatterResolver! resolver) -> void
+MessagePack.MessagePackSerializerOptions.MessagePackSerializerOptions(MessagePack.MessagePackSerializerOptions! copyFrom) -> void
+MessagePack.MessagePackSerializerOptions.OldSpec.get -> bool?
+MessagePack.MessagePackSerializerOptions.OmitAssemblyVersion.get -> bool
+MessagePack.MessagePackSerializerOptions.Resolver.get -> MessagePack.IFormatterResolver!
+MessagePack.MessagePackSerializerOptions.WithAllowAssemblyVersionMismatch(bool allowAssemblyVersionMismatch) -> MessagePack.MessagePackSerializerOptions!
+MessagePack.MessagePackSerializerOptions.WithCompression(MessagePack.MessagePackCompression compression) -> MessagePack.MessagePackSerializerOptions!
+MessagePack.MessagePackSerializerOptions.WithOldSpec(bool? oldSpec = true) -> MessagePack.MessagePackSerializerOptions!
+MessagePack.MessagePackSerializerOptions.WithOmitAssemblyVersion(bool omitAssemblyVersion) -> MessagePack.MessagePackSerializerOptions!
+MessagePack.MessagePackSerializerOptions.WithResolver(MessagePack.IFormatterResolver! resolver) -> MessagePack.MessagePackSerializerOptions!
+MessagePack.MessagePackStreamReader
+MessagePack.MessagePackStreamReader.Dispose() -> void
+MessagePack.MessagePackStreamReader.MessagePackStreamReader(System.IO.Stream! stream) -> void
+MessagePack.MessagePackStreamReader.ReadAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Buffers.ReadOnlySequence<byte>?>
+MessagePack.MessagePackStreamReader.RemainingBytes.get -> System.Buffers.ReadOnlySequence<byte>
+MessagePack.MessagePackType
+MessagePack.MessagePackType.Array = 7 -> MessagePack.MessagePackType
+MessagePack.MessagePackType.Binary = 6 -> MessagePack.MessagePackType
+MessagePack.MessagePackType.Boolean = 3 -> MessagePack.MessagePackType
+MessagePack.MessagePackType.Extension = 9 -> MessagePack.MessagePackType
+MessagePack.MessagePackType.Float = 4 -> MessagePack.MessagePackType
+MessagePack.MessagePackType.Integer = 1 -> MessagePack.MessagePackType
+MessagePack.MessagePackType.Map = 8 -> MessagePack.MessagePackType
+MessagePack.MessagePackType.Nil = 2 -> MessagePack.MessagePackType
+MessagePack.MessagePackType.String = 5 -> MessagePack.MessagePackType
+MessagePack.MessagePackType.Unknown = 0 -> MessagePack.MessagePackType
+MessagePack.MessagePackWriter
+MessagePack.MessagePackWriter.Advance(int length) -> void
+MessagePack.MessagePackWriter.CancellationToken.get -> System.Threading.CancellationToken
+MessagePack.MessagePackWriter.CancellationToken.set -> void
+MessagePack.MessagePackWriter.Clone(System.Buffers.IBufferWriter<byte>! writer) -> MessagePack.MessagePackWriter
+MessagePack.MessagePackWriter.Flush() -> void
+MessagePack.MessagePackWriter.GetSpan(int length) -> System.Span<byte>
+MessagePack.MessagePackWriter.MessagePackWriter(System.Buffers.IBufferWriter<byte>! writer) -> void
+MessagePack.MessagePackWriter.OldSpec.get -> bool
+MessagePack.MessagePackWriter.OldSpec.set -> void
+MessagePack.MessagePackWriter.Write(System.DateTime dateTime) -> void
+MessagePack.MessagePackWriter.Write(System.ReadOnlySpan<byte> src) -> void
+MessagePack.MessagePackWriter.Write(System.ReadOnlySpan<char> value) -> void
+MessagePack.MessagePackWriter.Write(bool value) -> void
+MessagePack.MessagePackWriter.Write(byte value) -> void
+MessagePack.MessagePackWriter.Write(byte[]? src) -> void
+MessagePack.MessagePackWriter.Write(char value) -> void
+MessagePack.MessagePackWriter.Write(double value) -> void
+MessagePack.MessagePackWriter.Write(float value) -> void
+MessagePack.MessagePackWriter.Write(in System.Buffers.ReadOnlySequence<byte> src) -> void
+MessagePack.MessagePackWriter.Write(int value) -> void
+MessagePack.MessagePackWriter.Write(long value) -> void
+MessagePack.MessagePackWriter.Write(sbyte value) -> void
+MessagePack.MessagePackWriter.Write(short value) -> void
+MessagePack.MessagePackWriter.Write(string? value) -> void
+MessagePack.MessagePackWriter.Write(uint value) -> void
+MessagePack.MessagePackWriter.Write(ulong value) -> void
+MessagePack.MessagePackWriter.Write(ushort value) -> void
+MessagePack.MessagePackWriter.WriteArrayHeader(int count) -> void
+MessagePack.MessagePackWriter.WriteArrayHeader(uint count) -> void
+MessagePack.MessagePackWriter.WriteExtensionFormat(MessagePack.ExtensionResult extensionData) -> void
+MessagePack.MessagePackWriter.WriteExtensionFormatHeader(MessagePack.ExtensionHeader extensionHeader) -> void
+MessagePack.MessagePackWriter.WriteInt16(short value) -> void
+MessagePack.MessagePackWriter.WriteInt32(int value) -> void
+MessagePack.MessagePackWriter.WriteInt64(long value) -> void
+MessagePack.MessagePackWriter.WriteInt8(sbyte value) -> void
+MessagePack.MessagePackWriter.WriteMapHeader(int count) -> void
+MessagePack.MessagePackWriter.WriteMapHeader(uint count) -> void
+MessagePack.MessagePackWriter.WriteNil() -> void
+MessagePack.MessagePackWriter.WriteRaw(System.ReadOnlySpan<byte> rawMessagePackBlock) -> void
+MessagePack.MessagePackWriter.WriteRaw(in System.Buffers.ReadOnlySequence<byte> rawMessagePackBlock) -> void
+MessagePack.MessagePackWriter.WriteString(System.ReadOnlySpan<byte> utf8stringBytes) -> void
+MessagePack.MessagePackWriter.WriteString(in System.Buffers.ReadOnlySequence<byte> utf8stringBytes) -> void
+MessagePack.MessagePackWriter.WriteUInt16(ushort value) -> void
+MessagePack.MessagePackWriter.WriteUInt32(uint value) -> void
+MessagePack.MessagePackWriter.WriteUInt64(ulong value) -> void
+MessagePack.MessagePackWriter.WriteUInt8(byte value) -> void
+MessagePack.Nil
+MessagePack.Nil.Equals(MessagePack.Nil other) -> bool
+MessagePack.Nil.Nil() -> void
+MessagePack.ReservedMessagePackExtensionTypeCode
+MessagePack.Resolvers.AttributeFormatterResolver
+MessagePack.Resolvers.AttributeFormatterResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.BuiltinResolver
+MessagePack.Resolvers.BuiltinResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.CompositeResolver
+MessagePack.Resolvers.ContractlessStandardResolver
+MessagePack.Resolvers.ContractlessStandardResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.ContractlessStandardResolverAllowPrivate
+MessagePack.Resolvers.ContractlessStandardResolverAllowPrivate.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.DynamicContractlessObjectResolver
+MessagePack.Resolvers.DynamicContractlessObjectResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.DynamicContractlessObjectResolverAllowPrivate
+MessagePack.Resolvers.DynamicContractlessObjectResolverAllowPrivate.DynamicContractlessObjectResolverAllowPrivate() -> void
+MessagePack.Resolvers.DynamicContractlessObjectResolverAllowPrivate.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.DynamicEnumAsStringResolver
+MessagePack.Resolvers.DynamicEnumAsStringResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.DynamicEnumResolver
+MessagePack.Resolvers.DynamicEnumResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.DynamicGenericResolver
+MessagePack.Resolvers.DynamicGenericResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.DynamicObjectResolver
+MessagePack.Resolvers.DynamicObjectResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.DynamicObjectResolverAllowPrivate
+MessagePack.Resolvers.DynamicObjectResolverAllowPrivate.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.DynamicUnionResolver
+MessagePack.Resolvers.DynamicUnionResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.NativeDateTimeResolver
+MessagePack.Resolvers.NativeDateTimeResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.NativeDecimalResolver
+MessagePack.Resolvers.NativeDecimalResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.NativeGuidResolver
+MessagePack.Resolvers.NativeGuidResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.PrimitiveObjectResolver
+MessagePack.Resolvers.PrimitiveObjectResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.StandardResolver
+MessagePack.Resolvers.StandardResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.StandardResolverAllowPrivate
+MessagePack.Resolvers.StandardResolverAllowPrivate.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.StaticCompositeResolver
+MessagePack.Resolvers.StaticCompositeResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.StaticCompositeResolver.Register(System.Collections.Generic.IReadOnlyList<MessagePack.Formatters.IMessagePackFormatter!>! formatters, System.Collections.Generic.IReadOnlyList<MessagePack.IFormatterResolver!>! resolvers) -> void
+MessagePack.Resolvers.StaticCompositeResolver.Register(params MessagePack.Formatters.IMessagePackFormatter![]! formatters) -> void
+MessagePack.Resolvers.StaticCompositeResolver.Register(params MessagePack.IFormatterResolver![]! resolvers) -> void
+MessagePack.Resolvers.TypelessContractlessStandardResolver
+MessagePack.Resolvers.TypelessContractlessStandardResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.TypelessContractlessStandardResolver.TypelessContractlessStandardResolver() -> void
+MessagePack.Resolvers.TypelessObjectResolver
+MessagePack.Resolvers.TypelessObjectResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.TinyJsonException
+MessagePack.TinyJsonException.TinyJsonException(string! message) -> void
+abstract MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TEnumerator, TCollection>.Add(TIntermediate collection, int index, TElement value, MessagePack.MessagePackSerializerOptions! options) -> void
+abstract MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TEnumerator, TCollection>.Complete(TIntermediate intermediateCollection) -> TCollection
+abstract MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TEnumerator, TCollection>.Create(int count, MessagePack.MessagePackSerializerOptions! options) -> TIntermediate
+abstract MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TEnumerator, TCollection>.GetSourceEnumerator(TCollection source) -> TEnumerator
+abstract MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TEnumerator, TDictionary>.Add(TIntermediate collection, int index, TKey key, TValue value, MessagePack.MessagePackSerializerOptions! options) -> void
+abstract MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TEnumerator, TDictionary>.Complete(TIntermediate intermediateCollection) -> TDictionary!
+abstract MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TEnumerator, TDictionary>.Create(int count, MessagePack.MessagePackSerializerOptions! options) -> TIntermediate
+abstract MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TEnumerator, TDictionary>.GetSourceEnumerator(TDictionary! source) -> TEnumerator
+const MessagePack.MessagePackCode.Array16 = 220 -> byte
+const MessagePack.MessagePackCode.Array32 = 221 -> byte
+const MessagePack.MessagePackCode.Bin16 = 197 -> byte
+const MessagePack.MessagePackCode.Bin32 = 198 -> byte
+const MessagePack.MessagePackCode.Bin8 = 196 -> byte
+const MessagePack.MessagePackCode.Ext16 = 200 -> byte
+const MessagePack.MessagePackCode.Ext32 = 201 -> byte
+const MessagePack.MessagePackCode.Ext8 = 199 -> byte
+const MessagePack.MessagePackCode.False = 194 -> byte
+const MessagePack.MessagePackCode.FixExt1 = 212 -> byte
+const MessagePack.MessagePackCode.FixExt16 = 216 -> byte
+const MessagePack.MessagePackCode.FixExt2 = 213 -> byte
+const MessagePack.MessagePackCode.FixExt4 = 214 -> byte
+const MessagePack.MessagePackCode.FixExt8 = 215 -> byte
+const MessagePack.MessagePackCode.Float32 = 202 -> byte
+const MessagePack.MessagePackCode.Float64 = 203 -> byte
+const MessagePack.MessagePackCode.Int16 = 209 -> byte
+const MessagePack.MessagePackCode.Int32 = 210 -> byte
+const MessagePack.MessagePackCode.Int64 = 211 -> byte
+const MessagePack.MessagePackCode.Int8 = 208 -> byte
+const MessagePack.MessagePackCode.Map16 = 222 -> byte
+const MessagePack.MessagePackCode.Map32 = 223 -> byte
+const MessagePack.MessagePackCode.MaxFixArray = 159 -> byte
+const MessagePack.MessagePackCode.MaxFixInt = 127 -> byte
+const MessagePack.MessagePackCode.MaxFixMap = 143 -> byte
+const MessagePack.MessagePackCode.MaxFixStr = 191 -> byte
+const MessagePack.MessagePackCode.MaxNegativeFixInt = 255 -> byte
+const MessagePack.MessagePackCode.MinFixArray = 144 -> byte
+const MessagePack.MessagePackCode.MinFixInt = 0 -> byte
+const MessagePack.MessagePackCode.MinFixMap = 128 -> byte
+const MessagePack.MessagePackCode.MinFixStr = 160 -> byte
+const MessagePack.MessagePackCode.MinNegativeFixInt = 224 -> byte
+const MessagePack.MessagePackCode.NeverUsed = 193 -> byte
+const MessagePack.MessagePackCode.Nil = 192 -> byte
+const MessagePack.MessagePackCode.Str16 = 218 -> byte
+const MessagePack.MessagePackCode.Str32 = 219 -> byte
+const MessagePack.MessagePackCode.Str8 = 217 -> byte
+const MessagePack.MessagePackCode.True = 195 -> byte
+const MessagePack.MessagePackCode.UInt16 = 205 -> byte
+const MessagePack.MessagePackCode.UInt32 = 206 -> byte
+const MessagePack.MessagePackCode.UInt64 = 207 -> byte
+const MessagePack.MessagePackCode.UInt8 = 204 -> byte
+const MessagePack.MessagePackRange.MaxFixArrayCount = 15 -> int
+const MessagePack.MessagePackRange.MaxFixMapCount = 15 -> int
+const MessagePack.MessagePackRange.MaxFixNegativeInt = -1 -> int
+const MessagePack.MessagePackRange.MaxFixPositiveInt = 127 -> int
+const MessagePack.MessagePackRange.MaxFixStringLength = 31 -> int
+const MessagePack.MessagePackRange.MinFixNegativeInt = -32 -> int
+const MessagePack.MessagePackRange.MinFixStringLength = 0 -> int
+const MessagePack.ReservedMessagePackExtensionTypeCode.DateTime = -1 -> sbyte
+override MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TCollection>.GetSourceEnumerator(TCollection source) -> System.Collections.Generic.IEnumerator<TElement>!
+override MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TDictionary>.Complete(TDictionary! intermediateCollection) -> TDictionary!
+override MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TDictionary>.GetSourceEnumerator(TDictionary! source) -> System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>!
+override MessagePack.Internal.AutomataDictionary.ToString() -> string!
+override MessagePack.Nil.Equals(object? obj) -> bool
+override MessagePack.Nil.GetHashCode() -> int
+override MessagePack.Nil.ToString() -> string!
+override sealed MessagePack.Formatters.CollectionFormatterBase<TElement, TCollection>.Complete(TCollection intermediateCollection) -> TCollection
+static MessagePack.FormatterResolverExtensions.GetFormatterDynamic(this MessagePack.IFormatterResolver! resolver, System.Type! type) -> object?
+static MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<T>(this MessagePack.IFormatterResolver! resolver) -> MessagePack.Formatters.IMessagePackFormatter<T>!
+static MessagePack.Formatters.PrimitiveObjectFormatter.IsSupportedType(System.Type! type, System.Reflection.TypeInfo! typeInfo, object! value) -> bool
+static MessagePack.Internal.AutomataKeyGen.GetKey(ref System.ReadOnlySpan<byte> span) -> ulong
+static MessagePack.Internal.CodeGenHelpers.GetArrayFromNullableSequence(in System.Buffers.ReadOnlySequence<byte>? sequence) -> byte[]?
+static MessagePack.Internal.CodeGenHelpers.GetEncodedStringBytes(string! value) -> byte[]!
+static MessagePack.Internal.CodeGenHelpers.GetSpanFromSequence(in System.Buffers.ReadOnlySequence<byte> sequence) -> System.ReadOnlySpan<byte>
+static MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref MessagePack.MessagePackReader reader) -> System.ReadOnlySpan<byte>
+static MessagePack.Internal.UnsafeMemory32.WriteRaw1(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw10(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw11(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw12(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw13(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw14(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw15(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw16(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw17(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw18(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw19(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw2(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw20(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw21(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw22(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw23(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw24(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw25(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw26(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw27(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw28(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw29(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw3(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw30(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw31(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw4(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw5(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw6(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw7(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw8(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw9(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw1(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw10(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw11(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw12(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw13(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw14(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw15(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw16(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw17(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw18(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw19(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw2(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw20(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw21(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw22(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw23(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw24(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw25(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw26(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw27(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw28(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw29(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw3(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw30(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw31(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw4(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw5(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw6(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw7(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw8(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw9(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.MessagePackCode.ToFormatName(byte code) -> string!
+static MessagePack.MessagePackCode.ToMessagePackType(byte code) -> MessagePack.MessagePackType
+static MessagePack.MessagePackSerializer.ConvertFromJson(System.IO.TextReader! reader, ref MessagePack.MessagePackWriter writer, MessagePack.MessagePackSerializerOptions? options = null) -> void
+static MessagePack.MessagePackSerializer.ConvertFromJson(string! str, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> byte[]!
+static MessagePack.MessagePackSerializer.ConvertFromJson(string! str, ref MessagePack.MessagePackWriter writer, MessagePack.MessagePackSerializerOptions? options = null) -> void
+static MessagePack.MessagePackSerializer.ConvertToJson(System.ReadOnlyMemory<byte> bytes, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> string!
+static MessagePack.MessagePackSerializer.ConvertToJson(in System.Buffers.ReadOnlySequence<byte> bytes, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> string!
+static MessagePack.MessagePackSerializer.ConvertToJson(ref MessagePack.MessagePackReader reader, System.IO.TextWriter! jsonWriter, MessagePack.MessagePackSerializerOptions? options = null) -> void
+static MessagePack.MessagePackSerializer.DefaultOptions.get -> MessagePack.MessagePackSerializerOptions!
+static MessagePack.MessagePackSerializer.DefaultOptions.set -> void
+static MessagePack.MessagePackSerializer.Deserialize(System.Type! type, System.Buffers.ReadOnlySequence<byte> bytes, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> object?
+static MessagePack.MessagePackSerializer.Deserialize(System.Type! type, System.IO.Stream! stream, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> object?
+static MessagePack.MessagePackSerializer.Deserialize(System.Type! type, System.ReadOnlyMemory<byte> bytes, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> object?
+static MessagePack.MessagePackSerializer.Deserialize(System.Type! type, ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions? options = null) -> object?
+static MessagePack.MessagePackSerializer.Deserialize<T>(System.IO.Stream! stream, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
+static MessagePack.MessagePackSerializer.Deserialize<T>(System.ReadOnlyMemory<byte> buffer, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
+static MessagePack.MessagePackSerializer.Deserialize<T>(System.ReadOnlyMemory<byte> buffer, MessagePack.MessagePackSerializerOptions? options, out int bytesRead, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
+static MessagePack.MessagePackSerializer.Deserialize<T>(System.ReadOnlyMemory<byte> buffer, out int bytesRead, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
+static MessagePack.MessagePackSerializer.Deserialize<T>(in System.Buffers.ReadOnlySequence<byte> byteSequence, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
+static MessagePack.MessagePackSerializer.Deserialize<T>(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions? options = null) -> T
+static MessagePack.MessagePackSerializer.DeserializeAsync(System.Type! type, System.IO.Stream! stream, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<object?>
+static MessagePack.MessagePackSerializer.DeserializeAsync<T>(System.IO.Stream! stream, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T>
+static MessagePack.MessagePackSerializer.Serialize(System.Type! type, System.Buffers.IBufferWriter<byte>! writer, object? obj, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+static MessagePack.MessagePackSerializer.Serialize(System.Type! type, System.IO.Stream! stream, object? obj, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+static MessagePack.MessagePackSerializer.Serialize(System.Type! type, object? obj, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> byte[]!
+static MessagePack.MessagePackSerializer.Serialize(System.Type! type, ref MessagePack.MessagePackWriter writer, object? obj, MessagePack.MessagePackSerializerOptions? options = null) -> void
+static MessagePack.MessagePackSerializer.Serialize<T>(System.Buffers.IBufferWriter<byte>! writer, T value, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+static MessagePack.MessagePackSerializer.Serialize<T>(System.IO.Stream! stream, T value, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+static MessagePack.MessagePackSerializer.Serialize<T>(T value, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> byte[]!
+static MessagePack.MessagePackSerializer.Serialize<T>(ref MessagePack.MessagePackWriter writer, T value, MessagePack.MessagePackSerializerOptions? options = null) -> void
+static MessagePack.MessagePackSerializer.SerializeAsync(System.Type! type, System.IO.Stream! stream, object? obj, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static MessagePack.MessagePackSerializer.SerializeAsync<T>(System.IO.Stream! stream, T value, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static MessagePack.MessagePackSerializer.SerializeToJson<T>(System.IO.TextWriter! textWriter, T obj, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+static MessagePack.MessagePackSerializer.SerializeToJson<T>(T obj, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> string!
+static MessagePack.MessagePackSerializer.Typeless.DefaultOptions.get -> MessagePack.MessagePackSerializerOptions!
+static MessagePack.MessagePackSerializer.Typeless.DefaultOptions.set -> void
+static MessagePack.MessagePackSerializer.Typeless.Deserialize(System.IO.Stream! stream, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> object?
+static MessagePack.MessagePackSerializer.Typeless.Deserialize(System.Memory<byte> bytes, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> object?
+static MessagePack.MessagePackSerializer.Typeless.Deserialize(in System.Buffers.ReadOnlySequence<byte> byteSequence, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> object?
+static MessagePack.MessagePackSerializer.Typeless.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions? options = null) -> object?
+static MessagePack.MessagePackSerializer.Typeless.DeserializeAsync(System.IO.Stream! stream, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<object?>
+static MessagePack.MessagePackSerializer.Typeless.Serialize(System.Buffers.IBufferWriter<byte>! writer, object? obj, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+static MessagePack.MessagePackSerializer.Typeless.Serialize(System.IO.Stream! stream, object? obj, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+static MessagePack.MessagePackSerializer.Typeless.Serialize(object? obj, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> byte[]!
+static MessagePack.MessagePackSerializer.Typeless.Serialize(ref MessagePack.MessagePackWriter writer, object? obj, MessagePack.MessagePackSerializerOptions? options = null) -> void
+static MessagePack.MessagePackSerializer.Typeless.SerializeAsync(System.IO.Stream! stream, object? obj, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static MessagePack.MessagePackSerializerOptions.Standard.get -> MessagePack.MessagePackSerializerOptions!
+static MessagePack.Resolvers.CompositeResolver.Create(System.Collections.Generic.IReadOnlyList<MessagePack.Formatters.IMessagePackFormatter!>! formatters, System.Collections.Generic.IReadOnlyList<MessagePack.IFormatterResolver!>! resolvers) -> MessagePack.IFormatterResolver!
+static MessagePack.Resolvers.CompositeResolver.Create(params MessagePack.Formatters.IMessagePackFormatter![]! formatters) -> MessagePack.IFormatterResolver!
+static MessagePack.Resolvers.CompositeResolver.Create(params MessagePack.IFormatterResolver![]! resolvers) -> MessagePack.IFormatterResolver!
+static readonly MessagePack.Formatters.BigIntegerFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Numerics.BigInteger>!
+static readonly MessagePack.Formatters.BitArrayFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Collections.BitArray?>!
+static readonly MessagePack.Formatters.BooleanArrayFormatter.Instance -> MessagePack.Formatters.BooleanArrayFormatter!
+static readonly MessagePack.Formatters.BooleanFormatter.Instance -> MessagePack.Formatters.BooleanFormatter!
+static readonly MessagePack.Formatters.ByteArrayFormatter.Instance -> MessagePack.Formatters.ByteArrayFormatter!
+static readonly MessagePack.Formatters.ByteArraySegmentFormatter.Instance -> MessagePack.Formatters.ByteArraySegmentFormatter!
+static readonly MessagePack.Formatters.ByteFormatter.Instance -> MessagePack.Formatters.ByteFormatter!
+static readonly MessagePack.Formatters.CharArrayFormatter.Instance -> MessagePack.Formatters.CharArrayFormatter!
+static readonly MessagePack.Formatters.CharFormatter.Instance -> MessagePack.Formatters.CharFormatter!
+static readonly MessagePack.Formatters.ComplexFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Numerics.Complex>!
+static readonly MessagePack.Formatters.DateTimeArrayFormatter.Instance -> MessagePack.Formatters.DateTimeArrayFormatter!
+static readonly MessagePack.Formatters.DateTimeFormatter.Instance -> MessagePack.Formatters.DateTimeFormatter!
+static readonly MessagePack.Formatters.DateTimeOffsetFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.DateTimeOffset>!
+static readonly MessagePack.Formatters.DecimalFormatter.Instance -> MessagePack.Formatters.DecimalFormatter!
+static readonly MessagePack.Formatters.DoubleArrayFormatter.Instance -> MessagePack.Formatters.DoubleArrayFormatter!
+static readonly MessagePack.Formatters.DoubleFormatter.Instance -> MessagePack.Formatters.DoubleFormatter!
+static readonly MessagePack.Formatters.DynamicObjectTypeFallbackFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<object?>!
+static readonly MessagePack.Formatters.ForceByteBlockFormatter.Instance -> MessagePack.Formatters.ForceByteBlockFormatter!
+static readonly MessagePack.Formatters.ForceInt16BlockArrayFormatter.Instance -> MessagePack.Formatters.ForceInt16BlockArrayFormatter!
+static readonly MessagePack.Formatters.ForceInt16BlockFormatter.Instance -> MessagePack.Formatters.ForceInt16BlockFormatter!
+static readonly MessagePack.Formatters.ForceInt32BlockArrayFormatter.Instance -> MessagePack.Formatters.ForceInt32BlockArrayFormatter!
+static readonly MessagePack.Formatters.ForceInt32BlockFormatter.Instance -> MessagePack.Formatters.ForceInt32BlockFormatter!
+static readonly MessagePack.Formatters.ForceInt64BlockArrayFormatter.Instance -> MessagePack.Formatters.ForceInt64BlockArrayFormatter!
+static readonly MessagePack.Formatters.ForceInt64BlockFormatter.Instance -> MessagePack.Formatters.ForceInt64BlockFormatter!
+static readonly MessagePack.Formatters.ForceSByteBlockArrayFormatter.Instance -> MessagePack.Formatters.ForceSByteBlockArrayFormatter!
+static readonly MessagePack.Formatters.ForceSByteBlockFormatter.Instance -> MessagePack.Formatters.ForceSByteBlockFormatter!
+static readonly MessagePack.Formatters.ForceUInt16BlockArrayFormatter.Instance -> MessagePack.Formatters.ForceUInt16BlockArrayFormatter!
+static readonly MessagePack.Formatters.ForceUInt16BlockFormatter.Instance -> MessagePack.Formatters.ForceUInt16BlockFormatter!
+static readonly MessagePack.Formatters.ForceUInt32BlockArrayFormatter.Instance -> MessagePack.Formatters.ForceUInt32BlockArrayFormatter!
+static readonly MessagePack.Formatters.ForceUInt32BlockFormatter.Instance -> MessagePack.Formatters.ForceUInt32BlockFormatter!
+static readonly MessagePack.Formatters.ForceUInt64BlockArrayFormatter.Instance -> MessagePack.Formatters.ForceUInt64BlockArrayFormatter!
+static readonly MessagePack.Formatters.ForceUInt64BlockFormatter.Instance -> MessagePack.Formatters.ForceUInt64BlockFormatter!
+static readonly MessagePack.Formatters.GuidFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Guid>!
+static readonly MessagePack.Formatters.Int16ArrayFormatter.Instance -> MessagePack.Formatters.Int16ArrayFormatter!
+static readonly MessagePack.Formatters.Int16Formatter.Instance -> MessagePack.Formatters.Int16Formatter!
+static readonly MessagePack.Formatters.Int32ArrayFormatter.Instance -> MessagePack.Formatters.Int32ArrayFormatter!
+static readonly MessagePack.Formatters.Int32Formatter.Instance -> MessagePack.Formatters.Int32Formatter!
+static readonly MessagePack.Formatters.Int64ArrayFormatter.Instance -> MessagePack.Formatters.Int64ArrayFormatter!
+static readonly MessagePack.Formatters.Int64Formatter.Instance -> MessagePack.Formatters.Int64Formatter!
+static readonly MessagePack.Formatters.NativeDateTimeArrayFormatter.Instance -> MessagePack.Formatters.NativeDateTimeArrayFormatter!
+static readonly MessagePack.Formatters.NativeDateTimeFormatter.Instance -> MessagePack.Formatters.NativeDateTimeFormatter!
+static readonly MessagePack.Formatters.NativeDecimalFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<decimal>!
+static readonly MessagePack.Formatters.NativeGuidFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Guid>!
+static readonly MessagePack.Formatters.NilFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<MessagePack.Nil>!
+static readonly MessagePack.Formatters.NonGenericInterfaceDictionaryFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Collections.IDictionary?>!
+static readonly MessagePack.Formatters.NonGenericInterfaceListFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Collections.IList?>!
+static readonly MessagePack.Formatters.NullableBooleanFormatter.Instance -> MessagePack.Formatters.NullableBooleanFormatter!
+static readonly MessagePack.Formatters.NullableByteFormatter.Instance -> MessagePack.Formatters.NullableByteFormatter!
+static readonly MessagePack.Formatters.NullableCharFormatter.Instance -> MessagePack.Formatters.NullableCharFormatter!
+static readonly MessagePack.Formatters.NullableDateTimeFormatter.Instance -> MessagePack.Formatters.NullableDateTimeFormatter!
+static readonly MessagePack.Formatters.NullableDoubleFormatter.Instance -> MessagePack.Formatters.NullableDoubleFormatter!
+static readonly MessagePack.Formatters.NullableForceByteBlockFormatter.Instance -> MessagePack.Formatters.NullableForceByteBlockFormatter!
+static readonly MessagePack.Formatters.NullableForceInt16BlockFormatter.Instance -> MessagePack.Formatters.NullableForceInt16BlockFormatter!
+static readonly MessagePack.Formatters.NullableForceInt32BlockFormatter.Instance -> MessagePack.Formatters.NullableForceInt32BlockFormatter!
+static readonly MessagePack.Formatters.NullableForceInt64BlockFormatter.Instance -> MessagePack.Formatters.NullableForceInt64BlockFormatter!
+static readonly MessagePack.Formatters.NullableForceSByteBlockFormatter.Instance -> MessagePack.Formatters.NullableForceSByteBlockFormatter!
+static readonly MessagePack.Formatters.NullableForceUInt16BlockFormatter.Instance -> MessagePack.Formatters.NullableForceUInt16BlockFormatter!
+static readonly MessagePack.Formatters.NullableForceUInt32BlockFormatter.Instance -> MessagePack.Formatters.NullableForceUInt32BlockFormatter!
+static readonly MessagePack.Formatters.NullableForceUInt64BlockFormatter.Instance -> MessagePack.Formatters.NullableForceUInt64BlockFormatter!
+static readonly MessagePack.Formatters.NullableInt16Formatter.Instance -> MessagePack.Formatters.NullableInt16Formatter!
+static readonly MessagePack.Formatters.NullableInt32Formatter.Instance -> MessagePack.Formatters.NullableInt32Formatter!
+static readonly MessagePack.Formatters.NullableInt64Formatter.Instance -> MessagePack.Formatters.NullableInt64Formatter!
+static readonly MessagePack.Formatters.NullableNilFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<MessagePack.Nil?>!
+static readonly MessagePack.Formatters.NullableSByteFormatter.Instance -> MessagePack.Formatters.NullableSByteFormatter!
+static readonly MessagePack.Formatters.NullableSingleFormatter.Instance -> MessagePack.Formatters.NullableSingleFormatter!
+static readonly MessagePack.Formatters.NullableStringArrayFormatter.Instance -> MessagePack.Formatters.NullableStringArrayFormatter!
+static readonly MessagePack.Formatters.NullableStringFormatter.Instance -> MessagePack.Formatters.NullableStringFormatter!
+static readonly MessagePack.Formatters.NullableUInt16Formatter.Instance -> MessagePack.Formatters.NullableUInt16Formatter!
+static readonly MessagePack.Formatters.NullableUInt32Formatter.Instance -> MessagePack.Formatters.NullableUInt32Formatter!
+static readonly MessagePack.Formatters.NullableUInt64Formatter.Instance -> MessagePack.Formatters.NullableUInt64Formatter!
+static readonly MessagePack.Formatters.PrimitiveObjectFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<object?>!
+static readonly MessagePack.Formatters.SByteArrayFormatter.Instance -> MessagePack.Formatters.SByteArrayFormatter!
+static readonly MessagePack.Formatters.SByteFormatter.Instance -> MessagePack.Formatters.SByteFormatter!
+static readonly MessagePack.Formatters.SingleArrayFormatter.Instance -> MessagePack.Formatters.SingleArrayFormatter!
+static readonly MessagePack.Formatters.SingleFormatter.Instance -> MessagePack.Formatters.SingleFormatter!
+static readonly MessagePack.Formatters.StringBuilderFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Text.StringBuilder?>!
+static readonly MessagePack.Formatters.TimeSpanFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.TimeSpan>!
+static readonly MessagePack.Formatters.TypelessFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<object?>!
+static readonly MessagePack.Formatters.UInt16ArrayFormatter.Instance -> MessagePack.Formatters.UInt16ArrayFormatter!
+static readonly MessagePack.Formatters.UInt16Formatter.Instance -> MessagePack.Formatters.UInt16Formatter!
+static readonly MessagePack.Formatters.UInt32ArrayFormatter.Instance -> MessagePack.Formatters.UInt32ArrayFormatter!
+static readonly MessagePack.Formatters.UInt32Formatter.Instance -> MessagePack.Formatters.UInt32Formatter!
+static readonly MessagePack.Formatters.UInt64ArrayFormatter.Instance -> MessagePack.Formatters.UInt64ArrayFormatter!
+static readonly MessagePack.Formatters.UInt64Formatter.Instance -> MessagePack.Formatters.UInt64Formatter!
+static readonly MessagePack.Formatters.UriFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Uri?>!
+static readonly MessagePack.Formatters.VersionFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Version?>!
+static readonly MessagePack.Internal.AutomataKeyGen.GetKeyMethod -> System.Reflection.MethodInfo!
+static readonly MessagePack.Internal.RuntimeTypeHandleEqualityComparer.Default -> System.Collections.Generic.IEqualityComparer<System.RuntimeTypeHandle>!
+static readonly MessagePack.Internal.UnsafeMemory.Is32Bit -> bool
+static readonly MessagePack.Nil.Default -> MessagePack.Nil
+static readonly MessagePack.Resolvers.AttributeFormatterResolver.Instance -> MessagePack.Resolvers.AttributeFormatterResolver!
+static readonly MessagePack.Resolvers.BuiltinResolver.Instance -> MessagePack.Resolvers.BuiltinResolver!
+static readonly MessagePack.Resolvers.ContractlessStandardResolver.Instance -> MessagePack.Resolvers.ContractlessStandardResolver!
+static readonly MessagePack.Resolvers.ContractlessStandardResolver.Options -> MessagePack.MessagePackSerializerOptions!
+static readonly MessagePack.Resolvers.ContractlessStandardResolverAllowPrivate.Instance -> MessagePack.Resolvers.ContractlessStandardResolverAllowPrivate!
+static readonly MessagePack.Resolvers.ContractlessStandardResolverAllowPrivate.Options -> MessagePack.MessagePackSerializerOptions!
+static readonly MessagePack.Resolvers.DynamicContractlessObjectResolver.Instance -> MessagePack.Resolvers.DynamicContractlessObjectResolver!
+static readonly MessagePack.Resolvers.DynamicContractlessObjectResolverAllowPrivate.Instance -> MessagePack.Resolvers.DynamicContractlessObjectResolverAllowPrivate!
+static readonly MessagePack.Resolvers.DynamicEnumAsStringResolver.Instance -> MessagePack.Resolvers.DynamicEnumAsStringResolver!
+static readonly MessagePack.Resolvers.DynamicEnumAsStringResolver.Options -> MessagePack.MessagePackSerializerOptions!
+static readonly MessagePack.Resolvers.DynamicEnumResolver.Instance -> MessagePack.Resolvers.DynamicEnumResolver!
+static readonly MessagePack.Resolvers.DynamicGenericResolver.Instance -> MessagePack.Resolvers.DynamicGenericResolver!
+static readonly MessagePack.Resolvers.DynamicObjectResolver.Instance -> MessagePack.Resolvers.DynamicObjectResolver!
+static readonly MessagePack.Resolvers.DynamicObjectResolver.Options -> MessagePack.MessagePackSerializerOptions!
+static readonly MessagePack.Resolvers.DynamicObjectResolverAllowPrivate.Instance -> MessagePack.Resolvers.DynamicObjectResolverAllowPrivate!
+static readonly MessagePack.Resolvers.DynamicUnionResolver.Instance -> MessagePack.Resolvers.DynamicUnionResolver!
+static readonly MessagePack.Resolvers.DynamicUnionResolver.Options -> MessagePack.MessagePackSerializerOptions!
+static readonly MessagePack.Resolvers.NativeDateTimeResolver.Instance -> MessagePack.Resolvers.NativeDateTimeResolver!
+static readonly MessagePack.Resolvers.NativeDateTimeResolver.Options -> MessagePack.MessagePackSerializerOptions!
+static readonly MessagePack.Resolvers.NativeDecimalResolver.Instance -> MessagePack.Resolvers.NativeDecimalResolver!
+static readonly MessagePack.Resolvers.NativeGuidResolver.Instance -> MessagePack.Resolvers.NativeGuidResolver!
+static readonly MessagePack.Resolvers.PrimitiveObjectResolver.Instance -> MessagePack.Resolvers.PrimitiveObjectResolver!
+static readonly MessagePack.Resolvers.PrimitiveObjectResolver.Options -> MessagePack.MessagePackSerializerOptions!
+static readonly MessagePack.Resolvers.StandardResolver.Instance -> MessagePack.Resolvers.StandardResolver!
+static readonly MessagePack.Resolvers.StandardResolver.Options -> MessagePack.MessagePackSerializerOptions!
+static readonly MessagePack.Resolvers.StandardResolverAllowPrivate.Instance -> MessagePack.Resolvers.StandardResolverAllowPrivate!
+static readonly MessagePack.Resolvers.StandardResolverAllowPrivate.Options -> MessagePack.MessagePackSerializerOptions!
+static readonly MessagePack.Resolvers.StaticCompositeResolver.Instance -> MessagePack.Resolvers.StaticCompositeResolver!
+static readonly MessagePack.Resolvers.TypelessContractlessStandardResolver.Instance -> MessagePack.Resolvers.TypelessContractlessStandardResolver!
+static readonly MessagePack.Resolvers.TypelessContractlessStandardResolver.Options -> MessagePack.MessagePackSerializerOptions!
+static readonly MessagePack.Resolvers.TypelessObjectResolver.Instance -> MessagePack.IFormatterResolver!
+virtual MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TEnumerator, TCollection>.GetCount(TCollection sequence) -> int?
+virtual MessagePack.MessagePackSerializerOptions.Clone() -> MessagePack.MessagePackSerializerOptions!
+virtual MessagePack.MessagePackSerializerOptions.LoadType(string! typeName) -> System.Type?
+virtual MessagePack.MessagePackSerializerOptions.ThrowIfDeserializingTypeIsDisallowed(System.Type! type) -> void
+MessagePack.ExtensionHeader.Equals(MessagePack.ExtensionHeader other) -> bool
+MessagePack.Formatters.InterfaceCollectionFormatter2<T>
+MessagePack.Formatters.InterfaceCollectionFormatter2<T>.InterfaceCollectionFormatter2() -> void
+MessagePack.Formatters.InterfaceListFormatter2<T>
+MessagePack.Formatters.InterfaceListFormatter2<T>.InterfaceListFormatter2() -> void
+MessagePack.MessagePackReader.Depth.get -> int
+MessagePack.MessagePackReader.Depth.set -> void
+MessagePack.MessagePackReader.ReadDateTime(MessagePack.ExtensionHeader header) -> System.DateTime
+MessagePack.MessagePackReader.TryReadArrayHeader(out int count) -> bool
+MessagePack.MessagePackReader.TryReadExtensionFormatHeader(out MessagePack.ExtensionHeader extensionHeader) -> bool
+MessagePack.MessagePackReader.TryReadMapHeader(out int count) -> bool
+MessagePack.MessagePackSecurity
+MessagePack.MessagePackSecurity.DepthStep(ref MessagePack.MessagePackReader reader) -> void
+MessagePack.MessagePackSecurity.GetEqualityComparer() -> System.Collections.IEqualityComparer!
+MessagePack.MessagePackSecurity.GetEqualityComparer<T>() -> System.Collections.Generic.IEqualityComparer<T>!
+MessagePack.MessagePackSecurity.HashCollisionResistant.get -> bool
+MessagePack.MessagePackSecurity.MaximumObjectGraphDepth.get -> int
+MessagePack.MessagePackSecurity.MessagePackSecurity(MessagePack.MessagePackSecurity! copyFrom) -> void
+MessagePack.MessagePackSecurity.WithHashCollisionResistant(bool hashCollisionResistant) -> MessagePack.MessagePackSecurity!
+MessagePack.MessagePackSecurity.WithMaximumObjectGraphDepth(int maximumObjectGraphDepth) -> MessagePack.MessagePackSecurity!
+MessagePack.MessagePackSerializerOptions.Security.get -> MessagePack.MessagePackSecurity!
+MessagePack.MessagePackSerializerOptions.WithSecurity(MessagePack.MessagePackSecurity! security) -> MessagePack.MessagePackSerializerOptions!
+MessagePack.MessagePackStreamReader.DiscardBufferedData() -> void
+MessagePack.MessagePackStreamReader.MessagePackStreamReader(System.IO.Stream! stream, bool leaveOpen) -> void
+MessagePack.MessagePackStreamReader.ReadArrayAsync(System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<System.Buffers.ReadOnlySequence<byte>>!
+MessagePack.MessagePackWriter.WriteBinHeader(int length) -> void
+MessagePack.MessagePackWriter.WriteStringHeader(int byteCount) -> void
+static readonly MessagePack.MessagePackSecurity.TrustedData -> MessagePack.MessagePackSecurity!
+static readonly MessagePack.MessagePackSecurity.UntrustedData -> MessagePack.MessagePackSecurity!
+virtual MessagePack.MessagePackSecurity.Clone() -> MessagePack.MessagePackSecurity!
+virtual MessagePack.MessagePackSecurity.GetHashCollisionResistantEqualityComparer() -> System.Collections.IEqualityComparer!
+virtual MessagePack.MessagePackSecurity.GetHashCollisionResistantEqualityComparer<T>() -> System.Collections.Generic.IEqualityComparer<T>!
+MessagePack.Formatters.ByteMemoryFormatter
+MessagePack.Formatters.ByteMemoryFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Memory<byte>
+MessagePack.Formatters.ByteMemoryFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Memory<byte> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ByteReadOnlyMemoryFormatter
+MessagePack.Formatters.ByteReadOnlyMemoryFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.ReadOnlyMemory<byte>
+MessagePack.Formatters.ByteReadOnlyMemoryFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.ReadOnlyMemory<byte> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ByteReadOnlySequenceFormatter
+MessagePack.Formatters.ByteReadOnlySequenceFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Buffers.ReadOnlySequence<byte>
+MessagePack.Formatters.ByteReadOnlySequenceFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Buffers.ReadOnlySequence<byte> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ExpandoObjectFormatter
+MessagePack.Formatters.ExpandoObjectFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Dynamic.ExpandoObject?
+MessagePack.Formatters.ExpandoObjectFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Dynamic.ExpandoObject? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceTypelessFormatter<T>
+MessagePack.Formatters.ForceTypelessFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T?
+MessagePack.Formatters.ForceTypelessFormatter<T>.ForceTypelessFormatter() -> void
+MessagePack.Formatters.ForceTypelessFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.MemoryFormatter<T>
+MessagePack.Formatters.MemoryFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Memory<T>
+MessagePack.Formatters.MemoryFormatter<T>.MemoryFormatter() -> void
+MessagePack.Formatters.MemoryFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, System.Memory<T> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NonGenericInterfaceCollectionFormatter
+MessagePack.Formatters.NonGenericInterfaceCollectionFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Collections.ICollection?
+MessagePack.Formatters.NonGenericInterfaceCollectionFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Collections.ICollection? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NonGenericInterfaceEnumerableFormatter
+MessagePack.Formatters.NonGenericInterfaceEnumerableFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Collections.IEnumerable?
+MessagePack.Formatters.NonGenericInterfaceEnumerableFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Collections.IEnumerable? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.PrimitiveObjectFormatter.PrimitiveObjectFormatter() -> void
+MessagePack.Formatters.ReadOnlyMemoryFormatter<T>
+MessagePack.Formatters.ReadOnlyMemoryFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.ReadOnlyMemory<T>
+MessagePack.Formatters.ReadOnlyMemoryFormatter<T>.ReadOnlyMemoryFormatter() -> void
+MessagePack.Formatters.ReadOnlyMemoryFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, System.ReadOnlyMemory<T> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ReadOnlySequenceFormatter<T>
+MessagePack.Formatters.ReadOnlySequenceFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Buffers.ReadOnlySequence<T>
+MessagePack.Formatters.ReadOnlySequenceFormatter<T>.ReadOnlySequenceFormatter() -> void
+MessagePack.Formatters.ReadOnlySequenceFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, System.Buffers.ReadOnlySequence<T> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TypeFormatter<T>
+MessagePack.Formatters.TypeFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T?
+MessagePack.Formatters.TypeFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TypelessFormatter.TypelessFormatter() -> void
+MessagePack.ImmutableCollection.ImmutableArrayFormatter<T>
+~MessagePack.ImmutableCollection.ImmutableArrayFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions options) -> System.Collections.Immutable.ImmutableArray<T>
+MessagePack.ImmutableCollection.ImmutableArrayFormatter<T>.ImmutableArrayFormatter() -> void
+~MessagePack.ImmutableCollection.ImmutableArrayFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, System.Collections.Immutable.ImmutableArray<T> value, MessagePack.MessagePackSerializerOptions options) -> void
+MessagePack.ImmutableCollection.ImmutableCollectionResolver
+MessagePack.ImmutableCollection.ImmutableCollectionResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.ImmutableCollection.ImmutableDictionaryFormatter<TKey, TValue>
+MessagePack.ImmutableCollection.ImmutableDictionaryFormatter<TKey, TValue>.ImmutableDictionaryFormatter() -> void
+MessagePack.ImmutableCollection.ImmutableHashSetFormatter<T>
+MessagePack.ImmutableCollection.ImmutableHashSetFormatter<T>.ImmutableHashSetFormatter() -> void
+MessagePack.ImmutableCollection.ImmutableListFormatter<T>
+MessagePack.ImmutableCollection.ImmutableListFormatter<T>.ImmutableListFormatter() -> void
+MessagePack.ImmutableCollection.ImmutableQueueBuilder<T>
+MessagePack.ImmutableCollection.ImmutableQueueBuilder<T>.Add(T value) -> void
+MessagePack.ImmutableCollection.ImmutableQueueBuilder<T>.ImmutableQueueBuilder() -> void
+~MessagePack.ImmutableCollection.ImmutableQueueBuilder<T>.Q.get -> System.Collections.Immutable.ImmutableQueue<T>
+~MessagePack.ImmutableCollection.ImmutableQueueBuilder<T>.Q.set -> void
+MessagePack.ImmutableCollection.ImmutableQueueFormatter<T>
+MessagePack.ImmutableCollection.ImmutableQueueFormatter<T>.ImmutableQueueFormatter() -> void
+MessagePack.ImmutableCollection.ImmutableSortedDictionaryFormatter<TKey, TValue>
+MessagePack.ImmutableCollection.ImmutableSortedDictionaryFormatter<TKey, TValue>.ImmutableSortedDictionaryFormatter() -> void
+MessagePack.ImmutableCollection.ImmutableSortedSetFormatter<T>
+MessagePack.ImmutableCollection.ImmutableSortedSetFormatter<T>.ImmutableSortedSetFormatter() -> void
+MessagePack.ImmutableCollection.ImmutableStackFormatter<T>
+MessagePack.ImmutableCollection.ImmutableStackFormatter<T>.ImmutableStackFormatter() -> void
+MessagePack.ImmutableCollection.InterfaceImmutableDictionaryFormatter<TKey, TValue>
+MessagePack.ImmutableCollection.InterfaceImmutableDictionaryFormatter<TKey, TValue>.InterfaceImmutableDictionaryFormatter() -> void
+MessagePack.ImmutableCollection.InterfaceImmutableListFormatter<T>
+MessagePack.ImmutableCollection.InterfaceImmutableListFormatter<T>.InterfaceImmutableListFormatter() -> void
+MessagePack.ImmutableCollection.InterfaceImmutableQueueFormatter<T>
+MessagePack.ImmutableCollection.InterfaceImmutableQueueFormatter<T>.InterfaceImmutableQueueFormatter() -> void
+MessagePack.ImmutableCollection.InterfaceImmutableSetFormatter<T>
+MessagePack.ImmutableCollection.InterfaceImmutableSetFormatter<T>.InterfaceImmutableSetFormatter() -> void
+MessagePack.ImmutableCollection.InterfaceImmutableStackFormatter<T>
+MessagePack.ImmutableCollection.InterfaceImmutableStackFormatter<T>.InterfaceImmutableStackFormatter() -> void
+MessagePack.Resolvers.ExpandoObjectResolver
+~override MessagePack.ImmutableCollection.ImmutableDictionaryFormatter<TKey, TValue>.Add(System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder collection, int index, TKey key, TValue value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.ImmutableDictionaryFormatter<TKey, TValue>.Complete(System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder intermediateCollection) -> System.Collections.Immutable.ImmutableDictionary<TKey, TValue>
+~override MessagePack.ImmutableCollection.ImmutableDictionaryFormatter<TKey, TValue>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder
+~override MessagePack.ImmutableCollection.ImmutableDictionaryFormatter<TKey, TValue>.GetSourceEnumerator(System.Collections.Immutable.ImmutableDictionary<TKey, TValue> source) -> System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Enumerator
+~override MessagePack.ImmutableCollection.ImmutableHashSetFormatter<T>.Add(System.Collections.Immutable.ImmutableHashSet<T>.Builder collection, int index, T value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.ImmutableHashSetFormatter<T>.Complete(System.Collections.Immutable.ImmutableHashSet<T>.Builder intermediateCollection) -> System.Collections.Immutable.ImmutableHashSet<T>
+~override MessagePack.ImmutableCollection.ImmutableHashSetFormatter<T>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> System.Collections.Immutable.ImmutableHashSet<T>.Builder
+~override MessagePack.ImmutableCollection.ImmutableHashSetFormatter<T>.GetSourceEnumerator(System.Collections.Immutable.ImmutableHashSet<T> source) -> System.Collections.Immutable.ImmutableHashSet<T>.Enumerator
+~override MessagePack.ImmutableCollection.ImmutableListFormatter<T>.Add(System.Collections.Immutable.ImmutableList<T>.Builder collection, int index, T value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.ImmutableListFormatter<T>.Complete(System.Collections.Immutable.ImmutableList<T>.Builder intermediateCollection) -> System.Collections.Immutable.ImmutableList<T>
+~override MessagePack.ImmutableCollection.ImmutableListFormatter<T>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> System.Collections.Immutable.ImmutableList<T>.Builder
+~override MessagePack.ImmutableCollection.ImmutableListFormatter<T>.GetSourceEnumerator(System.Collections.Immutable.ImmutableList<T> source) -> System.Collections.Immutable.ImmutableList<T>.Enumerator
+~override MessagePack.ImmutableCollection.ImmutableQueueFormatter<T>.Add(MessagePack.ImmutableCollection.ImmutableQueueBuilder<T> collection, int index, T value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.ImmutableQueueFormatter<T>.Complete(MessagePack.ImmutableCollection.ImmutableQueueBuilder<T> intermediateCollection) -> System.Collections.Immutable.ImmutableQueue<T>
+~override MessagePack.ImmutableCollection.ImmutableQueueFormatter<T>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> MessagePack.ImmutableCollection.ImmutableQueueBuilder<T>
+~override MessagePack.ImmutableCollection.ImmutableSortedDictionaryFormatter<TKey, TValue>.Add(System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder collection, int index, TKey key, TValue value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.ImmutableSortedDictionaryFormatter<TKey, TValue>.Complete(System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder intermediateCollection) -> System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>
+~override MessagePack.ImmutableCollection.ImmutableSortedDictionaryFormatter<TKey, TValue>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder
+~override MessagePack.ImmutableCollection.ImmutableSortedDictionaryFormatter<TKey, TValue>.GetSourceEnumerator(System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> source) -> System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Enumerator
+~override MessagePack.ImmutableCollection.ImmutableSortedSetFormatter<T>.Add(System.Collections.Immutable.ImmutableSortedSet<T>.Builder collection, int index, T value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.ImmutableSortedSetFormatter<T>.Complete(System.Collections.Immutable.ImmutableSortedSet<T>.Builder intermediateCollection) -> System.Collections.Immutable.ImmutableSortedSet<T>
+~override MessagePack.ImmutableCollection.ImmutableSortedSetFormatter<T>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> System.Collections.Immutable.ImmutableSortedSet<T>.Builder
+~override MessagePack.ImmutableCollection.ImmutableSortedSetFormatter<T>.GetSourceEnumerator(System.Collections.Immutable.ImmutableSortedSet<T> source) -> System.Collections.Immutable.ImmutableSortedSet<T>.Enumerator
+~override MessagePack.ImmutableCollection.ImmutableStackFormatter<T>.Add(T[] collection, int index, T value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.ImmutableStackFormatter<T>.Complete(T[] intermediateCollection) -> System.Collections.Immutable.ImmutableStack<T>
+~override MessagePack.ImmutableCollection.ImmutableStackFormatter<T>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> T[]
+~override MessagePack.ImmutableCollection.InterfaceImmutableDictionaryFormatter<TKey, TValue>.Add(System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder collection, int index, TKey key, TValue value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.InterfaceImmutableDictionaryFormatter<TKey, TValue>.Complete(System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder intermediateCollection) -> System.Collections.Immutable.IImmutableDictionary<TKey, TValue>
+~override MessagePack.ImmutableCollection.InterfaceImmutableDictionaryFormatter<TKey, TValue>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder
+~override MessagePack.ImmutableCollection.InterfaceImmutableListFormatter<T>.Add(System.Collections.Immutable.ImmutableList<T>.Builder collection, int index, T value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.InterfaceImmutableListFormatter<T>.Complete(System.Collections.Immutable.ImmutableList<T>.Builder intermediateCollection) -> System.Collections.Immutable.IImmutableList<T>
+~override MessagePack.ImmutableCollection.InterfaceImmutableListFormatter<T>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> System.Collections.Immutable.ImmutableList<T>.Builder
+~override MessagePack.ImmutableCollection.InterfaceImmutableQueueFormatter<T>.Add(MessagePack.ImmutableCollection.ImmutableQueueBuilder<T> collection, int index, T value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.InterfaceImmutableQueueFormatter<T>.Complete(MessagePack.ImmutableCollection.ImmutableQueueBuilder<T> intermediateCollection) -> System.Collections.Immutable.IImmutableQueue<T>
+~override MessagePack.ImmutableCollection.InterfaceImmutableQueueFormatter<T>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> MessagePack.ImmutableCollection.ImmutableQueueBuilder<T>
+~override MessagePack.ImmutableCollection.InterfaceImmutableSetFormatter<T>.Add(System.Collections.Immutable.ImmutableHashSet<T>.Builder collection, int index, T value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.InterfaceImmutableSetFormatter<T>.Complete(System.Collections.Immutable.ImmutableHashSet<T>.Builder intermediateCollection) -> System.Collections.Immutable.IImmutableSet<T>
+~override MessagePack.ImmutableCollection.InterfaceImmutableSetFormatter<T>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> System.Collections.Immutable.ImmutableHashSet<T>.Builder
+~override MessagePack.ImmutableCollection.InterfaceImmutableStackFormatter<T>.Add(T[] collection, int index, T value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.InterfaceImmutableStackFormatter<T>.Complete(T[] intermediateCollection) -> System.Collections.Immutable.IImmutableStack<T>
+~override MessagePack.ImmutableCollection.InterfaceImmutableStackFormatter<T>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> T[]
+static readonly MessagePack.Formatters.ByteMemoryFormatter.Instance -> MessagePack.Formatters.ByteMemoryFormatter!
+static readonly MessagePack.Formatters.ByteReadOnlyMemoryFormatter.Instance -> MessagePack.Formatters.ByteReadOnlyMemoryFormatter!
+static readonly MessagePack.Formatters.ByteReadOnlySequenceFormatter.Instance -> MessagePack.Formatters.ByteReadOnlySequenceFormatter!
+static readonly MessagePack.Formatters.ExpandoObjectFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Dynamic.ExpandoObject?>!
+static readonly MessagePack.Formatters.NonGenericInterfaceCollectionFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Collections.ICollection?>!
+static readonly MessagePack.Formatters.NonGenericInterfaceEnumerableFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Collections.IEnumerable?>!
+static readonly MessagePack.Formatters.TypeFormatter<T>.Instance -> MessagePack.Formatters.IMessagePackFormatter<T?>!
+static readonly MessagePack.ImmutableCollection.ImmutableCollectionResolver.Instance -> MessagePack.ImmutableCollection.ImmutableCollectionResolver!
+static readonly MessagePack.Resolvers.ExpandoObjectResolver.Instance -> MessagePack.IFormatterResolver!
+static readonly MessagePack.Resolvers.ExpandoObjectResolver.Options -> MessagePack.MessagePackSerializerOptions!
+virtual MessagePack.Formatters.PrimitiveObjectFormatter.DeserializeMap(ref MessagePack.MessagePackReader reader, int length, MessagePack.MessagePackSerializerOptions! options) -> object!
+MessagePack.ExtensionHeader.ExtensionHeader() -> void
+MessagePack.ExtensionResult.ExtensionResult() -> void
+MessagePack.FormatterNotRegisteredException.FormatterNotRegisteredException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+MessagePack.Formatters.HalfFormatter
+MessagePack.Formatters.HalfFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Half
+MessagePack.Formatters.HalfFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Half value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.InterfaceReadOnlySetFormatter<T>
+MessagePack.Formatters.InterfaceReadOnlySetFormatter<T>.InterfaceReadOnlySetFormatter() -> void
+MessagePack.MessagePackReader.MessagePackReader() -> void
+MessagePack.MessagePackSerializerOptions.SequencePool.get -> MessagePack.SequencePool!
+MessagePack.MessagePackSerializerOptions.WithPool(MessagePack.SequencePool! pool) -> MessagePack.MessagePackSerializerOptions!
+MessagePack.MessagePackStreamReader.MessagePackStreamReader(System.IO.Stream! stream, bool leaveOpen, MessagePack.SequencePool! sequencePool) -> void
+MessagePack.MessagePackStreamReader.ReadArrayHeaderAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<int>
+MessagePack.MessagePackStreamReader.ReadMapHeaderAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<int>
+MessagePack.MessagePackWriter.MessagePackWriter() -> void
+MessagePack.SequencePool
+MessagePack.SequencePool.SequencePool() -> void
+MessagePack.SequencePool.SequencePool(int maxSize) -> void
+MessagePack.SequencePool.SequencePool(int maxSize, System.Buffers.ArrayPool<byte>! arrayPool) -> void
+MessagePack.TinyJsonException.TinyJsonException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+static MessagePack.Nil.operator !=(MessagePack.Nil left, MessagePack.Nil right) -> bool
+static MessagePack.Nil.operator ==(MessagePack.Nil left, MessagePack.Nil right) -> bool
+static readonly MessagePack.Formatters.HalfFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Half>!
+virtual MessagePack.MessagePackStreamReader.Dispose(bool disposing) -> void
+MessagePack.Formatters.GenericEnumerableFormatter<TElement, TCollection>
+MessagePack.Formatters.GenericEnumerableFormatter<TElement, TCollection>.GenericEnumerableFormatter() -> void
+MessagePack.Formatters.GenericReadOnlyDictionaryFormatter<TKey, TValue, TDictionary>
+MessagePack.Formatters.GenericReadOnlyDictionaryFormatter<TKey, TValue, TDictionary>.GenericReadOnlyDictionaryFormatter() -> void

--- a/src/MessagePack/net8.0/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,44 @@
+MessagePack.Formatters.DateOnlyFormatter
+MessagePack.Formatters.DateOnlyFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.DateOnly
+MessagePack.Formatters.DateOnlyFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.DateOnly value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.Matrix3x2Formatter
+MessagePack.Formatters.Matrix3x2Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Numerics.Matrix3x2
+MessagePack.Formatters.Matrix3x2Formatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Numerics.Matrix3x2 value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.Matrix4x4Formatter
+MessagePack.Formatters.Matrix4x4Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Numerics.Matrix4x4
+MessagePack.Formatters.Matrix4x4Formatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Numerics.Matrix4x4 value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.QuaternionFormatter
+MessagePack.Formatters.QuaternionFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Numerics.Quaternion
+MessagePack.Formatters.QuaternionFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Numerics.Quaternion value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.StringInterningFormatter
+MessagePack.Formatters.StringInterningFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> string?
+MessagePack.Formatters.StringInterningFormatter.Serialize(ref MessagePack.MessagePackWriter writer, string? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.StringInterningFormatter.StringInterningFormatter() -> void
+MessagePack.Formatters.TimeOnlyFormatter
+MessagePack.Formatters.TimeOnlyFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.TimeOnly
+MessagePack.Formatters.TimeOnlyFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.TimeOnly value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.Vector2Formatter
+MessagePack.Formatters.Vector2Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Numerics.Vector2
+MessagePack.Formatters.Vector2Formatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Numerics.Vector2 value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.Vector3Formatter
+MessagePack.Formatters.Vector3Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Numerics.Vector3
+MessagePack.Formatters.Vector3Formatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Numerics.Vector3 value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.Vector4Formatter
+MessagePack.Formatters.Vector4Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Numerics.Vector4
+MessagePack.Formatters.Vector4Formatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Numerics.Vector4 value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.MessagePackSerializerOptions.CompressionMinLength.get -> int
+MessagePack.MessagePackSerializerOptions.SuggestedContiguousMemorySize.get -> int
+MessagePack.MessagePackSerializerOptions.WithCompressionMinLength(int compressionMinLength) -> MessagePack.MessagePackSerializerOptions!
+MessagePack.MessagePackSerializerOptions.WithSuggestedContiguousMemorySize(int suggestedContiguousMemorySize) -> MessagePack.MessagePackSerializerOptions!
+MessagePack.Resolvers.StandardAotResolver
+static MessagePack.MessagePackWriter.GetEncodedLength(long value) -> int
+static MessagePack.MessagePackWriter.GetEncodedLength(ulong value) -> int
+static readonly MessagePack.Formatters.DateOnlyFormatter.Instance -> MessagePack.Formatters.DateOnlyFormatter!
+static readonly MessagePack.Formatters.Matrix3x2Formatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Numerics.Matrix3x2>!
+static readonly MessagePack.Formatters.Matrix4x4Formatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Numerics.Matrix4x4>!
+static readonly MessagePack.Formatters.QuaternionFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Numerics.Quaternion>!
+static readonly MessagePack.Formatters.TimeOnlyFormatter.Instance -> MessagePack.Formatters.TimeOnlyFormatter!
+static readonly MessagePack.Formatters.Vector2Formatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Numerics.Vector2>!
+static readonly MessagePack.Formatters.Vector3Formatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Numerics.Vector3>!
+static readonly MessagePack.Formatters.Vector4Formatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Numerics.Vector4>!
+static readonly MessagePack.Resolvers.StandardAotResolver.Instance -> MessagePack.IFormatterResolver!

--- a/tests/MessagePack.Analyzers.Tests/MessagePack.Analyzers.Tests.csproj
+++ b/tests/MessagePack.Analyzers.Tests/MessagePack.Analyzers.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tests/MessagePack.AspNetCoreMvcFormatter.Tests/MessagePack.AspNetCoreMvcFormatter.Tests.csproj
+++ b/tests/MessagePack.AspNetCoreMvcFormatter.Tests/MessagePack.AspNetCoreMvcFormatter.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/MessagePack.Experimental.Tests/MessagePack.Experimental.Tests.csproj
+++ b/tests/MessagePack.Experimental.Tests/MessagePack.Experimental.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/MessagePack.GeneratedCode.Tests/MessagePack.GeneratedCode.Tests.csproj
+++ b/tests/MessagePack.GeneratedCode.Tests/MessagePack.GeneratedCode.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/MessagePack.Internal.Tests/MessagePack.Internal.Tests.csproj
+++ b/tests/MessagePack.Internal.Tests/MessagePack.Internal.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/MessagePack.SourceGenerator.ExecutionTests/MessagePack.SourceGenerator.ExecutionTests.csproj
+++ b/tests/MessagePack.SourceGenerator.ExecutionTests/MessagePack.SourceGenerator.ExecutionTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\SourceGeneratorConsumer.props" />
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublicMessagePackGeneratedResolver>true</PublicMessagePackGeneratedResolver>

--- a/tests/MessagePack.SourceGenerator.MapModeExecutionTests/MessagePack.SourceGenerator.MapModeExecutionTests.csproj
+++ b/tests/MessagePack.SourceGenerator.MapModeExecutionTests/MessagePack.SourceGenerator.MapModeExecutionTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\SourceGeneratorConsumer.props" />
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <MessagePackGeneratedUsesMapMode>true</MessagePackGeneratedUsesMapMode>

--- a/tests/MessagePack.SourceGenerator.Tests/MessagePack.SourceGenerator.Tests.csproj
+++ b/tests/MessagePack.SourceGenerator.Tests/MessagePack.SourceGenerator.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>11</LangVersion>

--- a/tests/MessagePack.SourceGenerator.Tests/Verifiers/CSharpSourceGeneratorVerifier`1+Test.cs
+++ b/tests/MessagePack.SourceGenerator.Tests/Verifiers/CSharpSourceGeneratorVerifier`1+Test.cs
@@ -36,7 +36,7 @@ public static partial class CSharpSourceGeneratorVerifier
         {
             this.CompilerDiagnostics = CompilerDiagnostics.Warnings;
 
-            this.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
+            this.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
             this.TestState.AdditionalReferences.Add(typeof(MessagePackObjectAttribute).Assembly);
             this.TestState.AdditionalReferences.Add(typeof(MessagePackSerializer).Assembly);
 

--- a/tests/MessagePack.SourceGenerator.Unity.Tests/MessagePack.SourceGenerator.Unity.Tests.csproj
+++ b/tests/MessagePack.SourceGenerator.Unity.Tests/MessagePack.SourceGenerator.Unity.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>11</LangVersion>

--- a/tests/MessagePack.Tests/MessagePack.Tests.csproj
+++ b/tests/MessagePack.Tests/MessagePack.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>10</LangVersion>

--- a/tests/SourceGeneratorConsumer.props
+++ b/tests/SourceGeneratorConsumer.props
@@ -15,10 +15,15 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="System.Text.Encodings.Web" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Keep this list in sync with what's in src\MessagePack.SourceGenerator\MessagePack.SourceGenerator.targets -->
     <Analyzer Include="$(PkgSystem_Text_Json)\lib\netstandard2.0\System.Text.Json.dll"/>
+    <Analyzer Include="$(PkgSystem_Text_Encodings_Web)\lib\netstandard2.0\System.Text.Encodings.Web.dll"/>
+    <Analyzer Include="$(PkgMicrosoft_Bcl_AsyncInterfaces)\lib\netstandard2.0\Microsoft.Bcl.AsyncInterfaces.dll"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### TargetFramework Changes

- `net6.0` -> `net6.0` and `net8.0`
- Single `net7.0` -> `net8.0`

### Code Fixes

- [SystemException constructor is obsoleted in .NET 8](https://learn.microsoft.com/en-us/dotnet/api/system.systemexception.-ctor?view=net-8.0#system-systemexception-ctor(system-runtime-serialization-serializationinfo-system-runtime-serialization-streamingcontext)). Add [Obsolete] attributes to the constructors which depend on it.
- Fix reference related error (CS8347)

### LangVersion

If `TargetFramework` is `net8.0` then `LangVersion` is `12` else as-is.