### PR TITLE
.Net 8 Update(5): System.Collections.Generic.PriorityQueue<TElement, TPriority>

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
@@ -574,6 +574,7 @@ namespace MessagePack.Formatters
             using PriorityQueue<TElement, TPriority>.UnorderedItemsCollection.Enumerator e = items.GetEnumerator();
             while (e.MoveNext())
             {
+                writer.CancellationToken.ThrowIfCancellationRequested();
                 var pair = e.Current;
                 elementFormatter.Serialize(ref writer, pair.Element, options);
                 priorityFormatter.Serialize(ref writer, pair.Priority, options);
@@ -593,6 +594,7 @@ namespace MessagePack.Formatters
                 return new PriorityQueue<TElement, TPriority>(comparer);
             }
 
+            options.Security.DepthStep(ref reader);
             IFormatterResolver resolver = options.Resolver;
             IMessagePackFormatter<TElement> elementFormatter = resolver.GetFormatterWithVerify<TElement>();
             IMessagePackFormatter<TPriority> priorityFormatter = resolver.GetFormatterWithVerify<TPriority>();
@@ -606,6 +608,7 @@ namespace MessagePack.Formatters
                 {
                     for (var i = 0; i < sharedBuffer.Length; i++)
                     {
+                        reader.CancellationToken.ThrowIfCancellationRequested();
                         sharedBuffer[i].Item1 = elementFormatter.Deserialize(ref reader, options);
                         sharedBuffer[i].Item2 = priorityFormatter.Deserialize(ref reader, options);
                     }
@@ -618,6 +621,7 @@ namespace MessagePack.Formatters
                     var span = segment.AsSpan();
                     for (var i = 0; i < span.Length; i++)
                     {
+                        reader.CancellationToken.ThrowIfCancellationRequested();
                         span[i].Item1 = elementFormatter.Deserialize(ref reader, options);
                         span[i].Item2 = priorityFormatter.Deserialize(ref reader, options);
                     }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicGenericResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicGenericResolver.cs
@@ -54,6 +54,9 @@ namespace MessagePack.Internal
               { typeof(List<>), typeof(ListFormatter<>) },
               { typeof(LinkedList<>), typeof(LinkedListFormatter<>) },
               { typeof(Queue<>), typeof(QueueFormatter<>) },
+#if NET6_0_OR_GREATER
+              { typeof(PriorityQueue<,>), typeof(PriorityQueueFormatter<,>) },
+#endif
               { typeof(Stack<>), typeof(StackFormatter<>) },
               { typeof(HashSet<>), typeof(HashSetFormatter<>) },
               { typeof(ReadOnlyCollection<>), typeof(ReadOnlyCollectionFormatter<>) },

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/CollectionTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/CollectionTest.cs
@@ -31,6 +31,9 @@ namespace MessagePack.Tests
             new object[] { new ReadOnlyCollection<int>(new[] { 1, 10, 100 }), null },
             new object[] { new ObservableCollection<int>(new[] { 1, 10, 100 }), null },
             new object[] { new ReadOnlyObservableCollection<int>(new ObservableCollection<int>(new[] { 1, 10, 100 })), null },
+#if NET6_0_OR_GREATER
+            new object[] { new PriorityQueue<string, int>(new[] { ("1", 1), ("10", 10), ("100", 100) }), null },
+#endif
         };
 
         [Theory]

--- a/src/MessagePack/net6.0/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/net6.0/PublicAPI.Unshipped.txt
@@ -7,6 +7,11 @@ MessagePack.Formatters.Matrix3x2Formatter.Serialize(ref MessagePack.MessagePackW
 MessagePack.Formatters.Matrix4x4Formatter
 MessagePack.Formatters.Matrix4x4Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Numerics.Matrix4x4
 MessagePack.Formatters.Matrix4x4Formatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Numerics.Matrix4x4 value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.PriorityQueueFormatter<TElement, TPriority>
+MessagePack.Formatters.PriorityQueueFormatter<TElement, TPriority>.PriorityQueueFormatter() -> void
+MessagePack.Formatters.PriorityQueueFormatter<TElement, TPriority>.PriorityQueueFormatter(System.Collections.Generic.IComparer<TPriority>? comparer) -> void
+MessagePack.Formatters.PriorityQueueFormatter<TElement, TPriority>.Serialize(ref MessagePack.MessagePackWriter writer, System.Collections.Generic.PriorityQueue<TElement, TPriority>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.PriorityQueueFormatter<TElement, TPriority>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Collections.Generic.PriorityQueue<TElement, TPriority>?
 MessagePack.Formatters.QuaternionFormatter
 MessagePack.Formatters.QuaternionFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Numerics.Quaternion
 MessagePack.Formatters.QuaternionFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Numerics.Quaternion value, MessagePack.MessagePackSerializerOptions! options) -> void

--- a/src/MessagePack/net8.0/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/net8.0/PublicAPI.Unshipped.txt
@@ -7,6 +7,11 @@ MessagePack.Formatters.Matrix3x2Formatter.Serialize(ref MessagePack.MessagePackW
 MessagePack.Formatters.Matrix4x4Formatter
 MessagePack.Formatters.Matrix4x4Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Numerics.Matrix4x4
 MessagePack.Formatters.Matrix4x4Formatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Numerics.Matrix4x4 value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.PriorityQueueFormatter<TElement, TPriority>
+MessagePack.Formatters.PriorityQueueFormatter<TElement, TPriority>.PriorityQueueFormatter() -> void
+MessagePack.Formatters.PriorityQueueFormatter<TElement, TPriority>.PriorityQueueFormatter(System.Collections.Generic.IComparer<TPriority>? comparer) -> void
+MessagePack.Formatters.PriorityQueueFormatter<TElement, TPriority>.Serialize(ref MessagePack.MessagePackWriter writer, System.Collections.Generic.PriorityQueue<TElement, TPriority>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.PriorityQueueFormatter<TElement, TPriority>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Collections.Generic.PriorityQueue<TElement, TPriority>?
 MessagePack.Formatters.QuaternionFormatter
 MessagePack.Formatters.QuaternionFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Numerics.Quaternion
 MessagePack.Formatters.QuaternionFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Numerics.Quaternion value, MessagePack.MessagePackSerializerOptions! options) -> void


### PR DESCRIPTION
[PriorityQueue<TElement, TPriority>](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.priorityqueue-2?view=net-8.0) was introduced at .NET 6. (I included this type because until recently I thought this type was added in .NET 7.)
It does not implement `IEnumerable`.
It constructs its map from `ValueTuple<TElement, TPriority>[]`.