### PR TITLE
.Net 8 Update(6): CollectionsMarshal for ListFormatter

### DIFF
--- a/MessagePack.sln
+++ b/MessagePack.sln
@@ -106,6 +106,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessagePack.SourceGenerator
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessagePack.Analyzers.CodeFixes", "src\MessagePack.Analyzers.CodeFixes\MessagePack.Analyzers.CodeFixes.csproj", "{7A6CB600-2393-468F-9952-84EC624D57BD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CollectionsMarshalBenchmark", "benchmark\CollectionsMarshalBenchmark\CollectionsMarshalBenchmark.csproj", "{9A31C44C-9C51-4D41-B8E5-2864245F877E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -232,6 +234,10 @@ Global
 		{7A6CB600-2393-468F-9952-84EC624D57BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7A6CB600-2393-468F-9952-84EC624D57BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7A6CB600-2393-468F-9952-84EC624D57BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9A31C44C-9C51-4D41-B8E5-2864245F877E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9A31C44C-9C51-4D41-B8E5-2864245F877E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9A31C44C-9C51-4D41-B8E5-2864245F877E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9A31C44C-9C51-4D41-B8E5-2864245F877E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -267,6 +273,7 @@ Global
 		{EDBA7DDC-69AF-4D5B-A8F6-3B508F8CC0FC} = {19FE674A-AC94-4E7E-B24C-2285D1D04CDE}
 		{EAC1B79C-F77D-4DEF-BF53-75E700A301A4} = {19FE674A-AC94-4E7E-B24C-2285D1D04CDE}
 		{7A6CB600-2393-468F-9952-84EC624D57BD} = {86309CF6-0054-4CE3-BFD3-CA0AA7DB17BC}
+		{9A31C44C-9C51-4D41-B8E5-2864245F877E} = {51A614B0-E583-4DD2-AC7D-6A65634582E0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B3911209-2DBF-47F8-98F6-BBC0EDFE63DE}

--- a/benchmark/CollectionsMarshalBenchmark/CollectionsMarshalBenchmark.csproj
+++ b/benchmark/CollectionsMarshalBenchmark/CollectionsMarshalBenchmark.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>Benchmark</RootNamespace>
+    <Nullable>enable</Nullable>
+    <LangVersion>12</LangVersion>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+
+    <TieredPGO>false</TieredPGO>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MessagePack\MessagePack.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/benchmark/CollectionsMarshalBenchmark/OldListFormatter`1.cs
+++ b/benchmark/CollectionsMarshalBenchmark/OldListFormatter`1.cs
@@ -1,0 +1,67 @@
+// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Buffers;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace MessagePack.Formatters;
+
+public sealed class OldListFormatter<T>
+    : IMessagePackFormatter<List<T>?>
+{
+    public void Serialize(ref MessagePackWriter writer, List<T>? value, MessagePackSerializerOptions options)
+    {
+        if (value == null)
+        {
+            writer.WriteNil();
+        }
+        else
+        {
+            IMessagePackFormatter<T> formatter = options.Resolver.GetFormatterWithVerify<T>();
+
+            var c = value.Count;
+            writer.WriteArrayHeader(c);
+            for (int i = 0; i < c; i++)
+            {
+                writer.CancellationToken.ThrowIfCancellationRequested();
+                formatter.Serialize(ref writer, value[i], options);
+            }
+        }
+    }
+
+    public List<T>? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        if (reader.TryReadNil())
+        {
+            return default;
+        }
+        else
+        {
+            IMessagePackFormatter<T> formatter = options.Resolver.GetFormatterWithVerify<T>();
+
+            var len = reader.ReadArrayHeader();
+            var list = new List<T>((int)len);
+            options.Security.DepthStep(ref reader);
+            try
+            {
+                for (int i = 0; i < len; i++)
+                {
+                    reader.CancellationToken.ThrowIfCancellationRequested();
+                    list.Add(formatter.Deserialize(ref reader, options));
+                }
+            }
+            finally
+            {
+                reader.Depth--;
+            }
+
+            return list;
+        }
+    }
+}

--- a/benchmark/CollectionsMarshalBenchmark/Program.cs
+++ b/benchmark/CollectionsMarshalBenchmark/Program.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Benchmark;
+using BenchmarkDotNet.Running;
+
+namespace CollectionsMarshalBenchmark;
+
+internal class Program
+{
+    private static void Main()
+    {
+        BenchmarkRunner.Run<RandomByteBenchmark>();
+        BenchmarkRunner.Run<RandomMatrix4x4Benchmark>();
+    }
+}

--- a/benchmark/CollectionsMarshalBenchmark/RandomByteBenchmark.cs
+++ b/benchmark/CollectionsMarshalBenchmark/RandomByteBenchmark.cs
@@ -1,0 +1,84 @@
+// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using MessagePack;
+using MessagePack.Formatters;
+
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
+namespace Benchmark;
+
+[MessagePackObject]
+public struct OldTypeByte(List<byte> value)
+{
+    public OldTypeByte() : this([])
+    {
+    }
+
+    [Key(0)]
+    [MessagePackFormatter(typeof(OldListFormatter<byte>))]
+    public List<byte> Value = value;
+}
+
+[MessagePackObject]
+public struct NewTypeByte(List<byte> value)
+{
+    public NewTypeByte() : this([])
+    {
+    }
+
+    [Key(0)]
+    [MessagePackFormatter(typeof(ListFormatter<byte>))]
+    public List<byte> Value = value;
+}
+
+public class RandomByteBenchmark
+{
+    [Params(1, 64, 1024, 16 * 1024 * 1024)]
+    public int Size { get; set; }
+
+    private List<byte> input = [];
+    private byte[] serialized = [];
+
+    [GlobalSetup]
+    public void SetUp()
+    {
+        input = new(Size);
+        for (var i = 0; i < Size; i++)
+        {
+            input.Add((byte)Random.Shared.Next());
+        }
+
+        serialized = MessagePackSerializer.Serialize(new NewTypeByte(input));
+    }
+
+    [Benchmark]
+    public byte[] SerializeNew()
+    {
+        return MessagePackSerializer.Serialize(new NewTypeByte(input));
+    }
+
+    [Benchmark]
+    public byte[] SerializeOld()
+    {
+        return MessagePackSerializer.Serialize(new OldTypeByte(input));
+    }
+
+    [Benchmark]
+    public List<byte> DeserializeNew()
+    {
+        return MessagePackSerializer.Deserialize<NewTypeByte>(serialized).Value;
+    }
+
+    [Benchmark]
+    public List<byte> DeserializeOld()
+    {
+        return MessagePackSerializer.Deserialize<OldTypeByte>(serialized).Value;
+    }
+}

--- a/benchmark/CollectionsMarshalBenchmark/RandomByteBenchmark.cs
+++ b/benchmark/CollectionsMarshalBenchmark/RandomByteBenchmark.cs
@@ -17,7 +17,8 @@ namespace Benchmark;
 [MessagePackObject]
 public struct OldTypeByte(List<byte> value)
 {
-    public OldTypeByte() : this([])
+    public OldTypeByte()
+        : this([])
     {
     }
 
@@ -29,7 +30,8 @@ public struct OldTypeByte(List<byte> value)
 [MessagePackObject]
 public struct NewTypeByte(List<byte> value)
 {
-    public NewTypeByte() : this([])
+    public NewTypeByte()
+        : this([])
     {
     }
 

--- a/benchmark/CollectionsMarshalBenchmark/RandomMatrix4x4Benchmark.cs
+++ b/benchmark/CollectionsMarshalBenchmark/RandomMatrix4x4Benchmark.cs
@@ -1,0 +1,126 @@
+// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using MessagePack;
+using MessagePack.Formatters;
+
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
+namespace Benchmark;
+
+[MessagePack.MessagePackObjectAttribute]
+public struct Matrix4x4
+{
+    [MessagePack.Key(0)] public float M11;
+    [MessagePack.Key(1)] public float M12;
+    [MessagePack.Key(2)] public float M13;
+    [MessagePack.Key(3)] public float M14;
+    [MessagePack.Key(4)] public float M21;
+    [MessagePack.Key(5)] public float M22;
+    [MessagePack.Key(6)] public float M23;
+    [MessagePack.Key(7)] public float M24;
+    [MessagePack.Key(8)] public float M31;
+    [MessagePack.Key(9)] public float M32;
+    [MessagePack.Key(10)] public float M33;
+    [MessagePack.Key(11)] public float M34;
+    [MessagePack.Key(12)] public float M41;
+    [MessagePack.Key(13)] public float M42;
+    [MessagePack.Key(14)] public float M43;
+    [MessagePack.Key(15)] public float M44;
+
+    public Matrix4x4(float m11, float m12, float m13, float m14, float m21, float m22, float m23, float m24, float m31, float m32, float m33, float m34, float m41, float m42, float m43, float m44)
+    {
+        M11 = m11;
+        M12 = m12;
+        M13 = m13;
+        M14 = m14;
+        M21 = m21;
+        M22 = m22;
+        M23 = m23;
+        M24 = m24;
+        M31 = m31;
+        M32 = m32;
+        M33 = m33;
+        M34 = m34;
+        M41 = m41;
+        M42 = m42;
+        M43 = m43;
+        M44 = m44;
+    }
+}
+
+[MessagePackObject]
+public struct OldTypeMatrix4x4(List<Matrix4x4> value)
+{
+    public OldTypeMatrix4x4() : this([])
+    {
+    }
+
+    [Key(0)]
+    [MessagePackFormatter(typeof(OldListFormatter<Matrix4x4>))]
+    public List<Matrix4x4> Value = value;
+}
+
+[MessagePackObject]
+public struct NewTypeMatrix4x4(List<Matrix4x4> value)
+{
+    public NewTypeMatrix4x4() : this([])
+    {
+    }
+
+    [Key(0)]
+    [MessagePackFormatter(typeof(ListFormatter<Matrix4x4>))]
+    public List<Matrix4x4> Value = value;
+}
+
+public class RandomMatrix4x4Benchmark
+{
+    [Params(1, 64, 1024, 16 * 1024 * 1024)]
+    public int Size { get; set; }
+
+    private List<Matrix4x4> input = [];
+    private byte[] serialized = [];
+
+    [GlobalSetup]
+    public void SetUp()
+    {
+        input = new(Size);
+        var r = new Random();
+        for (var i = 0; i < Size; i++)
+        {
+            input.Add(new((float)r.NextDouble(), (float)r.NextDouble(), (float)r.NextDouble(), (float)r.NextDouble(), (float)r.NextDouble(), (float)r.NextDouble(), (float)r.NextDouble(), (float)r.NextDouble(), (float)r.NextDouble(), (float)r.NextDouble(), (float)r.NextDouble(), (float)r.NextDouble(), (float)r.NextDouble(), (float)r.NextDouble(), (float)r.NextDouble(), (float)r.NextDouble()));
+        }
+
+        serialized = MessagePackSerializer.Serialize(new NewTypeMatrix4x4(input));
+    }
+
+    [Benchmark]
+    public byte[] SerializeNew()
+    {
+        return MessagePackSerializer.Serialize(new NewTypeMatrix4x4(input));
+    }
+
+    [Benchmark]
+    public byte[] SerializeOld()
+    {
+        return MessagePackSerializer.Serialize(new OldTypeMatrix4x4(input));
+    }
+
+    [Benchmark]
+    public List<Matrix4x4> DeserializeNew()
+    {
+        return MessagePackSerializer.Deserialize<NewTypeMatrix4x4>(serialized).Value;
+    }
+
+    [Benchmark]
+    public List<Matrix4x4> DeserializeOld()
+    {
+        return MessagePackSerializer.Deserialize<OldTypeMatrix4x4>(serialized).Value;
+    }
+}

--- a/benchmark/CollectionsMarshalBenchmark/RandomMatrix4x4Benchmark.cs
+++ b/benchmark/CollectionsMarshalBenchmark/RandomMatrix4x4Benchmark.cs
@@ -58,7 +58,8 @@ public struct Matrix4x4
 [MessagePackObject]
 public struct OldTypeMatrix4x4(List<Matrix4x4> value)
 {
-    public OldTypeMatrix4x4() : this([])
+    public OldTypeMatrix4x4()
+        : this([])
     {
     }
 
@@ -70,7 +71,8 @@ public struct OldTypeMatrix4x4(List<Matrix4x4> value)
 [MessagePackObject]
 public struct NewTypeMatrix4x4(List<Matrix4x4> value)
 {
-    public NewTypeMatrix4x4() : this([])
+    public NewTypeMatrix4x4()
+        : this([])
     {
     }
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
@@ -262,21 +262,11 @@ namespace MessagePack.Formatters
 
                 var c = value.Count;
                 writer.WriteArrayHeader(c);
-
-#if NET6_0_OR_GREATER
-                var span = CollectionsMarshal.AsSpan(value);
-                for (int i = 0; i < span.Length; i++)
-                {
-                    writer.CancellationToken.ThrowIfCancellationRequested();
-                    formatter.Serialize(ref writer, span[i], options);
-                }
-#else
                 for (int i = 0; i < c; i++)
                 {
                     writer.CancellationToken.ThrowIfCancellationRequested();
                     formatter.Serialize(ref writer, value[i], options);
                 }
-#endif
             }
         }
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
@@ -263,11 +263,20 @@ namespace MessagePack.Formatters
                 var c = value.Count;
                 writer.WriteArrayHeader(c);
 
+#if NET6_0_OR_GREATER
+                var span = CollectionsMarshal.AsSpan(value);
+                for (int i = 0; i < span.Length; i++)
+                {
+                    writer.CancellationToken.ThrowIfCancellationRequested();
+                    formatter.Serialize(ref writer, span[i], options);
+                }
+#else
                 for (int i = 0; i < c; i++)
                 {
                     writer.CancellationToken.ThrowIfCancellationRequested();
                     formatter.Serialize(ref writer, value[i], options);
                 }
+#endif
             }
         }
 
@@ -286,11 +295,21 @@ namespace MessagePack.Formatters
                 options.Security.DepthStep(ref reader);
                 try
                 {
+#if NET8_0_OR_GREATER
+                    CollectionsMarshal.SetCount(list, len);
+                    var span = CollectionsMarshal.AsSpan(list);
+                    for (int i = 0; i < span.Length; i++)
+                    {
+                        reader.CancellationToken.ThrowIfCancellationRequested();
+                        span[i] = formatter.Deserialize(ref reader, options);
+                    }
+#else
                     for (int i = 0; i < len; i++)
                     {
                         reader.CancellationToken.ThrowIfCancellationRequested();
                         list.Add(formatter.Deserialize(ref reader, options));
                     }
+#endif
                 }
                 finally
                 {


### PR DESCRIPTION
`List<T>` for loop is slower than `Span<T>` for loop.
`CollectionsMarshal.AsSpan` converts `List<T>` to `Span<T>`
`CollectionsMarshal.SetCount` can be used for deserialize.