### PR TITLE
.Net 8 Update(7): Throw Exception Helper functions

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/BufferWriter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/BufferWriter.cs
@@ -56,7 +56,12 @@ namespace MessagePack
         {
             _buffered = 0;
             _bytesCommitted = 0;
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(output, nameof(output));
+            _output = output;
+#else
             _output = output ?? throw new ArgumentNullException(nameof(output));
+#endif
 
             _sequencePool = default;
             _rental = default;
@@ -76,7 +81,12 @@ namespace MessagePack
         {
             _buffered = 0;
             _bytesCommitted = 0;
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(sequencePool, nameof(sequencePool));
+            _sequencePool = sequencePool;
+#else
             _sequencePool = sequencePool ?? throw new ArgumentNullException(nameof(sequencePool));
+#endif
             _rental = default;
             _output = null;
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/IFormatterResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/IFormatterResolver.cs
@@ -33,10 +33,14 @@ namespace MessagePack
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static IMessagePackFormatter<T> GetFormatterWithVerify<T>(this IFormatterResolver resolver)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(resolver, nameof(resolver));
+#else
             if (resolver is null)
             {
                 throw new ArgumentNullException(nameof(resolver));
             }
+#endif
 
             IMessagePackFormatter<T>? formatter;
             try
@@ -80,6 +84,10 @@ namespace MessagePack
 
         public static object? GetFormatterDynamic(this IFormatterResolver resolver, Type type)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(resolver, nameof(resolver));
+            ArgumentNullException.ThrowIfNull(type, nameof(type));
+#else
             if (resolver is null)
             {
                 throw new ArgumentNullException(nameof(resolver));
@@ -89,6 +97,7 @@ namespace MessagePack
             {
                 throw new ArgumentNullException(nameof(type));
             }
+#endif
 
             if (!FormatterGetters.TryGetValue(type, out var formatterGetter))
             {

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ExpressionUtility.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ExpressionUtility.cs
@@ -11,10 +11,14 @@ namespace MessagePack.Internal
     {
         private static MethodInfo GetMethodInfoCore(LambdaExpression expression)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(expression, nameof(expression));
+#else
             if (expression == null)
             {
-                throw new ArgumentNullException("expression");
+                throw new ArgumentNullException(nameof(expression));
             }
+#endif
 
             return ((MethodCallExpression)expression.Body).Method;
         }
@@ -63,10 +67,14 @@ namespace MessagePack.Internal
 
         private static MemberInfo GetMemberInfoCore<T>(Expression<T> source)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(source, nameof(source));
+#else
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
+#endif
 
             var memberExpression = (MemberExpression)source.Body;
             return memberExpression.Member;

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ThreadsafeTypeKeyHashTable.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ThreadsafeTypeKeyHashTable.cs
@@ -103,10 +103,14 @@ namespace MessagePack.Internal
                 }
                 else
                 {
+#if NET6_0_OR_GREATER
+                    ArgumentNullException.ThrowIfNull(valueFactory, nameof(valueFactory));
+#else
                     if (valueFactory is null)
                     {
                         throw new ArgumentNullException(nameof(valueFactory));
                     }
+#endif
 
                     resultingValue = valueFactory(newKey);
                     VolatileWrite(ref buckets[h & (buckets.Length - 1)], new Entry(newKey, resultingValue, h));
@@ -132,10 +136,14 @@ namespace MessagePack.Internal
                         }
                         else
                         {
+#if NET6_0_OR_GREATER
+                            ArgumentNullException.ThrowIfNull(valueFactory, nameof(valueFactory));
+#else
                             if (valueFactory is null)
                             {
                                 throw new ArgumentNullException(nameof(valueFactory));
                             }
+#endif
 
                             resultingValue = valueFactory(newKey);
                             VolatileWrite(ref searchLastEntry.Next, new Entry(newKey, resultingValue, h));

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/LZ4/LZ4Codec.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/LZ4/LZ4Codec.cs
@@ -142,35 +142,53 @@ namespace MessagePack.LZ4
                 return;
             }
 
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(input, nameof(input));
+#else
             if (input == null)
             {
-                throw new ArgumentNullException("input");
+                throw new ArgumentNullException(nameof(input));
             }
+#endif
 
+#if NET8_0_OR_GREATER
+            ArgumentOutOfRangeException.ThrowIfGreaterThan((uint)inputOffset, (uint)input.Length, nameof(inputOffset));
+            ArgumentOutOfRangeException.ThrowIfGreaterThan((uint)inputLength, (uint)input.Length - (uint)inputOffset, nameof(inputLength));
+#else
             if ((uint)inputOffset > (uint)input.Length)
             {
-                throw new ArgumentOutOfRangeException("inputOffset");
+                throw new ArgumentOutOfRangeException(nameof(inputOffset));
             }
 
             if ((uint)inputLength > (uint)input.Length - (uint)inputOffset)
             {
-                throw new ArgumentOutOfRangeException("inputLength");
+                throw new ArgumentOutOfRangeException(nameof(inputLength));
             }
+#endif
 
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(output, nameof(output));
+#else
             if (output == null)
             {
-                throw new ArgumentNullException("output");
+                throw new ArgumentNullException(nameof(output));
             }
+#endif
 
+#if NET8_0_OR_GREATER
+            ArgumentOutOfRangeException.ThrowIfGreaterThan((uint)outputOffset, (uint)output.Length, nameof(outputOffset));
+            ArgumentOutOfRangeException.ThrowIfGreaterThan((uint)outputLength, (uint)output.Length - (uint)outputOffset, nameof(outputLength));
+#else
             if ((uint)outputOffset > (uint)output.Length)
             {
-                throw new ArgumentOutOfRangeException("outputOffset");
+                throw new ArgumentOutOfRangeException(nameof(outputOffset));
             }
 
             if ((uint)outputLength > (uint)output.Length - (uint)outputOffset)
             {
-                throw new ArgumentOutOfRangeException("outputLength");
+                throw new ArgumentOutOfRangeException(nameof(outputLength));
             }
+#endif
         }
 
         #endregion

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSecurity.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSecurity.cs
@@ -46,10 +46,14 @@ namespace MessagePack
         protected MessagePackSecurity(MessagePackSecurity copyFrom)
             : this()
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(copyFrom, nameof(copyFrom));
+#else
             if (copyFrom is null)
             {
                 throw new ArgumentNullException(nameof(copyFrom));
             }
+#endif
 
             this.HashCollisionResistant = copyFrom.HashCollisionResistant;
             this.MaximumObjectGraphDepth = copyFrom.MaximumObjectGraphDepth;
@@ -262,7 +266,12 @@ namespace MessagePack
 
             internal ObjectFallbackEqualityComparer(MessagePackSecurity security)
             {
+#if NET6_0_OR_GREATER
+                ArgumentNullException.ThrowIfNull(security, nameof(security));
+                this.security = security;
+#else
                 this.security = security ?? throw new ArgumentNullException(nameof(security));
+#endif
             }
 
             bool IEqualityComparer<object>.Equals(object? x, object? y) => EqualityComparer<object?>.Default.Equals(x, y);

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs
@@ -426,10 +426,14 @@ namespace MessagePack
 
         private static T DeserializeFromSequenceAndRewindStreamIfPossible<T>(Stream streamToRewind, MessagePackSerializerOptions? options, ReadOnlySequence<byte> sequence, CancellationToken cancellationToken)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(streamToRewind, nameof(streamToRewind));
+#else
             if (streamToRewind is null)
             {
                 throw new ArgumentNullException(nameof(streamToRewind));
             }
+#endif
 
             var reader = new MessagePackReader(sequence)
             {

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializerOptions.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializerOptions.cs
@@ -40,7 +40,12 @@ namespace MessagePack
         /// </summary>
         public MessagePackSerializerOptions(IFormatterResolver resolver)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(resolver, nameof(resolver));
+            this.Resolver = resolver;
+#else
             this.Resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+#endif
         }
 
         /// <summary>
@@ -50,10 +55,14 @@ namespace MessagePack
         /// <param name="copyFrom">The options to copy from.</param>
         protected MessagePackSerializerOptions(MessagePackSerializerOptions copyFrom)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(copyFrom, nameof(copyFrom));
+#else
             if (copyFrom == null)
             {
                 throw new ArgumentNullException(nameof(copyFrom));
             }
+#endif
 
             this.Resolver = copyFrom.Resolver;
             this.Compression = copyFrom.Compression;
@@ -228,10 +237,14 @@ namespace MessagePack
                 return this;
             }
 
+#if NET8_0_OR_GREATER
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(compressionMinLength, nameof(compressionMinLength));
+#else
             if (compressionMinLength <= 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(compressionMinLength));
             }
+#endif
 
             var result = this.Clone();
             result.CompressionMinLength = compressionMinLength;
@@ -250,10 +263,14 @@ namespace MessagePack
                 return this;
             }
 
+#if NET8_0_OR_GREATER
+            ArgumentOutOfRangeException.ThrowIfLessThan(suggestedContiguousMemorySize, 256, nameof(suggestedContiguousMemorySize));
+#else
             if (suggestedContiguousMemorySize < 256)
             {
                 throw new ArgumentOutOfRangeException(nameof(suggestedContiguousMemorySize), "This should be at least 256");
             }
+#endif
 
             var result = this.Clone();
             result.SuggestedContiguousMemorySize = suggestedContiguousMemorySize;
@@ -318,10 +335,14 @@ namespace MessagePack
         /// <returns>The new instance; or the original if the value is unchanged.</returns>
         public MessagePackSerializerOptions WithSecurity(MessagePackSecurity security)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(security, nameof(security));
+#else
             if (security is null)
             {
                 throw new ArgumentNullException(nameof(security));
             }
+#endif
 
             if (this.Security == security)
             {
@@ -340,10 +361,14 @@ namespace MessagePack
         /// <returns>The new instance.</returns>
         public MessagePackSerializerOptions WithPool(SequencePool pool)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(pool, nameof(pool));
+#else
             if (pool is null)
             {
                 throw new ArgumentNullException(nameof(pool));
             }
+#endif
 
             if (this.SequencePool == pool)
             {

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackStreamReader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackStreamReader.cs
@@ -51,12 +51,18 @@ namespace MessagePack
         /// <param name="sequencePool">The pool to rent a <see cref="Sequence{T}"/> object from.</param>
         public MessagePackStreamReader(Stream stream, bool leaveOpen, SequencePool sequencePool)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(sequencePool, nameof(sequencePool));
+            ArgumentNullException.ThrowIfNull(stream, nameof(stream));
+            this.stream = stream;
+#else
             if (sequencePool == null)
             {
                 throw new ArgumentNullException(nameof(sequencePool));
             }
 
             this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
+#endif
             this.leaveOpen = leaveOpen;
             this.sequenceRental = sequencePool.Rent();
         }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/CompositeResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/CompositeResolver.cs
@@ -38,6 +38,10 @@ namespace MessagePack.Resolvers
         /// </returns>
         public static IFormatterResolver Create(IReadOnlyList<IMessagePackFormatter> formatters, IReadOnlyList<IFormatterResolver> resolvers)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(formatters, nameof(formatters));
+            ArgumentNullException.ThrowIfNull(resolvers, nameof(resolvers));
+#else
             if (formatters is null)
             {
                 throw new ArgumentNullException(nameof(formatters));
@@ -47,6 +51,7 @@ namespace MessagePack.Resolvers
             {
                 throw new ArgumentNullException(nameof(resolvers));
             }
+#endif
 
             // Make a copy of the resolvers list provided by the caller to guard against them changing it later.
             var immutableFormatters = formatters.ToArray();

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/StaticCompositeResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/StaticCompositeResolver.cs
@@ -35,15 +35,15 @@ namespace MessagePack.Resolvers
         /// </param>
         public void Register(params IMessagePackFormatter[] formatters)
         {
-            if (this.frozen)
-            {
-                throw new InvalidOperationException("Register must call on startup(before use GetFormatter<T>).");
-            }
-
+            ThrowInvalidOperationExceptionIfFrozen(this.frozen);
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(formatters, nameof(formatters));
+#else
             if (formatters is null)
             {
                 throw new ArgumentNullException(nameof(formatters));
             }
+#endif
 
             this.formatters = formatters;
             this.resolvers = Array.Empty<IFormatterResolver>();
@@ -60,15 +60,15 @@ namespace MessagePack.Resolvers
         /// </param>
         public void Register(params IFormatterResolver[] resolvers)
         {
-            if (this.frozen)
-            {
-                throw new InvalidOperationException("Register must call on startup(before use GetFormatter<T>).");
-            }
-
+            ThrowInvalidOperationExceptionIfFrozen(this.frozen);
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(resolvers, nameof(resolvers));
+#else
             if (resolvers is null)
             {
                 throw new ArgumentNullException(nameof(resolvers));
             }
+#endif
 
             this.formatters = Array.Empty<IMessagePackFormatter>();
             this.resolvers = resolvers;
@@ -89,11 +89,11 @@ namespace MessagePack.Resolvers
         /// </param>
         public void Register(IReadOnlyList<IMessagePackFormatter> formatters, IReadOnlyList<IFormatterResolver> resolvers)
         {
-            if (this.frozen)
-            {
-                throw new InvalidOperationException("Register must call on startup(before use GetFormatter<T>).");
-            }
-
+            ThrowInvalidOperationExceptionIfFrozen(this.frozen);
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(formatters, nameof(formatters));
+            ArgumentNullException.ThrowIfNull(resolvers, nameof(resolvers));
+#else
             if (formatters is null)
             {
                 throw new ArgumentNullException(nameof(formatters));
@@ -103,9 +103,22 @@ namespace MessagePack.Resolvers
             {
                 throw new ArgumentNullException(nameof(resolvers));
             }
+#endif
 
             this.formatters = formatters;
             this.resolvers = resolvers;
+        }
+
+#if NETCOREAPP3_0_OR_GREATER
+        private static void ThrowInvalidOperationExceptionIfFrozen([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(true)] bool isFrozen)
+#else
+        private static void ThrowInvalidOperationExceptionIfFrozen(bool isFrozen)
+#endif
+        {
+            if (isFrozen)
+            {
+                throw new InvalidOperationException("Register must call on startup(before use GetFormatter<T>).");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Aggressive Inlining is suppressed in function which has `throw` statement.
Such a `ArgumentNullException.ThrowIfNull` function helps inlining.