### PR TITLE
Bump Microsoft.CodeAnalysis to 4.8.0 for tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,8 +8,8 @@
     <BenchmarkDotNetVersion>0.13.12</BenchmarkDotNetVersion>
 
     <!-- https://learn.microsoft.com/en-us/visualstudio/extensibility/roslyn-version-support?view=vs-2022 -->
-    <MicrosoftCodeAnalysisVersion>4.3.0</MicrosoftCodeAnalysisVersion>
-    <MicrosoftCodeAnalysisVersion Condition="'$(IsAnalyzerProject)'!='true'">4.3.0</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisVersion>4.8.0</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisVersion Condition="'$(IsAnalyzerProject)'=='true'">4.3.0</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.23509.1</MicrosoftCodeAnalysisTestingVersion>
 
     <!-- Unity 2021.3 has Roslyn 3.8.0 (https://docs.unity3d.com/Manual/roslyn-analyzers.html) -->

--- a/src/MessagePack.Analyzers.CodeFixes.Unity/MessagePack.Analyzers.CodeFixes.Unity.csproj
+++ b/src/MessagePack.Analyzers.CodeFixes.Unity/MessagePack.Analyzers.CodeFixes.Unity.csproj
@@ -4,6 +4,7 @@
     <RootNamespace>MessagePack.Analyzers</RootNamespace>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <IsAnalyzerProject>true</IsAnalyzerProject>
 
     <MicrosoftCodeAnalysisVersion>$(CodeAnalysisVersionForUnity)</MicrosoftCodeAnalysisVersion>
   </PropertyGroup>

--- a/src/MessagePack.Analyzers.CodeFixes/MessagePack.Analyzers.CodeFixes.csproj
+++ b/src/MessagePack.Analyzers.CodeFixes/MessagePack.Analyzers.CodeFixes.csproj
@@ -4,6 +4,7 @@
     <RootNamespace>MessagePack.Analyzers</RootNamespace>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <IsAnalyzerProject>true</IsAnalyzerProject>
 
     <MicrosoftCodeAnalysisVersion>$(MicrosoftCodeAnalysisVersion)</MicrosoftCodeAnalysisVersion>
   </PropertyGroup>

--- a/src/SourceGenerator.props
+++ b/src/SourceGenerator.props
@@ -4,6 +4,7 @@
     <LangVersion>12</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsAnalyzerProject>true</IsAnalyzerProject>
     <AnalyzerLanguage>cs</AnalyzerLanguage>
   </PropertyGroup>
 


### PR DESCRIPTION
The analyzers and source generators remain targeting 4.3.0