### PR TITLE
Added support for System.Collection.Frozen-types

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/StandardResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/StandardResolver.cs
@@ -297,6 +297,10 @@ namespace MessagePack.Internal
             CompositeResolver.Create(ExpandoObjectFormatter.Instance),
 #endif
 
+#if NET8_0_OR_GREATER
+            FrozenCollection.FrozenCollectionResolver.Instance,
+#endif
+
 #if DYNAMIC_GENERATION
             DynamicGenericResolver.Instance, // Try Array, Tuple, Collection, Enum(Generic Fallback)
 #endif

--- a/src/MessagePack/Formatters/FrozenCollectionFormatters.cs
+++ b/src/MessagePack/Formatters/FrozenCollectionFormatters.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Frozen;
+using MessagePack.Formatters;
+
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
+namespace MessagePack.FrozenCollection
+{
+    public class FrozenDictionaryFormatter<TKey, TValue> : DictionaryFormatterBase<TKey, TValue, Dictionary<TKey, TValue>, FrozenDictionary<TKey, TValue>.Enumerator, FrozenDictionary<TKey, TValue>>
+            where TKey : notnull
+    {
+        protected override void Add(Dictionary<TKey, TValue> collection, int index, TKey key, TValue value, MessagePackSerializerOptions options)
+        =>  collection.Add(key, value);
+
+        protected override FrozenDictionary<TKey, TValue> Complete(Dictionary<TKey, TValue> intermediateCollection)
+        => intermediateCollection.ToFrozenDictionary();
+
+        protected override Dictionary<TKey, TValue> Create(int count, MessagePackSerializerOptions options)
+        => new(options.Security.GetEqualityComparer<TKey>());
+
+        protected override FrozenDictionary<TKey, TValue>.Enumerator GetSourceEnumerator(FrozenDictionary<TKey, TValue> source)
+        => source.GetEnumerator();
+    }
+
+    public class FrozenSetFormatter<T> : CollectionFormatterBase<T, HashSet<T>, FrozenSet<T>.Enumerator, FrozenSet<T>>
+    {
+        protected override void Add(HashSet<T> collection, int index, T value, MessagePackSerializerOptions options)
+        => collection.Add(value);
+
+        protected override FrozenSet<T> Complete(HashSet<T> intermediateCollection)
+        => intermediateCollection.ToFrozenSet();
+
+        protected override HashSet<T> Create(int count, MessagePackSerializerOptions options)
+        => new(options.Security.GetEqualityComparer<T>());
+
+        protected override FrozenSet<T>.Enumerator GetSourceEnumerator(FrozenSet<T> source)
+        => source.GetEnumerator();
+    }
+}
+
+#endif

--- a/src/MessagePack/Resolvers/FrozenCollectionResolver.cs
+++ b/src/MessagePack/Resolvers/FrozenCollectionResolver.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NET8_0_OR_GREATER
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using MessagePack.Formatters;
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+namespace MessagePack.FrozenCollection
+{
+    public class FrozenCollectionResolver : IFormatterResolver
+    {
+        public static readonly FrozenCollectionResolver Instance = new FrozenCollectionResolver();
+
+        private FrozenCollectionResolver()
+        {
+        }
+
+        public IMessagePackFormatter<T>? GetFormatter<T>()
+        {
+            return FormatterCache<T>.Formatter;
+        }
+
+        private static class FormatterCache<T>
+        {
+            internal static readonly IMessagePackFormatter<T>? Formatter;
+
+            static FormatterCache()
+            {
+                Formatter = (IMessagePackFormatter<T>?)FrozenCollectionGetFormatterHelper.GetFormatter(typeof(T));
+            }
+        }
+
+        private static class FrozenCollectionGetFormatterHelper
+        {
+            private static readonly Dictionary<Type, Type> FormatterMap = new()
+            {
+                { typeof(FrozenSet<>), typeof(FrozenSetFormatter<>) },
+                { typeof(FrozenDictionary<,>), typeof(FrozenDictionaryFormatter<,>) },
+            };
+
+            internal static object? GetFormatter(Type t)
+            {
+                if (t.IsGenericType)
+                {
+                    var genericType = t.GetGenericTypeDefinition();
+                    if (FormatterMap.TryGetValue(genericType, out var formatterType))
+                    {
+                        return CreateInstance(formatterType, t.GenericTypeArguments);
+                    }
+                }
+
+                return null;
+            }
+
+            private static object? CreateInstance(Type genericType, Type[] genericTypeArguments, params object[] arguments)
+            {
+                return Activator.CreateInstance(genericType.MakeGenericType(genericTypeArguments), arguments);
+            }
+        }
+    }
+}
+
+#endif

--- a/tests/MessagePack.Tests/ExtensionTests/FrozenCollectionTest.cs
+++ b/tests/MessagePack.Tests/ExtensionTests/FrozenCollectionTest.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using Xunit;
+
+namespace MessagePack.Tests.ExtensionTests
+{
+    public class FrozenCollectionTest
+    {
+        private T Convert<T>(T value)
+        {
+            MessagePackSerializerOptions options = MessagePackSerializerOptions.Standard;
+            return MessagePackSerializer.Deserialize<T>(MessagePackSerializer.Serialize(value, options), options);
+        }
+
+        [Fact]
+        public void FrozenSet_WithContent()
+        {
+            FrozenSet<int> populated = new[] { 1, 10, 100 }.ToFrozenSet();
+            this.Convert(populated).Is(1, 10, 100);
+        }
+
+        [Fact]
+        public void FrozenSet_Nullable_WithContent()
+        {
+            FrozenSet<int>? populatedNullable = new[] { 1, 10, 100 }.ToFrozenSet();
+            this.Convert(populatedNullable).Is(1, 10, 100);
+        }
+
+        [Fact]
+        public void FrozenSet_Nullable_Null()
+        {
+            FrozenSet<int>? nullNullable = null;
+            Assert.Null(this.Convert(nullNullable));
+        }
+
+        [Fact]
+        public void FrozenSet_Empty()
+        {
+            FrozenSet<int> defaultArray = FrozenSet<int>.Empty;
+            Assert.Equal(FrozenSet<int>.Empty, this.Convert(defaultArray));
+        }
+
+        [Fact]
+        public void FrozenDictionary_WithContent()
+        {
+            FrozenDictionary<int, int> populated = new Dictionary<int, int> { { 1, 10 }, { 2, 10 }, { 3, 100 } }.ToFrozenDictionary();
+            this.Convert(populated).IsStructuralEqualIgnoreCollectionOrder(populated);
+        }
+
+        [Fact]
+        public void FrozenDictionary_Nullable_WithContent()
+        {
+            FrozenDictionary<int, int>? populatedNullable = new Dictionary<int, int> { { 1, 10 }, { 2, 10 }, { 3, 100 } }.ToFrozenDictionary();
+            this.Convert(populatedNullable).IsStructuralEqualIgnoreCollectionOrder(populatedNullable);
+        }
+
+        [Fact]
+        public void FrozenDictionary_Nullable_Null()
+        {
+            FrozenDictionary<int, int>? nullNullable = null;
+            Assert.Null(this.Convert(nullNullable));
+        }
+
+        [Fact]
+        public void FrozenDictionary_Empty()
+        {
+            FrozenDictionary<int, int> defaultArray = FrozenDictionary<int, int>.Empty;
+            Assert.Equal(FrozenDictionary<int, int>.Empty, this.Convert(defaultArray));
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
This PR adds support for `System.Collections.Frozen.FrozenSet<T>` and `System.Collections.Frozen.FrozenDictionary<TKey, TValue>`.

The implementation is very similar to that of the [ImmutableCollectionResolver](https://github.com/MessagePack-CSharp/MessagePack-CSharp/blob/master/src/MessagePack/Resolvers/ImmutableCollectionResolver.cs).

Internally, the data will be de-/serialized like a normal `HashSet`/`Dictionary` and eventually transformed into a frozen collection. Since neither sets nor (non-ordered-)dictionaries enforce ordering, any possible shuffling during de-/serialization is irrelevant.

Fixes #1720 