### PR TITLE
IEnumerable<T> serialize improvement: Enumerable.TryGetNonEnumeratedCount

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
@@ -414,18 +414,22 @@ namespace MessagePack.Formatters
         // abstraction for serialize
         protected virtual int? GetCount(TCollection sequence)
         {
+#if NET6_0_OR_GREATER
+            if (Enumerable.TryGetNonEnumeratedCount(sequence, out var count))
+            {
+                return count;
+            }
+#else
             var collection = sequence as ICollection<TElement>;
             if (collection != null)
             {
                 return collection.Count;
             }
-            else
+#endif
+            var c2 = sequence as IReadOnlyCollection<TElement>;
+            if (c2 != null)
             {
-                var c2 = sequence as IReadOnlyCollection<TElement>;
-                if (c2 != null)
-                {
-                    return c2.Count;
-                }
+                return c2.Count;
             }
 
             return null;


### PR DESCRIPTION
[Enumerable.TryGetNonEnumeratedCount](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.trygetnonenumeratedcount?view=net-8.0) is efficient API for getting `Count` when dealing with `IEnumerable<T>`.
`IEnumerable<T>` generated by LINQ can be more efficiently counted since this API can access dotnet's internal interface `IIListProvider<T>`'s `GetCount` method.