### PR TITLE
Use LangVersion=12 everywhere except code that Unity compiles

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,8 +6,7 @@
     <BaseIntermediateOutputPath>$(RepoRootPath)obj\$([MSBuild]::MakeRelative($(RepoRootPath), $(MSBuildProjectDirectory)))\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(RepoRootPath)bin\$(MSBuildProjectName)\</BaseOutputPath>
     <PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\</PackageOutputPath>
-    <LangVersion>10</LangVersion>
-    <LangVersion Condition=" '$(TargetFramework)' == 'net8.0' ">12</LangVersion>
+    <LangVersion>12</LangVersion>
     <AnalysisLevel>latest</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/benchmark/CollectionsMarshalBenchmark/CollectionsMarshalBenchmark.csproj
+++ b/benchmark/CollectionsMarshalBenchmark/CollectionsMarshalBenchmark.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Benchmark</RootNamespace>
     <Nullable>enable</Nullable>
-    <LangVersion>12</LangVersion>
     <ServerGarbageCollection>true</ServerGarbageCollection>
 
     <TieredPGO>false</TieredPGO>

--- a/benchmark/ExperimentalBenchmark/ExperimentalBenchmark.csproj
+++ b/benchmark/ExperimentalBenchmark/ExperimentalBenchmark.csproj
@@ -7,7 +7,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);MSB3243</NoWarn>
     <Nullable>enable</Nullable>
-    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MessagePack.SourceGenerator/MessagePack.SourceGenerator.csproj
+++ b/src/MessagePack.SourceGenerator/MessagePack.SourceGenerator.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>12</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAnalyzerProject>true</IsAnalyzerProject>

--- a/tests/MessagePack.SourceGenerator.Tests/MessagePack.SourceGenerator.Tests.csproj
+++ b/tests/MessagePack.SourceGenerator.Tests/MessagePack.SourceGenerator.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/MessagePack.Tests/MessagePack.Tests.csproj
+++ b/tests/MessagePack.Tests/MessagePack.Tests.csproj
@@ -3,7 +3,6 @@
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>10</LangVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>$(NoWarn);CS1701</NoWarn>


### PR DESCRIPTION
When #1734 merges, I expect we'll be able to use C# 12 even in the main library.