### PR TITLE
Feature/1804 locate formatters only if has elements inside

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/DictionaryFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/DictionaryFormatter.cs
@@ -88,6 +88,8 @@ namespace MessagePack.Formatters
                 options.Security.DepthStep(ref reader);
                 try
                 {
+                    if (len > 0)
+                    {
                     for (int i = 0; i < len; i++)
                     {
                         reader.CancellationToken.ThrowIfCancellationRequested();
@@ -96,6 +98,7 @@ namespace MessagePack.Formatters
                         TValue value = valueFormatter.Deserialize(ref reader, options);
 
                         this.Add(dict, i, key, value, options);
+                    }
                     }
                 }
                 finally

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/DictionaryFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/DictionaryFormatter.cs
@@ -90,15 +90,15 @@ namespace MessagePack.Formatters
                 {
                     if (len > 0)
                     {
-                    for (int i = 0; i < len; i++)
-                    {
-                        reader.CancellationToken.ThrowIfCancellationRequested();
-                        TKey key = keyFormatter.Deserialize(ref reader, options);
+                        for (int i = 0; i < len; i++)
+                        {
+                            reader.CancellationToken.ThrowIfCancellationRequested();
+                            TKey key = keyFormatter.Deserialize(ref reader, options);
 
-                        TValue value = valueFormatter.Deserialize(ref reader, options);
+                            TValue value = valueFormatter.Deserialize(ref reader, options);
 
-                        this.Add(dict, i, key, value, options);
-                    }
+                            this.Add(dict, i, key, value, options);
+                        }
                     }
                 }
                 finally

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/DictionaryFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/DictionaryFormatter.cs
@@ -78,10 +78,6 @@ namespace MessagePack.Formatters
             }
             else
             {
-                IFormatterResolver resolver = options.Resolver;
-                IMessagePackFormatter<TKey>? keyFormatter = resolver.GetFormatterWithVerify<TKey>();
-                IMessagePackFormatter<TValue>? valueFormatter = resolver.GetFormatterWithVerify<TValue>();
-
                 var len = reader.ReadMapHeader();
 
                 TIntermediate dict = this.Create(len, options);
@@ -90,6 +86,9 @@ namespace MessagePack.Formatters
                 {
                     if (len > 0)
                     {
+                        IFormatterResolver resolver = options.Resolver;
+                        IMessagePackFormatter<TKey>? keyFormatter = resolver.GetFormatterWithVerify<TKey>();
+                        IMessagePackFormatter<TValue>? valueFormatter = resolver.GetFormatterWithVerify<TValue>();
                         for (int i = 0; i < len; i++)
                         {
                             reader.CancellationToken.ThrowIfCancellationRequested();

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DictionaryTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DictionaryTest.cs
@@ -53,12 +53,14 @@ namespace MessagePack.Tests
         public void ConcurrentDictionaryTest()
         {
             var cd = new ConcurrentDictionary<int, int>();
+            ConcurrentDictionary<int, int> conv = this.Convert(cd);
+            conv.Count.Is(0);
 
             cd.TryAdd(1, 100);
             cd.TryAdd(2, 200);
             cd.TryAdd(3, 300);
 
-            ConcurrentDictionary<int, int> conv = this.Convert(cd);
+            conv = this.Convert(cd);
             conv[1].Is(100);
             conv[2].Is(200);
             conv[3].Is(300);


### PR DESCRIPTION
Folks, if we are to deserialize the empty dictionary, there is no need to fetch formatters.

Please review per commits.

Thanks.