### PR TITLE
Enable ignoring fields by using [NonSerialized]

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1766,7 +1766,7 @@ namespace MessagePack.Internal
 
             EmittableMember? CreateEmittableMember(MemberInfo m)
             {
-                if (m.IsDefined(typeof(IgnoreMemberAttribute), true) || m.IsDefined(typeof(IgnoreDataMemberAttribute), true))
+                if (m.IsDefined(typeof(IgnoreMemberAttribute), true) || m.IsDefined(typeof(IgnoreDataMemberAttribute), true) || m.IsDefined(typeof(NonSerializedAttribute), true))
                 {
                     return null;
                 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DataContractTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DataContractTest.cs
@@ -195,6 +195,33 @@ namespace MessagePack.Tests
             public bool Equals(Detail other) => other != null && this.B1 == other.B1 && this.B2 == other.B2;
         }
 
+        [Fact]
+        public void Serialize_WithNonSerializedAttribute()
+        {
+            var mc = new ClassWithOldSchoolNonSerializedAttribute
+            {
+                PublicField = 1,
+                IgnoredPublicField = 2,
+            };
+
+            var options = ContractlessStandardResolverAllowPrivate.Options;
+            var bin = MessagePackSerializer.Serialize(mc, options);
+            var mc2 = MessagePackSerializer.Deserialize<ClassWithOldSchoolNonSerializedAttribute>(bin, options);
+
+            mc2.PublicField.Is(1);
+            mc2.IgnoredPublicField.Is(0);
+
+            MessagePackSerializer.ConvertToJson(bin).Is(@"{""PublicField"":1}");
+        }
+
+        public class ClassWithOldSchoolNonSerializedAttribute
+        {
+            public int PublicField;
+
+            [NonSerialized]
+            public int IgnoredPublicField;
+        }
+
 #if !UNITY_2018_3_OR_NEWER
 
         [Fact]


### PR DESCRIPTION
MessagePack-CSharp is nice enough to simply skip serialization of properties and fields tagged with `[IgnoreDataMember]` and `[IgnoreMember]` without fuzz, which seems appropriate.

Since .NET also contains the `[NonSerialized]` attribute, which I believe is the oldest "dear serializer, please ignore this field"-type of serializer hint, it seems natural to also ignore these. This will in turn make migration from the old `BinaryFormatter` (which is deprecated and no longer exists in .NET 9) much easier, because `[NonSerialized]` was how it was told to skip specific fields.

This PR adds an extra case to the `CreateEmittableMember` method of `DynamicObjectResolver`, which causes fields decorated with `[NonSerialized]` to be ignored. It's backed up by an additional test `Serialize_WithNonSerializedAttribute` in `DataContractTest`.