### PR TITLE
Merge master and dependency updates into develop

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,9 +4,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-
     <BenchmarkDotNetVersion>0.13.12</BenchmarkDotNetVersion>
-
     <!-- https://learn.microsoft.com/en-us/visualstudio/extensibility/roslyn-version-support?view=vs-2022 -->
     <MicrosoftCodeAnalysisVersion>4.8.0</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisVersion Condition="'$(IsAnalyzerProject)'=='true'">4.3.0</MicrosoftCodeAnalysisVersion>
@@ -24,7 +22,6 @@
     <PackageVersion Include="Jil" version="2.17.0" />
     <PackageVersion Include="MessagePack" Version="2.1.90" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="$(MicrosoftCodeAnalysisTestingVersion)" />
@@ -52,16 +49,7 @@
     <PackageVersion Include="ReactiveProperty" Version="9.5.0" />
     <PackageVersion Include="Required" Version="1.0.0" />
     <PackageVersion Include="Sigil" version="5.0.0" />
-    <PackageVersion Include="SpanJson" Version="4.0.1" />
-    <PackageVersion Include="System.CodeDom" Version="8.0.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
-    <PackageVersion Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-    <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
-    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="6.0.0" />
-    <PackageVersion Include="System.Text.Encodings.Web" Version="6.0.0" />
-    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
+    <PackageVersion Include="SpanJson" Version="4.0.0" />
     <PackageVersion Include="Utf8Json" Version="1.3.7" />
     <PackageVersion Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageVersion Include="xunit.runner.console" Version="2.7.0" />
@@ -70,13 +58,27 @@
     <PackageVersion Include="xunit" Version="2.7.0" />
     <PackageVersion Include="ZeroFormatter" Version="1.6.4" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net472'">
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageVersion Include="System.CodeDom" Version="6.0.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageVersion Include="System.Memory" Version="4.5.5" />
+    <PackageVersion Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
+    <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="6.0.0" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="6.0.0" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </ItemGroup>
   <ItemGroup Condition="'$(IsAnalyzerProject)'=='true'">
-    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageVersion Update="System.Collections.Immutable" Version="6.0.0" />
-    <PackageVersion Update="System.Memory" Version="4.5.5" />
-    <PackageVersion Update="System.Reflection.Metadata" Version="6.0.0" />
-    <PackageVersion Update="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageVersion Update="System.Text.Json" Version="6.0.0" />
+    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageVersion Update="System.Collections.Immutable" Version="7.0.0" />
+    <PackageVersion Update="System.Reflection.Metadata" Version="7.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(NonShipping)'=='true'">
+    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageVersion Update="System.Collections.Immutable" Version="7.0.0" />
+    <PackageVersion Update="System.Reflection.Metadata" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.495" />

--- a/benchmark/SerializerBenchmark/SerializerBenchmark.csproj
+++ b/benchmark/SerializerBenchmark/SerializerBenchmark.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="MsgPack.Cli" />
     <PackageReference Include="protobuf-net" />
     <PackageReference Include="SpanJson" />
-    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="Utf8Json" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Newtonsoft.Json.Bson" />

--- a/sandbox/Directory.Build.props
+++ b/sandbox/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
   <PropertyGroup>
+    <NonShipping>true</NonShipping>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
 </Project>

--- a/sandbox/MessagePack.Internal/MessagePack.Internal.csproj
+++ b/sandbox/MessagePack.Internal/MessagePack.Internal.csproj
@@ -16,10 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\BufferWriter.cs" />
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\ExtensionHeader.cs" />
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\ExtensionResult.cs" />

--- a/sandbox/TestData2/TestData2.csproj
+++ b/sandbox/TestData2/TestData2.csproj
@@ -5,8 +5,6 @@
   <ItemGroup>
     <PackageReference Include="MessagePack" />
     <PackageReference Include="IsExternalInit" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" />
-    <PackageReference Include="System.ValueTuple" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="System.Collections.Generic" />

--- a/src/MessagePack.Analyzers/MessagePack.Analyzers.csproj
+++ b/src/MessagePack.Analyzers/MessagePack.Analyzers.csproj
@@ -12,6 +12,7 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IncludeSymbols>false</IncludeSymbols>
     <DevelopmentDependency>true</DevelopmentDependency>
+    <IsAnalyzerProject>true</IsAnalyzerProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/DictionaryFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/DictionaryFormatter.cs
@@ -78,24 +78,26 @@ namespace MessagePack.Formatters
             }
             else
             {
-                IFormatterResolver resolver = options.Resolver;
-                IMessagePackFormatter<TKey>? keyFormatter = resolver.GetFormatterWithVerify<TKey>();
-                IMessagePackFormatter<TValue>? valueFormatter = resolver.GetFormatterWithVerify<TValue>();
-
                 var len = reader.ReadMapHeader();
 
                 TIntermediate dict = this.Create(len, options);
                 options.Security.DepthStep(ref reader);
                 try
                 {
-                    for (int i = 0; i < len; i++)
+                    if (len > 0)
                     {
-                        reader.CancellationToken.ThrowIfCancellationRequested();
-                        TKey key = keyFormatter.Deserialize(ref reader, options);
+                        IFormatterResolver resolver = options.Resolver;
+                        IMessagePackFormatter<TKey>? keyFormatter = resolver.GetFormatterWithVerify<TKey>();
+                        IMessagePackFormatter<TValue>? valueFormatter = resolver.GetFormatterWithVerify<TValue>();
+                        for (int i = 0; i < len; i++)
+                        {
+                            reader.CancellationToken.ThrowIfCancellationRequested();
+                            TKey key = keyFormatter.Deserialize(ref reader, options);
 
-                        TValue value = valueFormatter.Deserialize(ref reader, options);
+                            TValue value = valueFormatter.Deserialize(ref reader, options);
 
-                        this.Add(dict, i, key, value, options);
+                            this.Add(dict, i, key, value, options);
+                        }
                     }
                 }
                 finally

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/DynamicAssembly.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/DynamicAssembly.cs
@@ -42,7 +42,7 @@ namespace MessagePack.Internal
 
 #if NETFRAMEWORK
 
-        public AssemblyBuilder Save()
+        internal AssemblyBuilder Save()
         {
             this.assemblyBuilder.Save(this.moduleName + ".dll");
             return this.assemblyBuilder;

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicEnumResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicEnumResolver.cs
@@ -39,7 +39,7 @@ namespace MessagePack.Resolvers
         }
 
 #if NETFRAMEWORK
-        public AssemblyBuilder Save()
+        internal AssemblyBuilder Save()
         {
             return DynamicAssembly.Value.Save();
         }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -52,7 +52,7 @@ namespace MessagePack.Resolvers
         }
 
 #if NETFRAMEWORK
-        public AssemblyBuilder Save()
+        internal AssemblyBuilder Save()
         {
             return DynamicAssembly.Value.Save();
         }
@@ -193,7 +193,7 @@ namespace MessagePack.Resolvers
         }
 
 #if NETFRAMEWORK
-        public AssemblyBuilder Save()
+        internal AssemblyBuilder Save()
         {
             return DynamicAssembly.Value.Save();
         }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1766,7 +1766,7 @@ namespace MessagePack.Internal
 
             EmittableMember? CreateEmittableMember(MemberInfo m)
             {
-                if (m.IsDefined(typeof(IgnoreMemberAttribute), true) || m.IsDefined(typeof(IgnoreDataMemberAttribute), true))
+                if (m.IsDefined(typeof(IgnoreMemberAttribute), true) || m.IsDefined(typeof(IgnoreDataMemberAttribute), true) || m.IsDefined(typeof(NonSerializedAttribute), true))
                 {
                     return null;
                 }
@@ -2019,19 +2019,6 @@ namespace MessagePack.Internal
 
                             if (len != 0)
                             {
-                                if (len != 1)
-                                {
-                                    if (ctorEnumerator != null)
-                                    {
-                                        ctor = null;
-                                        break;
-                                    }
-                                    else
-                                    {
-                                        throw new MessagePackDynamicObjectResolverException("duplicate matched constructor parameter name:" + type.FullName + " parameterName:" + item.Name + " parameterType:" + item.ParameterType.Name);
-                                    }
-                                }
-
                                 paramMember = hasKey.First().Value;
                                 if (item.ParameterType.IsAssignableFrom(paramMember.Type) && paramMember.IsReadable)
                                 {

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicUnionResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicUnionResolver.cs
@@ -58,7 +58,7 @@ namespace MessagePack.Resolvers
         }
 
 #if NETFRAMEWORK
-        public AssemblyBuilder Save()
+        internal AssemblyBuilder Save()
         {
             return DynamicAssembly.Value.Save();
         }

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DataContractTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DataContractTest.cs
@@ -195,6 +195,33 @@ namespace MessagePack.Tests
             public bool Equals(Detail other) => other != null && this.B1 == other.B1 && this.B2 == other.B2;
         }
 
+        [Fact]
+        public void Serialize_WithNonSerializedAttribute()
+        {
+            var mc = new ClassWithOldSchoolNonSerializedAttribute
+            {
+                PublicField = 1,
+                IgnoredPublicField = 2,
+            };
+
+            var options = ContractlessStandardResolverAllowPrivate.Options;
+            var bin = MessagePackSerializer.Serialize(mc, options);
+            var mc2 = MessagePackSerializer.Deserialize<ClassWithOldSchoolNonSerializedAttribute>(bin, options);
+
+            mc2.PublicField.Is(1);
+            mc2.IgnoredPublicField.Is(0);
+
+            MessagePackSerializer.ConvertToJson(bin).Is(@"{""PublicField"":1}");
+        }
+
+        public class ClassWithOldSchoolNonSerializedAttribute
+        {
+            public int PublicField;
+
+            [NonSerialized]
+            public int IgnoredPublicField;
+        }
+
 #if !UNITY_2018_3_OR_NEWER
 
         [Fact]

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DictionaryTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DictionaryTest.cs
@@ -53,12 +53,14 @@ namespace MessagePack.Tests
         public void ConcurrentDictionaryTest()
         {
             var cd = new ConcurrentDictionary<int, int>();
+            ConcurrentDictionary<int, int> conv = this.Convert(cd);
+            conv.Count.Is(0);
 
             cd.TryAdd(1, 100);
             cd.TryAdd(2, 200);
             cd.TryAdd(3, 300);
 
-            ConcurrentDictionary<int, int> conv = this.Convert(cd);
+            conv = this.Convert(cd);
             conv[1].Is(100);
             conv[2].Is(200);
             conv[3].Is(300);

--- a/src/MessagePack/MessagePack.csproj
+++ b/src/MessagePack/MessagePack.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net472</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0649</NoWarn>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <DefineConstants Condition=" '$(TargetFramework)' != 'netstandard2.0' ">$(DefineConstants);SPAN_BUILTIN</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net8.0' ">$(DefineConstants);SPAN_BUILTIN</DefineConstants>
     <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
     <LangVersion>9.0</LangVersion>
 
@@ -41,6 +41,10 @@
     <PackageReference Include="System.Reflection.Emit" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MessagePack/net472/PublicAPI.Shipped.txt
+++ b/src/MessagePack/net472/PublicAPI.Shipped.txt
@@ -1,0 +1,1185 @@
+#nullable enable
+MessagePack.ExtensionHeader
+MessagePack.ExtensionHeader.ExtensionHeader(sbyte typeCode, int length) -> void
+MessagePack.ExtensionHeader.ExtensionHeader(sbyte typeCode, uint length) -> void
+MessagePack.ExtensionHeader.Length.get -> uint
+MessagePack.ExtensionHeader.TypeCode.get -> sbyte
+MessagePack.ExtensionResult
+MessagePack.ExtensionResult.Data.get -> System.Buffers.ReadOnlySequence<byte>
+MessagePack.ExtensionResult.ExtensionResult(sbyte typeCode, System.Buffers.ReadOnlySequence<byte> data) -> void
+MessagePack.ExtensionResult.ExtensionResult(sbyte typeCode, System.Memory<byte> data) -> void
+MessagePack.ExtensionResult.Header.get -> MessagePack.ExtensionHeader
+MessagePack.ExtensionResult.TypeCode.get -> sbyte
+MessagePack.FormatterNotRegisteredException
+MessagePack.FormatterNotRegisteredException.FormatterNotRegisteredException(string? message) -> void
+MessagePack.FormatterResolverExtensions
+MessagePack.Formatters.ArrayFormatter<T>
+MessagePack.Formatters.ArrayFormatter<T>.ArrayFormatter() -> void
+MessagePack.Formatters.ArrayFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T[]?
+MessagePack.Formatters.ArrayFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ArraySegmentFormatter<T>
+MessagePack.Formatters.ArraySegmentFormatter<T>.ArraySegmentFormatter() -> void
+MessagePack.Formatters.ArraySegmentFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.ArraySegment<T>
+MessagePack.Formatters.ArraySegmentFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, System.ArraySegment<T> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.BigIntegerFormatter
+MessagePack.Formatters.BigIntegerFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Numerics.BigInteger
+MessagePack.Formatters.BigIntegerFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Numerics.BigInteger value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.BitArrayFormatter
+MessagePack.Formatters.BitArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Collections.BitArray?
+MessagePack.Formatters.BitArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Collections.BitArray? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.BooleanArrayFormatter
+MessagePack.Formatters.BooleanArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> bool[]?
+MessagePack.Formatters.BooleanArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, bool[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.BooleanFormatter
+MessagePack.Formatters.BooleanFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> bool
+MessagePack.Formatters.BooleanFormatter.Serialize(ref MessagePack.MessagePackWriter writer, bool value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ByteArrayFormatter
+MessagePack.Formatters.ByteArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> byte[]?
+MessagePack.Formatters.ByteArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, byte[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ByteArraySegmentFormatter
+MessagePack.Formatters.ByteArraySegmentFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.ArraySegment<byte>
+MessagePack.Formatters.ByteArraySegmentFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.ArraySegment<byte> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ByteFormatter
+MessagePack.Formatters.ByteFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> byte
+MessagePack.Formatters.ByteFormatter.Serialize(ref MessagePack.MessagePackWriter writer, byte value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.CharArrayFormatter
+MessagePack.Formatters.CharArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> char[]?
+MessagePack.Formatters.CharArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, char[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.CharFormatter
+MessagePack.Formatters.CharFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> char
+MessagePack.Formatters.CharFormatter.Serialize(ref MessagePack.MessagePackWriter writer, char value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.CollectionFormatterBase<TElement, TCollection>
+MessagePack.Formatters.CollectionFormatterBase<TElement, TCollection>.CollectionFormatterBase() -> void
+MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TCollection>
+MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TCollection>.CollectionFormatterBase() -> void
+MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TEnumerator, TCollection>
+MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TEnumerator, TCollection>.CollectionFormatterBase() -> void
+MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TEnumerator, TCollection>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> TCollection?
+MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TEnumerator, TCollection>.Serialize(ref MessagePack.MessagePackWriter writer, TCollection? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ComplexFormatter
+MessagePack.Formatters.ComplexFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Numerics.Complex
+MessagePack.Formatters.ComplexFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Numerics.Complex value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ConcurrentBagFormatter<T>
+MessagePack.Formatters.ConcurrentBagFormatter<T>.ConcurrentBagFormatter() -> void
+MessagePack.Formatters.ConcurrentDictionaryFormatter<TKey, TValue>
+MessagePack.Formatters.ConcurrentDictionaryFormatter<TKey, TValue>.ConcurrentDictionaryFormatter() -> void
+MessagePack.Formatters.ConcurrentQueueFormatter<T>
+MessagePack.Formatters.ConcurrentQueueFormatter<T>.ConcurrentQueueFormatter() -> void
+MessagePack.Formatters.ConcurrentStackFormatter<T>
+MessagePack.Formatters.ConcurrentStackFormatter<T>.ConcurrentStackFormatter() -> void
+MessagePack.Formatters.DateTimeArrayFormatter
+MessagePack.Formatters.DateTimeArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.DateTime[]?
+MessagePack.Formatters.DateTimeArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.DateTime[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.DateTimeFormatter
+MessagePack.Formatters.DateTimeFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.DateTime
+MessagePack.Formatters.DateTimeFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.DateTime value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.DateTimeOffsetFormatter
+MessagePack.Formatters.DateTimeOffsetFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.DateTimeOffset
+MessagePack.Formatters.DateTimeOffsetFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.DateTimeOffset value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.DecimalFormatter
+MessagePack.Formatters.DecimalFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> decimal
+MessagePack.Formatters.DecimalFormatter.Serialize(ref MessagePack.MessagePackWriter writer, decimal value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.DictionaryFormatter<TKey, TValue>
+MessagePack.Formatters.DictionaryFormatter<TKey, TValue>.DictionaryFormatter() -> void
+MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TDictionary>
+MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TDictionary>.DictionaryFormatterBase() -> void
+MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TDictionary>
+MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TDictionary>.DictionaryFormatterBase() -> void
+MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TEnumerator, TDictionary>
+MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TEnumerator, TDictionary>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> TDictionary?
+MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TEnumerator, TDictionary>.DictionaryFormatterBase() -> void
+MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TEnumerator, TDictionary>.Serialize(ref MessagePack.MessagePackWriter writer, TDictionary? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.DoubleArrayFormatter
+MessagePack.Formatters.DoubleArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> double[]?
+MessagePack.Formatters.DoubleArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, double[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.DoubleFormatter
+MessagePack.Formatters.DoubleFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> double
+MessagePack.Formatters.DoubleFormatter.Serialize(ref MessagePack.MessagePackWriter writer, double value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.DynamicObjectTypeFallbackFormatter
+MessagePack.Formatters.DynamicObjectTypeFallbackFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> object?
+MessagePack.Formatters.DynamicObjectTypeFallbackFormatter.Serialize(ref MessagePack.MessagePackWriter writer, object? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.EnumAsStringFormatter<T>
+MessagePack.Formatters.EnumAsStringFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T
+MessagePack.Formatters.EnumAsStringFormatter<T>.EnumAsStringFormatter() -> void
+MessagePack.Formatters.EnumAsStringFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceByteBlockFormatter
+MessagePack.Formatters.ForceByteBlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> byte
+MessagePack.Formatters.ForceByteBlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, byte value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceInt16BlockArrayFormatter
+MessagePack.Formatters.ForceInt16BlockArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> short[]?
+MessagePack.Formatters.ForceInt16BlockArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, short[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceInt16BlockFormatter
+MessagePack.Formatters.ForceInt16BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> short
+MessagePack.Formatters.ForceInt16BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, short value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceInt32BlockArrayFormatter
+MessagePack.Formatters.ForceInt32BlockArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> int[]?
+MessagePack.Formatters.ForceInt32BlockArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, int[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceInt32BlockFormatter
+MessagePack.Formatters.ForceInt32BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> int
+MessagePack.Formatters.ForceInt32BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, int value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceInt64BlockArrayFormatter
+MessagePack.Formatters.ForceInt64BlockArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> long[]?
+MessagePack.Formatters.ForceInt64BlockArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, long[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceInt64BlockFormatter
+MessagePack.Formatters.ForceInt64BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> long
+MessagePack.Formatters.ForceInt64BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, long value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceSByteBlockArrayFormatter
+MessagePack.Formatters.ForceSByteBlockArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> sbyte[]?
+MessagePack.Formatters.ForceSByteBlockArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, sbyte[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceSByteBlockFormatter
+MessagePack.Formatters.ForceSByteBlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> sbyte
+MessagePack.Formatters.ForceSByteBlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, sbyte value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceUInt16BlockArrayFormatter
+MessagePack.Formatters.ForceUInt16BlockArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ushort[]?
+MessagePack.Formatters.ForceUInt16BlockArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, ushort[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceUInt16BlockFormatter
+MessagePack.Formatters.ForceUInt16BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ushort
+MessagePack.Formatters.ForceUInt16BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, ushort value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceUInt32BlockArrayFormatter
+MessagePack.Formatters.ForceUInt32BlockArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> uint[]?
+MessagePack.Formatters.ForceUInt32BlockArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, uint[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceUInt32BlockFormatter
+MessagePack.Formatters.ForceUInt32BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> uint
+MessagePack.Formatters.ForceUInt32BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, uint value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceUInt64BlockArrayFormatter
+MessagePack.Formatters.ForceUInt64BlockArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ulong[]?
+MessagePack.Formatters.ForceUInt64BlockArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, ulong[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceUInt64BlockFormatter
+MessagePack.Formatters.ForceUInt64BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ulong
+MessagePack.Formatters.ForceUInt64BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, ulong value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.FourDimensionalArrayFormatter<T>
+MessagePack.Formatters.FourDimensionalArrayFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T[,,,]?
+MessagePack.Formatters.FourDimensionalArrayFormatter<T>.FourDimensionalArrayFormatter() -> void
+MessagePack.Formatters.FourDimensionalArrayFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T[,,,]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.GenericCollectionFormatter<TElement, TCollection>
+MessagePack.Formatters.GenericCollectionFormatter<TElement, TCollection>.GenericCollectionFormatter() -> void
+MessagePack.Formatters.GenericDictionaryFormatter<TKey, TValue, TDictionary>
+MessagePack.Formatters.GenericDictionaryFormatter<TKey, TValue, TDictionary>.GenericDictionaryFormatter() -> void
+MessagePack.Formatters.GenericEnumFormatter<T>
+MessagePack.Formatters.GenericEnumFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T
+MessagePack.Formatters.GenericEnumFormatter<T>.GenericEnumFormatter() -> void
+MessagePack.Formatters.GenericEnumFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.GuidFormatter
+MessagePack.Formatters.GuidFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Guid
+MessagePack.Formatters.GuidFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Guid value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.HashSetFormatter<T>
+MessagePack.Formatters.HashSetFormatter<T>.HashSetFormatter() -> void
+MessagePack.Formatters.IMessagePackFormatter
+MessagePack.Formatters.IMessagePackFormatter<T>
+MessagePack.Formatters.IMessagePackFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T
+MessagePack.Formatters.IMessagePackFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.IgnoreFormatter<T>
+MessagePack.Formatters.IgnoreFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T?
+MessagePack.Formatters.IgnoreFormatter<T>.IgnoreFormatter() -> void
+MessagePack.Formatters.IgnoreFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.Int16ArrayFormatter
+MessagePack.Formatters.Int16ArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> short[]?
+MessagePack.Formatters.Int16ArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, short[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.Int16Formatter
+MessagePack.Formatters.Int16Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> short
+MessagePack.Formatters.Int16Formatter.Serialize(ref MessagePack.MessagePackWriter writer, short value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.Int32ArrayFormatter
+MessagePack.Formatters.Int32ArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> int[]?
+MessagePack.Formatters.Int32ArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, int[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.Int32Formatter
+MessagePack.Formatters.Int32Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> int
+MessagePack.Formatters.Int32Formatter.Serialize(ref MessagePack.MessagePackWriter writer, int value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.Int64ArrayFormatter
+MessagePack.Formatters.Int64ArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> long[]?
+MessagePack.Formatters.Int64ArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, long[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.Int64Formatter
+MessagePack.Formatters.Int64Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> long
+MessagePack.Formatters.Int64Formatter.Serialize(ref MessagePack.MessagePackWriter writer, long value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.InterfaceCollectionFormatter<T>
+MessagePack.Formatters.InterfaceCollectionFormatter<T>.InterfaceCollectionFormatter() -> void
+MessagePack.Formatters.InterfaceDictionaryFormatter<TKey, TValue>
+MessagePack.Formatters.InterfaceDictionaryFormatter<TKey, TValue>.InterfaceDictionaryFormatter() -> void
+MessagePack.Formatters.InterfaceEnumerableFormatter<T>
+MessagePack.Formatters.InterfaceEnumerableFormatter<T>.InterfaceEnumerableFormatter() -> void
+MessagePack.Formatters.InterfaceGroupingFormatter<TKey, TElement>
+MessagePack.Formatters.InterfaceGroupingFormatter<TKey, TElement>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Linq.IGrouping<TKey, TElement>?
+MessagePack.Formatters.InterfaceGroupingFormatter<TKey, TElement>.InterfaceGroupingFormatter() -> void
+MessagePack.Formatters.InterfaceGroupingFormatter<TKey, TElement>.Serialize(ref MessagePack.MessagePackWriter writer, System.Linq.IGrouping<TKey, TElement>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.InterfaceListFormatter<T>
+MessagePack.Formatters.InterfaceListFormatter<T>.InterfaceListFormatter() -> void
+MessagePack.Formatters.InterfaceLookupFormatter<TKey, TElement>
+MessagePack.Formatters.InterfaceLookupFormatter<TKey, TElement>.InterfaceLookupFormatter() -> void
+MessagePack.Formatters.InterfaceReadOnlyCollectionFormatter<T>
+MessagePack.Formatters.InterfaceReadOnlyCollectionFormatter<T>.InterfaceReadOnlyCollectionFormatter() -> void
+MessagePack.Formatters.InterfaceReadOnlyDictionaryFormatter<TKey, TValue>
+MessagePack.Formatters.InterfaceReadOnlyDictionaryFormatter<TKey, TValue>.InterfaceReadOnlyDictionaryFormatter() -> void
+MessagePack.Formatters.InterfaceReadOnlyListFormatter<T>
+MessagePack.Formatters.InterfaceReadOnlyListFormatter<T>.InterfaceReadOnlyListFormatter() -> void
+MessagePack.Formatters.InterfaceSetFormatter<T>
+MessagePack.Formatters.InterfaceSetFormatter<T>.InterfaceSetFormatter() -> void
+MessagePack.Formatters.KeyValuePairFormatter<TKey, TValue>
+MessagePack.Formatters.KeyValuePairFormatter<TKey, TValue>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Collections.Generic.KeyValuePair<TKey, TValue>
+MessagePack.Formatters.KeyValuePairFormatter<TKey, TValue>.KeyValuePairFormatter() -> void
+MessagePack.Formatters.KeyValuePairFormatter<TKey, TValue>.Serialize(ref MessagePack.MessagePackWriter writer, System.Collections.Generic.KeyValuePair<TKey, TValue> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.LazyFormatter<T>
+MessagePack.Formatters.LazyFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Lazy<T>?
+MessagePack.Formatters.LazyFormatter<T>.LazyFormatter() -> void
+MessagePack.Formatters.LazyFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, System.Lazy<T>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.LinkedListFormatter<T>
+MessagePack.Formatters.LinkedListFormatter<T>.LinkedListFormatter() -> void
+MessagePack.Formatters.ListFormatter<T>
+MessagePack.Formatters.ListFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Collections.Generic.List<T>?
+MessagePack.Formatters.ListFormatter<T>.ListFormatter() -> void
+MessagePack.Formatters.ListFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, System.Collections.Generic.List<T>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NativeDateTimeArrayFormatter
+MessagePack.Formatters.NativeDateTimeArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.DateTime[]?
+MessagePack.Formatters.NativeDateTimeArrayFormatter.NativeDateTimeArrayFormatter() -> void
+MessagePack.Formatters.NativeDateTimeArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.DateTime[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NativeDateTimeFormatter
+MessagePack.Formatters.NativeDateTimeFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.DateTime
+MessagePack.Formatters.NativeDateTimeFormatter.NativeDateTimeFormatter() -> void
+MessagePack.Formatters.NativeDateTimeFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.DateTime value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NativeDecimalFormatter
+MessagePack.Formatters.NativeDecimalFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> decimal
+MessagePack.Formatters.NativeDecimalFormatter.Serialize(ref MessagePack.MessagePackWriter writer, decimal value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NativeGuidFormatter
+MessagePack.Formatters.NativeGuidFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Guid
+MessagePack.Formatters.NativeGuidFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Guid value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NilFormatter
+MessagePack.Formatters.NilFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> MessagePack.Nil
+MessagePack.Formatters.NilFormatter.Serialize(ref MessagePack.MessagePackWriter writer, MessagePack.Nil value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NonGenericDictionaryFormatter<T>
+MessagePack.Formatters.NonGenericDictionaryFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T?
+MessagePack.Formatters.NonGenericDictionaryFormatter<T>.NonGenericDictionaryFormatter() -> void
+MessagePack.Formatters.NonGenericDictionaryFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NonGenericInterfaceDictionaryFormatter
+MessagePack.Formatters.NonGenericInterfaceDictionaryFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Collections.IDictionary?
+MessagePack.Formatters.NonGenericInterfaceDictionaryFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Collections.IDictionary? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NonGenericInterfaceListFormatter
+MessagePack.Formatters.NonGenericInterfaceListFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Collections.IList?
+MessagePack.Formatters.NonGenericInterfaceListFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Collections.IList? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NonGenericListFormatter<T>
+MessagePack.Formatters.NonGenericListFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T?
+MessagePack.Formatters.NonGenericListFormatter<T>.NonGenericListFormatter() -> void
+MessagePack.Formatters.NonGenericListFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableBooleanFormatter
+MessagePack.Formatters.NullableBooleanFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> bool?
+MessagePack.Formatters.NullableBooleanFormatter.Serialize(ref MessagePack.MessagePackWriter writer, bool? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableByteFormatter
+MessagePack.Formatters.NullableByteFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> byte?
+MessagePack.Formatters.NullableByteFormatter.Serialize(ref MessagePack.MessagePackWriter writer, byte? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableCharFormatter
+MessagePack.Formatters.NullableCharFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> char?
+MessagePack.Formatters.NullableCharFormatter.Serialize(ref MessagePack.MessagePackWriter writer, char? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableDateTimeFormatter
+MessagePack.Formatters.NullableDateTimeFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.DateTime?
+MessagePack.Formatters.NullableDateTimeFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.DateTime? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableDoubleFormatter
+MessagePack.Formatters.NullableDoubleFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> double?
+MessagePack.Formatters.NullableDoubleFormatter.Serialize(ref MessagePack.MessagePackWriter writer, double? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableForceByteBlockFormatter
+MessagePack.Formatters.NullableForceByteBlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> byte?
+MessagePack.Formatters.NullableForceByteBlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, byte? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableForceInt16BlockFormatter
+MessagePack.Formatters.NullableForceInt16BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> short?
+MessagePack.Formatters.NullableForceInt16BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, short? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableForceInt32BlockFormatter
+MessagePack.Formatters.NullableForceInt32BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> int?
+MessagePack.Formatters.NullableForceInt32BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, int? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableForceInt64BlockFormatter
+MessagePack.Formatters.NullableForceInt64BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> long?
+MessagePack.Formatters.NullableForceInt64BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, long? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableForceSByteBlockFormatter
+MessagePack.Formatters.NullableForceSByteBlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> sbyte?
+MessagePack.Formatters.NullableForceSByteBlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, sbyte? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableForceUInt16BlockFormatter
+MessagePack.Formatters.NullableForceUInt16BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ushort?
+MessagePack.Formatters.NullableForceUInt16BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, ushort? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableForceUInt32BlockFormatter
+MessagePack.Formatters.NullableForceUInt32BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> uint?
+MessagePack.Formatters.NullableForceUInt32BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, uint? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableForceUInt64BlockFormatter
+MessagePack.Formatters.NullableForceUInt64BlockFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ulong?
+MessagePack.Formatters.NullableForceUInt64BlockFormatter.Serialize(ref MessagePack.MessagePackWriter writer, ulong? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableFormatter<T>
+MessagePack.Formatters.NullableFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T?
+MessagePack.Formatters.NullableFormatter<T>.NullableFormatter() -> void
+MessagePack.Formatters.NullableFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableInt16Formatter
+MessagePack.Formatters.NullableInt16Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> short?
+MessagePack.Formatters.NullableInt16Formatter.Serialize(ref MessagePack.MessagePackWriter writer, short? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableInt32Formatter
+MessagePack.Formatters.NullableInt32Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> int?
+MessagePack.Formatters.NullableInt32Formatter.Serialize(ref MessagePack.MessagePackWriter writer, int? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableInt64Formatter
+MessagePack.Formatters.NullableInt64Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> long?
+MessagePack.Formatters.NullableInt64Formatter.Serialize(ref MessagePack.MessagePackWriter writer, long? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableNilFormatter
+MessagePack.Formatters.NullableNilFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> MessagePack.Nil?
+MessagePack.Formatters.NullableNilFormatter.Serialize(ref MessagePack.MessagePackWriter writer, MessagePack.Nil? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableSByteFormatter
+MessagePack.Formatters.NullableSByteFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> sbyte?
+MessagePack.Formatters.NullableSByteFormatter.Serialize(ref MessagePack.MessagePackWriter writer, sbyte? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableSingleFormatter
+MessagePack.Formatters.NullableSingleFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> float?
+MessagePack.Formatters.NullableSingleFormatter.Serialize(ref MessagePack.MessagePackWriter writer, float? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableStringArrayFormatter
+MessagePack.Formatters.NullableStringArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> string?[]?
+MessagePack.Formatters.NullableStringArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, string?[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableStringFormatter
+MessagePack.Formatters.NullableStringFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> string?
+MessagePack.Formatters.NullableStringFormatter.Serialize(ref MessagePack.MessagePackWriter writer, string? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableUInt16Formatter
+MessagePack.Formatters.NullableUInt16Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ushort?
+MessagePack.Formatters.NullableUInt16Formatter.Serialize(ref MessagePack.MessagePackWriter writer, ushort? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableUInt32Formatter
+MessagePack.Formatters.NullableUInt32Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> uint?
+MessagePack.Formatters.NullableUInt32Formatter.Serialize(ref MessagePack.MessagePackWriter writer, uint? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NullableUInt64Formatter
+MessagePack.Formatters.NullableUInt64Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ulong?
+MessagePack.Formatters.NullableUInt64Formatter.Serialize(ref MessagePack.MessagePackWriter writer, ulong? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ObservableCollectionFormatter<T>
+MessagePack.Formatters.ObservableCollectionFormatter<T>.ObservableCollectionFormatter() -> void
+MessagePack.Formatters.PrimitiveObjectFormatter
+MessagePack.Formatters.PrimitiveObjectFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> object?
+MessagePack.Formatters.PrimitiveObjectFormatter.Serialize(ref MessagePack.MessagePackWriter writer, object? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.QueueFormatter<T>
+MessagePack.Formatters.QueueFormatter<T>.QueueFormatter() -> void
+MessagePack.Formatters.ReadOnlyCollectionFormatter<T>
+MessagePack.Formatters.ReadOnlyCollectionFormatter<T>.ReadOnlyCollectionFormatter() -> void
+MessagePack.Formatters.ReadOnlyDictionaryFormatter<TKey, TValue>
+MessagePack.Formatters.ReadOnlyDictionaryFormatter<TKey, TValue>.ReadOnlyDictionaryFormatter() -> void
+MessagePack.Formatters.ReadOnlyObservableCollectionFormatter<T>
+MessagePack.Formatters.ReadOnlyObservableCollectionFormatter<T>.ReadOnlyObservableCollectionFormatter() -> void
+MessagePack.Formatters.SByteArrayFormatter
+MessagePack.Formatters.SByteArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> sbyte[]?
+MessagePack.Formatters.SByteArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, sbyte[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.SByteFormatter
+MessagePack.Formatters.SByteFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> sbyte
+MessagePack.Formatters.SByteFormatter.Serialize(ref MessagePack.MessagePackWriter writer, sbyte value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.SingleArrayFormatter
+MessagePack.Formatters.SingleArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> float[]?
+MessagePack.Formatters.SingleArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, float[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.SingleFormatter
+MessagePack.Formatters.SingleFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> float
+MessagePack.Formatters.SingleFormatter.Serialize(ref MessagePack.MessagePackWriter writer, float value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.SortedDictionaryFormatter<TKey, TValue>
+MessagePack.Formatters.SortedDictionaryFormatter<TKey, TValue>.SortedDictionaryFormatter() -> void
+MessagePack.Formatters.SortedListFormatter<TKey, TValue>
+MessagePack.Formatters.SortedListFormatter<TKey, TValue>.SortedListFormatter() -> void
+MessagePack.Formatters.StackFormatter<T>
+MessagePack.Formatters.StackFormatter<T>.StackFormatter() -> void
+MessagePack.Formatters.StaticNullableFormatter<T>
+MessagePack.Formatters.StaticNullableFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T?
+MessagePack.Formatters.StaticNullableFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.StaticNullableFormatter<T>.StaticNullableFormatter(MessagePack.Formatters.IMessagePackFormatter<T>! underlyingFormatter) -> void
+MessagePack.Formatters.StringBuilderFormatter
+MessagePack.Formatters.StringBuilderFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Text.StringBuilder?
+MessagePack.Formatters.StringBuilderFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Text.StringBuilder? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ThreeDimensionalArrayFormatter<T>
+MessagePack.Formatters.ThreeDimensionalArrayFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T[,,]?
+MessagePack.Formatters.ThreeDimensionalArrayFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T[,,]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ThreeDimensionalArrayFormatter<T>.ThreeDimensionalArrayFormatter() -> void
+MessagePack.Formatters.TimeSpanFormatter
+MessagePack.Formatters.TimeSpanFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.TimeSpan
+MessagePack.Formatters.TimeSpanFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.TimeSpan value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest>
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Tuple<T1, T2, T3, T4, T5, T6, T7, TRest>?
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest>.Serialize(ref MessagePack.MessagePackWriter writer, System.Tuple<T1, T2, T3, T4, T5, T6, T7, TRest>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest>.TupleFormatter() -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6, T7>
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6, T7>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Tuple<T1, T2, T3, T4, T5, T6, T7>?
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6, T7>.Serialize(ref MessagePack.MessagePackWriter writer, System.Tuple<T1, T2, T3, T4, T5, T6, T7>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6, T7>.TupleFormatter() -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6>
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Tuple<T1, T2, T3, T4, T5, T6>?
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6>.Serialize(ref MessagePack.MessagePackWriter writer, System.Tuple<T1, T2, T3, T4, T5, T6>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5, T6>.TupleFormatter() -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5>
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Tuple<T1, T2, T3, T4, T5>?
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5>.Serialize(ref MessagePack.MessagePackWriter writer, System.Tuple<T1, T2, T3, T4, T5>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4, T5>.TupleFormatter() -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4>
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Tuple<T1, T2, T3, T4>?
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4>.Serialize(ref MessagePack.MessagePackWriter writer, System.Tuple<T1, T2, T3, T4>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3, T4>.TupleFormatter() -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3>
+MessagePack.Formatters.TupleFormatter<T1, T2, T3>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Tuple<T1, T2, T3>?
+MessagePack.Formatters.TupleFormatter<T1, T2, T3>.Serialize(ref MessagePack.MessagePackWriter writer, System.Tuple<T1, T2, T3>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TupleFormatter<T1, T2, T3>.TupleFormatter() -> void
+MessagePack.Formatters.TupleFormatter<T1, T2>
+MessagePack.Formatters.TupleFormatter<T1, T2>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Tuple<T1, T2>?
+MessagePack.Formatters.TupleFormatter<T1, T2>.Serialize(ref MessagePack.MessagePackWriter writer, System.Tuple<T1, T2>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TupleFormatter<T1, T2>.TupleFormatter() -> void
+MessagePack.Formatters.TupleFormatter<T1>
+MessagePack.Formatters.TupleFormatter<T1>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Tuple<T1>?
+MessagePack.Formatters.TupleFormatter<T1>.Serialize(ref MessagePack.MessagePackWriter writer, System.Tuple<T1>? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TupleFormatter<T1>.TupleFormatter() -> void
+MessagePack.Formatters.TwoDimensionalArrayFormatter<T>
+MessagePack.Formatters.TwoDimensionalArrayFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T[,]?
+MessagePack.Formatters.TwoDimensionalArrayFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T[,]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TwoDimensionalArrayFormatter<T>.TwoDimensionalArrayFormatter() -> void
+MessagePack.Formatters.TypelessFormatter
+MessagePack.Formatters.TypelessFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> object?
+MessagePack.Formatters.TypelessFormatter.Serialize(ref MessagePack.MessagePackWriter writer, object? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.UInt16ArrayFormatter
+MessagePack.Formatters.UInt16ArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ushort[]?
+MessagePack.Formatters.UInt16ArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, ushort[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.UInt16Formatter
+MessagePack.Formatters.UInt16Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ushort
+MessagePack.Formatters.UInt16Formatter.Serialize(ref MessagePack.MessagePackWriter writer, ushort value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.UInt32ArrayFormatter
+MessagePack.Formatters.UInt32ArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> uint[]?
+MessagePack.Formatters.UInt32ArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, uint[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.UInt32Formatter
+MessagePack.Formatters.UInt32Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> uint
+MessagePack.Formatters.UInt32Formatter.Serialize(ref MessagePack.MessagePackWriter writer, uint value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.UInt64ArrayFormatter
+MessagePack.Formatters.UInt64ArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ulong[]?
+MessagePack.Formatters.UInt64ArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, ulong[]? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.UInt64Formatter
+MessagePack.Formatters.UInt64Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> ulong
+MessagePack.Formatters.UInt64Formatter.Serialize(ref MessagePack.MessagePackWriter writer, ulong value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.UriFormatter
+MessagePack.Formatters.UriFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Uri?
+MessagePack.Formatters.UriFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Uri? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest>
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest>.Serialize(ref MessagePack.MessagePackWriter writer, System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest>.ValueTupleFormatter() -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7>
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> (T1, T2, T3, T4, T5, T6, T7)
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7>.Serialize(ref MessagePack.MessagePackWriter writer, (T1, T2, T3, T4, T5, T6, T7) value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7>.ValueTupleFormatter() -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6>
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> (T1, T2, T3, T4, T5, T6)
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6>.Serialize(ref MessagePack.MessagePackWriter writer, (T1, T2, T3, T4, T5, T6) value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5, T6>.ValueTupleFormatter() -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5>
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> (T1, T2, T3, T4, T5)
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5>.Serialize(ref MessagePack.MessagePackWriter writer, (T1, T2, T3, T4, T5) value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4, T5>.ValueTupleFormatter() -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4>
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> (T1, T2, T3, T4)
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4>.Serialize(ref MessagePack.MessagePackWriter writer, (T1, T2, T3, T4) value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3, T4>.ValueTupleFormatter() -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3>
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> (T1, T2, T3)
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3>.Serialize(ref MessagePack.MessagePackWriter writer, (T1, T2, T3) value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2, T3>.ValueTupleFormatter() -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2>
+MessagePack.Formatters.ValueTupleFormatter<T1, T2>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> (T1, T2)
+MessagePack.Formatters.ValueTupleFormatter<T1, T2>.Serialize(ref MessagePack.MessagePackWriter writer, (T1, T2) value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ValueTupleFormatter<T1, T2>.ValueTupleFormatter() -> void
+MessagePack.Formatters.ValueTupleFormatter<T1>
+MessagePack.Formatters.ValueTupleFormatter<T1>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.ValueTuple<T1>
+MessagePack.Formatters.ValueTupleFormatter<T1>.Serialize(ref MessagePack.MessagePackWriter writer, System.ValueTuple<T1> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ValueTupleFormatter<T1>.ValueTupleFormatter() -> void
+MessagePack.Formatters.VersionFormatter
+MessagePack.Formatters.VersionFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Version?
+MessagePack.Formatters.VersionFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Version? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.IFormatterResolver
+MessagePack.IFormatterResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Internal.AutomataDictionary
+MessagePack.Internal.AutomataDictionary.Add(string! str, int value) -> void
+MessagePack.Internal.AutomataDictionary.AutomataDictionary() -> void
+MessagePack.Internal.AutomataDictionary.EmitMatch(System.Reflection.Emit.ILGenerator! il, System.Reflection.Emit.LocalBuilder! bytesSpan, System.Reflection.Emit.LocalBuilder! key, System.Action<System.Collections.Generic.KeyValuePair<string?, int>>! onFound, System.Action! onNotFound) -> void
+MessagePack.Internal.AutomataDictionary.GetEnumerator() -> System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string?, int>>!
+MessagePack.Internal.AutomataDictionary.TryGetValue(System.ReadOnlySpan<byte> bytes, out int value) -> bool
+MessagePack.Internal.AutomataDictionary.TryGetValue(in System.Buffers.ReadOnlySequence<byte> bytes, out int value) -> bool
+MessagePack.Internal.AutomataKeyGen
+MessagePack.Internal.ByteArrayStringHashTable
+MessagePack.Internal.ByteArrayStringHashTable.Add(byte[]! key, int value) -> void
+MessagePack.Internal.ByteArrayStringHashTable.Add(string! key, int value) -> void
+MessagePack.Internal.ByteArrayStringHashTable.ByteArrayStringHashTable(int capacity) -> void
+MessagePack.Internal.ByteArrayStringHashTable.ByteArrayStringHashTable(int capacity, float loadFactor) -> void
+MessagePack.Internal.ByteArrayStringHashTable.GetEnumerator() -> System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string!, int>>!
+MessagePack.Internal.ByteArrayStringHashTable.TryGetValue(System.ReadOnlySpan<byte> key, out int value) -> bool
+MessagePack.Internal.ByteArrayStringHashTable.TryGetValue(in System.Buffers.ReadOnlySequence<byte> key, out int value) -> bool
+MessagePack.Internal.CodeGenHelpers
+MessagePack.Internal.RuntimeTypeHandleEqualityComparer
+MessagePack.Internal.RuntimeTypeHandleEqualityComparer.Equals(System.RuntimeTypeHandle x, System.RuntimeTypeHandle y) -> bool
+MessagePack.Internal.RuntimeTypeHandleEqualityComparer.GetHashCode(System.RuntimeTypeHandle obj) -> int
+MessagePack.Internal.UnsafeMemory
+MessagePack.Internal.UnsafeMemory32
+MessagePack.Internal.UnsafeMemory64
+MessagePack.MessagePackCode
+MessagePack.MessagePackCompression
+MessagePack.MessagePackCompression.Lz4Block = 1 -> MessagePack.MessagePackCompression
+MessagePack.MessagePackCompression.Lz4BlockArray = 2 -> MessagePack.MessagePackCompression
+MessagePack.MessagePackCompression.None = 0 -> MessagePack.MessagePackCompression
+MessagePack.MessagePackRange
+MessagePack.MessagePackReader
+MessagePack.MessagePackReader.CancellationToken.get -> System.Threading.CancellationToken
+MessagePack.MessagePackReader.CancellationToken.set -> void
+MessagePack.MessagePackReader.Clone(in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> MessagePack.MessagePackReader
+MessagePack.MessagePackReader.Consumed.get -> long
+MessagePack.MessagePackReader.CreatePeekReader() -> MessagePack.MessagePackReader
+MessagePack.MessagePackReader.End.get -> bool
+MessagePack.MessagePackReader.IsNil.get -> bool
+MessagePack.MessagePackReader.MessagePackReader(System.ReadOnlyMemory<byte> memory) -> void
+MessagePack.MessagePackReader.MessagePackReader(in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> void
+MessagePack.MessagePackReader.NextCode.get -> byte
+MessagePack.MessagePackReader.NextMessagePackType.get -> MessagePack.MessagePackType
+MessagePack.MessagePackReader.Position.get -> System.SequencePosition
+MessagePack.MessagePackReader.ReadArrayHeader() -> int
+MessagePack.MessagePackReader.ReadBoolean() -> bool
+MessagePack.MessagePackReader.ReadByte() -> byte
+MessagePack.MessagePackReader.ReadBytes() -> System.Buffers.ReadOnlySequence<byte>?
+MessagePack.MessagePackReader.ReadChar() -> char
+MessagePack.MessagePackReader.ReadDateTime() -> System.DateTime
+MessagePack.MessagePackReader.ReadDouble() -> double
+MessagePack.MessagePackReader.ReadExtensionFormat() -> MessagePack.ExtensionResult
+MessagePack.MessagePackReader.ReadExtensionFormatHeader() -> MessagePack.ExtensionHeader
+MessagePack.MessagePackReader.ReadInt16() -> short
+MessagePack.MessagePackReader.ReadInt32() -> int
+MessagePack.MessagePackReader.ReadInt64() -> long
+MessagePack.MessagePackReader.ReadMapHeader() -> int
+MessagePack.MessagePackReader.ReadNil() -> MessagePack.Nil
+MessagePack.MessagePackReader.ReadRaw() -> System.Buffers.ReadOnlySequence<byte>
+MessagePack.MessagePackReader.ReadRaw(long length) -> System.Buffers.ReadOnlySequence<byte>
+MessagePack.MessagePackReader.ReadSByte() -> sbyte
+MessagePack.MessagePackReader.ReadSingle() -> float
+MessagePack.MessagePackReader.ReadString() -> string?
+MessagePack.MessagePackReader.ReadStringSequence() -> System.Buffers.ReadOnlySequence<byte>?
+MessagePack.MessagePackReader.ReadUInt16() -> ushort
+MessagePack.MessagePackReader.ReadUInt32() -> uint
+MessagePack.MessagePackReader.ReadUInt64() -> ulong
+MessagePack.MessagePackReader.Sequence.get -> System.Buffers.ReadOnlySequence<byte>
+MessagePack.MessagePackReader.Skip() -> void
+MessagePack.MessagePackReader.TryReadNil() -> bool
+MessagePack.MessagePackReader.TryReadStringSpan(out System.ReadOnlySpan<byte> span) -> bool
+MessagePack.MessagePackSerializationException
+MessagePack.MessagePackSerializationException.MessagePackSerializationException() -> void
+MessagePack.MessagePackSerializationException.MessagePackSerializationException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+MessagePack.MessagePackSerializationException.MessagePackSerializationException(string? message) -> void
+MessagePack.MessagePackSerializationException.MessagePackSerializationException(string? message, System.Exception? inner) -> void
+MessagePack.MessagePackSerializer
+MessagePack.MessagePackSerializer.Typeless
+MessagePack.MessagePackSerializerOptions
+MessagePack.MessagePackSerializerOptions.AllowAssemblyVersionMismatch.get -> bool
+MessagePack.MessagePackSerializerOptions.Compression.get -> MessagePack.MessagePackCompression
+MessagePack.MessagePackSerializerOptions.MessagePackSerializerOptions(MessagePack.IFormatterResolver! resolver) -> void
+MessagePack.MessagePackSerializerOptions.MessagePackSerializerOptions(MessagePack.MessagePackSerializerOptions! copyFrom) -> void
+MessagePack.MessagePackSerializerOptions.OldSpec.get -> bool?
+MessagePack.MessagePackSerializerOptions.OmitAssemblyVersion.get -> bool
+MessagePack.MessagePackSerializerOptions.Resolver.get -> MessagePack.IFormatterResolver!
+MessagePack.MessagePackSerializerOptions.WithAllowAssemblyVersionMismatch(bool allowAssemblyVersionMismatch) -> MessagePack.MessagePackSerializerOptions!
+MessagePack.MessagePackSerializerOptions.WithCompression(MessagePack.MessagePackCompression compression) -> MessagePack.MessagePackSerializerOptions!
+MessagePack.MessagePackSerializerOptions.WithOldSpec(bool? oldSpec = true) -> MessagePack.MessagePackSerializerOptions!
+MessagePack.MessagePackSerializerOptions.WithOmitAssemblyVersion(bool omitAssemblyVersion) -> MessagePack.MessagePackSerializerOptions!
+MessagePack.MessagePackSerializerOptions.WithResolver(MessagePack.IFormatterResolver! resolver) -> MessagePack.MessagePackSerializerOptions!
+MessagePack.MessagePackStreamReader
+MessagePack.MessagePackStreamReader.Dispose() -> void
+MessagePack.MessagePackStreamReader.MessagePackStreamReader(System.IO.Stream! stream) -> void
+MessagePack.MessagePackStreamReader.ReadAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Buffers.ReadOnlySequence<byte>?>
+MessagePack.MessagePackStreamReader.RemainingBytes.get -> System.Buffers.ReadOnlySequence<byte>
+MessagePack.MessagePackType
+MessagePack.MessagePackType.Array = 7 -> MessagePack.MessagePackType
+MessagePack.MessagePackType.Binary = 6 -> MessagePack.MessagePackType
+MessagePack.MessagePackType.Boolean = 3 -> MessagePack.MessagePackType
+MessagePack.MessagePackType.Extension = 9 -> MessagePack.MessagePackType
+MessagePack.MessagePackType.Float = 4 -> MessagePack.MessagePackType
+MessagePack.MessagePackType.Integer = 1 -> MessagePack.MessagePackType
+MessagePack.MessagePackType.Map = 8 -> MessagePack.MessagePackType
+MessagePack.MessagePackType.Nil = 2 -> MessagePack.MessagePackType
+MessagePack.MessagePackType.String = 5 -> MessagePack.MessagePackType
+MessagePack.MessagePackType.Unknown = 0 -> MessagePack.MessagePackType
+MessagePack.MessagePackWriter
+MessagePack.MessagePackWriter.Advance(int length) -> void
+MessagePack.MessagePackWriter.CancellationToken.get -> System.Threading.CancellationToken
+MessagePack.MessagePackWriter.CancellationToken.set -> void
+MessagePack.MessagePackWriter.Clone(System.Buffers.IBufferWriter<byte>! writer) -> MessagePack.MessagePackWriter
+MessagePack.MessagePackWriter.Flush() -> void
+MessagePack.MessagePackWriter.GetSpan(int length) -> System.Span<byte>
+MessagePack.MessagePackWriter.MessagePackWriter(System.Buffers.IBufferWriter<byte>! writer) -> void
+MessagePack.MessagePackWriter.OldSpec.get -> bool
+MessagePack.MessagePackWriter.OldSpec.set -> void
+MessagePack.MessagePackWriter.Write(System.DateTime dateTime) -> void
+MessagePack.MessagePackWriter.Write(System.ReadOnlySpan<byte> src) -> void
+MessagePack.MessagePackWriter.Write(System.ReadOnlySpan<char> value) -> void
+MessagePack.MessagePackWriter.Write(bool value) -> void
+MessagePack.MessagePackWriter.Write(byte value) -> void
+MessagePack.MessagePackWriter.Write(byte[]? src) -> void
+MessagePack.MessagePackWriter.Write(char value) -> void
+MessagePack.MessagePackWriter.Write(double value) -> void
+MessagePack.MessagePackWriter.Write(float value) -> void
+MessagePack.MessagePackWriter.Write(in System.Buffers.ReadOnlySequence<byte> src) -> void
+MessagePack.MessagePackWriter.Write(int value) -> void
+MessagePack.MessagePackWriter.Write(long value) -> void
+MessagePack.MessagePackWriter.Write(sbyte value) -> void
+MessagePack.MessagePackWriter.Write(short value) -> void
+MessagePack.MessagePackWriter.Write(string? value) -> void
+MessagePack.MessagePackWriter.Write(uint value) -> void
+MessagePack.MessagePackWriter.Write(ulong value) -> void
+MessagePack.MessagePackWriter.Write(ushort value) -> void
+MessagePack.MessagePackWriter.WriteArrayHeader(int count) -> void
+MessagePack.MessagePackWriter.WriteArrayHeader(uint count) -> void
+MessagePack.MessagePackWriter.WriteExtensionFormat(MessagePack.ExtensionResult extensionData) -> void
+MessagePack.MessagePackWriter.WriteExtensionFormatHeader(MessagePack.ExtensionHeader extensionHeader) -> void
+MessagePack.MessagePackWriter.WriteInt16(short value) -> void
+MessagePack.MessagePackWriter.WriteInt32(int value) -> void
+MessagePack.MessagePackWriter.WriteInt64(long value) -> void
+MessagePack.MessagePackWriter.WriteInt8(sbyte value) -> void
+MessagePack.MessagePackWriter.WriteMapHeader(int count) -> void
+MessagePack.MessagePackWriter.WriteMapHeader(uint count) -> void
+MessagePack.MessagePackWriter.WriteNil() -> void
+MessagePack.MessagePackWriter.WriteRaw(System.ReadOnlySpan<byte> rawMessagePackBlock) -> void
+MessagePack.MessagePackWriter.WriteRaw(in System.Buffers.ReadOnlySequence<byte> rawMessagePackBlock) -> void
+MessagePack.MessagePackWriter.WriteString(System.ReadOnlySpan<byte> utf8stringBytes) -> void
+MessagePack.MessagePackWriter.WriteString(in System.Buffers.ReadOnlySequence<byte> utf8stringBytes) -> void
+MessagePack.MessagePackWriter.WriteUInt16(ushort value) -> void
+MessagePack.MessagePackWriter.WriteUInt32(uint value) -> void
+MessagePack.MessagePackWriter.WriteUInt64(ulong value) -> void
+MessagePack.MessagePackWriter.WriteUInt8(byte value) -> void
+MessagePack.Nil
+MessagePack.Nil.Equals(MessagePack.Nil other) -> bool
+MessagePack.Nil.Nil() -> void
+MessagePack.ReservedMessagePackExtensionTypeCode
+MessagePack.Resolvers.AttributeFormatterResolver
+MessagePack.Resolvers.AttributeFormatterResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.BuiltinResolver
+MessagePack.Resolvers.BuiltinResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.CompositeResolver
+MessagePack.Resolvers.ContractlessStandardResolver
+MessagePack.Resolvers.ContractlessStandardResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.ContractlessStandardResolverAllowPrivate
+MessagePack.Resolvers.ContractlessStandardResolverAllowPrivate.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.DynamicContractlessObjectResolver
+MessagePack.Resolvers.DynamicContractlessObjectResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.DynamicContractlessObjectResolverAllowPrivate
+MessagePack.Resolvers.DynamicContractlessObjectResolverAllowPrivate.DynamicContractlessObjectResolverAllowPrivate() -> void
+MessagePack.Resolvers.DynamicContractlessObjectResolverAllowPrivate.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.DynamicEnumAsStringResolver
+MessagePack.Resolvers.DynamicEnumAsStringResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.DynamicEnumResolver
+MessagePack.Resolvers.DynamicEnumResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.DynamicGenericResolver
+MessagePack.Resolvers.DynamicGenericResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.DynamicObjectResolver
+MessagePack.Resolvers.DynamicObjectResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.DynamicObjectResolverAllowPrivate
+MessagePack.Resolvers.DynamicObjectResolverAllowPrivate.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.DynamicUnionResolver
+MessagePack.Resolvers.DynamicUnionResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.NativeDateTimeResolver
+MessagePack.Resolvers.NativeDateTimeResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.NativeDecimalResolver
+MessagePack.Resolvers.NativeDecimalResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.NativeGuidResolver
+MessagePack.Resolvers.NativeGuidResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.PrimitiveObjectResolver
+MessagePack.Resolvers.PrimitiveObjectResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.StandardResolver
+MessagePack.Resolvers.StandardResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.StandardResolverAllowPrivate
+MessagePack.Resolvers.StandardResolverAllowPrivate.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.StaticCompositeResolver
+MessagePack.Resolvers.StaticCompositeResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.StaticCompositeResolver.Register(System.Collections.Generic.IReadOnlyList<MessagePack.Formatters.IMessagePackFormatter!>! formatters, System.Collections.Generic.IReadOnlyList<MessagePack.IFormatterResolver!>! resolvers) -> void
+MessagePack.Resolvers.StaticCompositeResolver.Register(params MessagePack.Formatters.IMessagePackFormatter![]! formatters) -> void
+MessagePack.Resolvers.StaticCompositeResolver.Register(params MessagePack.IFormatterResolver![]! resolvers) -> void
+MessagePack.Resolvers.TypelessContractlessStandardResolver
+MessagePack.Resolvers.TypelessContractlessStandardResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.Resolvers.TypelessContractlessStandardResolver.TypelessContractlessStandardResolver() -> void
+MessagePack.Resolvers.TypelessObjectResolver
+MessagePack.Resolvers.TypelessObjectResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.TinyJsonException
+MessagePack.TinyJsonException.TinyJsonException(string! message) -> void
+abstract MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TEnumerator, TCollection>.Add(TIntermediate collection, int index, TElement value, MessagePack.MessagePackSerializerOptions! options) -> void
+abstract MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TEnumerator, TCollection>.Complete(TIntermediate intermediateCollection) -> TCollection
+abstract MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TEnumerator, TCollection>.Create(int count, MessagePack.MessagePackSerializerOptions! options) -> TIntermediate
+abstract MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TEnumerator, TCollection>.GetSourceEnumerator(TCollection source) -> TEnumerator
+abstract MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TEnumerator, TDictionary>.Add(TIntermediate collection, int index, TKey key, TValue value, MessagePack.MessagePackSerializerOptions! options) -> void
+abstract MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TEnumerator, TDictionary>.Complete(TIntermediate intermediateCollection) -> TDictionary!
+abstract MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TEnumerator, TDictionary>.Create(int count, MessagePack.MessagePackSerializerOptions! options) -> TIntermediate
+abstract MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TEnumerator, TDictionary>.GetSourceEnumerator(TDictionary! source) -> TEnumerator
+const MessagePack.MessagePackCode.Array16 = 220 -> byte
+const MessagePack.MessagePackCode.Array32 = 221 -> byte
+const MessagePack.MessagePackCode.Bin16 = 197 -> byte
+const MessagePack.MessagePackCode.Bin32 = 198 -> byte
+const MessagePack.MessagePackCode.Bin8 = 196 -> byte
+const MessagePack.MessagePackCode.Ext16 = 200 -> byte
+const MessagePack.MessagePackCode.Ext32 = 201 -> byte
+const MessagePack.MessagePackCode.Ext8 = 199 -> byte
+const MessagePack.MessagePackCode.False = 194 -> byte
+const MessagePack.MessagePackCode.FixExt1 = 212 -> byte
+const MessagePack.MessagePackCode.FixExt16 = 216 -> byte
+const MessagePack.MessagePackCode.FixExt2 = 213 -> byte
+const MessagePack.MessagePackCode.FixExt4 = 214 -> byte
+const MessagePack.MessagePackCode.FixExt8 = 215 -> byte
+const MessagePack.MessagePackCode.Float32 = 202 -> byte
+const MessagePack.MessagePackCode.Float64 = 203 -> byte
+const MessagePack.MessagePackCode.Int16 = 209 -> byte
+const MessagePack.MessagePackCode.Int32 = 210 -> byte
+const MessagePack.MessagePackCode.Int64 = 211 -> byte
+const MessagePack.MessagePackCode.Int8 = 208 -> byte
+const MessagePack.MessagePackCode.Map16 = 222 -> byte
+const MessagePack.MessagePackCode.Map32 = 223 -> byte
+const MessagePack.MessagePackCode.MaxFixArray = 159 -> byte
+const MessagePack.MessagePackCode.MaxFixInt = 127 -> byte
+const MessagePack.MessagePackCode.MaxFixMap = 143 -> byte
+const MessagePack.MessagePackCode.MaxFixStr = 191 -> byte
+const MessagePack.MessagePackCode.MaxNegativeFixInt = 255 -> byte
+const MessagePack.MessagePackCode.MinFixArray = 144 -> byte
+const MessagePack.MessagePackCode.MinFixInt = 0 -> byte
+const MessagePack.MessagePackCode.MinFixMap = 128 -> byte
+const MessagePack.MessagePackCode.MinFixStr = 160 -> byte
+const MessagePack.MessagePackCode.MinNegativeFixInt = 224 -> byte
+const MessagePack.MessagePackCode.NeverUsed = 193 -> byte
+const MessagePack.MessagePackCode.Nil = 192 -> byte
+const MessagePack.MessagePackCode.Str16 = 218 -> byte
+const MessagePack.MessagePackCode.Str32 = 219 -> byte
+const MessagePack.MessagePackCode.Str8 = 217 -> byte
+const MessagePack.MessagePackCode.True = 195 -> byte
+const MessagePack.MessagePackCode.UInt16 = 205 -> byte
+const MessagePack.MessagePackCode.UInt32 = 206 -> byte
+const MessagePack.MessagePackCode.UInt64 = 207 -> byte
+const MessagePack.MessagePackCode.UInt8 = 204 -> byte
+const MessagePack.MessagePackRange.MaxFixArrayCount = 15 -> int
+const MessagePack.MessagePackRange.MaxFixMapCount = 15 -> int
+const MessagePack.MessagePackRange.MaxFixNegativeInt = -1 -> int
+const MessagePack.MessagePackRange.MaxFixPositiveInt = 127 -> int
+const MessagePack.MessagePackRange.MaxFixStringLength = 31 -> int
+const MessagePack.MessagePackRange.MinFixNegativeInt = -32 -> int
+const MessagePack.MessagePackRange.MinFixStringLength = 0 -> int
+const MessagePack.ReservedMessagePackExtensionTypeCode.DateTime = -1 -> sbyte
+override MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TCollection>.GetSourceEnumerator(TCollection source) -> System.Collections.Generic.IEnumerator<TElement>!
+override MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TDictionary>.Complete(TDictionary! intermediateCollection) -> TDictionary!
+override MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TDictionary>.GetSourceEnumerator(TDictionary! source) -> System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>!
+override MessagePack.Internal.AutomataDictionary.ToString() -> string!
+override MessagePack.Nil.Equals(object? obj) -> bool
+override MessagePack.Nil.GetHashCode() -> int
+override MessagePack.Nil.ToString() -> string!
+override sealed MessagePack.Formatters.CollectionFormatterBase<TElement, TCollection>.Complete(TCollection intermediateCollection) -> TCollection
+static MessagePack.FormatterResolverExtensions.GetFormatterDynamic(this MessagePack.IFormatterResolver! resolver, System.Type! type) -> object?
+static MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<T>(this MessagePack.IFormatterResolver! resolver) -> MessagePack.Formatters.IMessagePackFormatter<T>!
+static MessagePack.Formatters.PrimitiveObjectFormatter.IsSupportedType(System.Type! type, System.Reflection.TypeInfo! typeInfo, object! value) -> bool
+static MessagePack.Internal.AutomataKeyGen.GetKey(ref System.ReadOnlySpan<byte> span) -> ulong
+static MessagePack.Internal.CodeGenHelpers.GetArrayFromNullableSequence(in System.Buffers.ReadOnlySequence<byte>? sequence) -> byte[]?
+static MessagePack.Internal.CodeGenHelpers.GetEncodedStringBytes(string! value) -> byte[]!
+static MessagePack.Internal.CodeGenHelpers.GetSpanFromSequence(in System.Buffers.ReadOnlySequence<byte> sequence) -> System.ReadOnlySpan<byte>
+static MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref MessagePack.MessagePackReader reader) -> System.ReadOnlySpan<byte>
+static MessagePack.Internal.UnsafeMemory32.WriteRaw1(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw10(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw11(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw12(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw13(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw14(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw15(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw16(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw17(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw18(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw19(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw2(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw20(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw21(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw22(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw23(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw24(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw25(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw26(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw27(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw28(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw29(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw3(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw30(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw31(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw4(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw5(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw6(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw7(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw8(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory32.WriteRaw9(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw1(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw10(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw11(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw12(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw13(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw14(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw15(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw16(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw17(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw18(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw19(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw2(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw20(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw21(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw22(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw23(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw24(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw25(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw26(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw27(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw28(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw29(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw3(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw30(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw31(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw4(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw5(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw6(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw7(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw8(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.Internal.UnsafeMemory64.WriteRaw9(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
+static MessagePack.MessagePackCode.ToFormatName(byte code) -> string!
+static MessagePack.MessagePackCode.ToMessagePackType(byte code) -> MessagePack.MessagePackType
+static MessagePack.MessagePackSerializer.ConvertFromJson(System.IO.TextReader! reader, ref MessagePack.MessagePackWriter writer, MessagePack.MessagePackSerializerOptions? options = null) -> void
+static MessagePack.MessagePackSerializer.ConvertFromJson(string! str, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> byte[]!
+static MessagePack.MessagePackSerializer.ConvertFromJson(string! str, ref MessagePack.MessagePackWriter writer, MessagePack.MessagePackSerializerOptions? options = null) -> void
+static MessagePack.MessagePackSerializer.ConvertToJson(System.ReadOnlyMemory<byte> bytes, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> string!
+static MessagePack.MessagePackSerializer.ConvertToJson(in System.Buffers.ReadOnlySequence<byte> bytes, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> string!
+static MessagePack.MessagePackSerializer.ConvertToJson(ref MessagePack.MessagePackReader reader, System.IO.TextWriter! jsonWriter, MessagePack.MessagePackSerializerOptions? options = null) -> void
+static MessagePack.MessagePackSerializer.DefaultOptions.get -> MessagePack.MessagePackSerializerOptions!
+static MessagePack.MessagePackSerializer.DefaultOptions.set -> void
+static MessagePack.MessagePackSerializer.Deserialize(System.Type! type, System.Buffers.ReadOnlySequence<byte> bytes, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> object?
+static MessagePack.MessagePackSerializer.Deserialize(System.Type! type, System.IO.Stream! stream, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> object?
+static MessagePack.MessagePackSerializer.Deserialize(System.Type! type, System.ReadOnlyMemory<byte> bytes, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> object?
+static MessagePack.MessagePackSerializer.Deserialize(System.Type! type, ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions? options = null) -> object?
+static MessagePack.MessagePackSerializer.Deserialize<T>(System.IO.Stream! stream, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
+static MessagePack.MessagePackSerializer.Deserialize<T>(System.ReadOnlyMemory<byte> buffer, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
+static MessagePack.MessagePackSerializer.Deserialize<T>(System.ReadOnlyMemory<byte> buffer, MessagePack.MessagePackSerializerOptions? options, out int bytesRead, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
+static MessagePack.MessagePackSerializer.Deserialize<T>(System.ReadOnlyMemory<byte> buffer, out int bytesRead, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
+static MessagePack.MessagePackSerializer.Deserialize<T>(in System.Buffers.ReadOnlySequence<byte> byteSequence, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
+static MessagePack.MessagePackSerializer.Deserialize<T>(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions? options = null) -> T
+static MessagePack.MessagePackSerializer.DeserializeAsync(System.Type! type, System.IO.Stream! stream, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<object?>
+static MessagePack.MessagePackSerializer.DeserializeAsync<T>(System.IO.Stream! stream, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T>
+static MessagePack.MessagePackSerializer.Serialize(System.Type! type, System.Buffers.IBufferWriter<byte>! writer, object? obj, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+static MessagePack.MessagePackSerializer.Serialize(System.Type! type, System.IO.Stream! stream, object? obj, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+static MessagePack.MessagePackSerializer.Serialize(System.Type! type, object? obj, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> byte[]!
+static MessagePack.MessagePackSerializer.Serialize(System.Type! type, ref MessagePack.MessagePackWriter writer, object? obj, MessagePack.MessagePackSerializerOptions? options = null) -> void
+static MessagePack.MessagePackSerializer.Serialize<T>(System.Buffers.IBufferWriter<byte>! writer, T value, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+static MessagePack.MessagePackSerializer.Serialize<T>(System.IO.Stream! stream, T value, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+static MessagePack.MessagePackSerializer.Serialize<T>(T value, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> byte[]!
+static MessagePack.MessagePackSerializer.Serialize<T>(ref MessagePack.MessagePackWriter writer, T value, MessagePack.MessagePackSerializerOptions? options = null) -> void
+static MessagePack.MessagePackSerializer.SerializeAsync(System.Type! type, System.IO.Stream! stream, object? obj, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static MessagePack.MessagePackSerializer.SerializeAsync<T>(System.IO.Stream! stream, T value, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static MessagePack.MessagePackSerializer.SerializeToJson<T>(System.IO.TextWriter! textWriter, T obj, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+static MessagePack.MessagePackSerializer.SerializeToJson<T>(T obj, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> string!
+static MessagePack.MessagePackSerializer.Typeless.DefaultOptions.get -> MessagePack.MessagePackSerializerOptions!
+static MessagePack.MessagePackSerializer.Typeless.DefaultOptions.set -> void
+static MessagePack.MessagePackSerializer.Typeless.Deserialize(System.IO.Stream! stream, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> object?
+static MessagePack.MessagePackSerializer.Typeless.Deserialize(System.Memory<byte> bytes, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> object?
+static MessagePack.MessagePackSerializer.Typeless.Deserialize(in System.Buffers.ReadOnlySequence<byte> byteSequence, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> object?
+static MessagePack.MessagePackSerializer.Typeless.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions? options = null) -> object?
+static MessagePack.MessagePackSerializer.Typeless.DeserializeAsync(System.IO.Stream! stream, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<object?>
+static MessagePack.MessagePackSerializer.Typeless.Serialize(System.Buffers.IBufferWriter<byte>! writer, object? obj, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+static MessagePack.MessagePackSerializer.Typeless.Serialize(System.IO.Stream! stream, object? obj, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+static MessagePack.MessagePackSerializer.Typeless.Serialize(object? obj, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> byte[]!
+static MessagePack.MessagePackSerializer.Typeless.Serialize(ref MessagePack.MessagePackWriter writer, object? obj, MessagePack.MessagePackSerializerOptions? options = null) -> void
+static MessagePack.MessagePackSerializer.Typeless.SerializeAsync(System.IO.Stream! stream, object? obj, MessagePack.MessagePackSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static MessagePack.MessagePackSerializerOptions.Standard.get -> MessagePack.MessagePackSerializerOptions!
+static MessagePack.Resolvers.CompositeResolver.Create(System.Collections.Generic.IReadOnlyList<MessagePack.Formatters.IMessagePackFormatter!>! formatters, System.Collections.Generic.IReadOnlyList<MessagePack.IFormatterResolver!>! resolvers) -> MessagePack.IFormatterResolver!
+static MessagePack.Resolvers.CompositeResolver.Create(params MessagePack.Formatters.IMessagePackFormatter![]! formatters) -> MessagePack.IFormatterResolver!
+static MessagePack.Resolvers.CompositeResolver.Create(params MessagePack.IFormatterResolver![]! resolvers) -> MessagePack.IFormatterResolver!
+static readonly MessagePack.Formatters.BigIntegerFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Numerics.BigInteger>!
+static readonly MessagePack.Formatters.BitArrayFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Collections.BitArray?>!
+static readonly MessagePack.Formatters.BooleanArrayFormatter.Instance -> MessagePack.Formatters.BooleanArrayFormatter!
+static readonly MessagePack.Formatters.BooleanFormatter.Instance -> MessagePack.Formatters.BooleanFormatter!
+static readonly MessagePack.Formatters.ByteArrayFormatter.Instance -> MessagePack.Formatters.ByteArrayFormatter!
+static readonly MessagePack.Formatters.ByteArraySegmentFormatter.Instance -> MessagePack.Formatters.ByteArraySegmentFormatter!
+static readonly MessagePack.Formatters.ByteFormatter.Instance -> MessagePack.Formatters.ByteFormatter!
+static readonly MessagePack.Formatters.CharArrayFormatter.Instance -> MessagePack.Formatters.CharArrayFormatter!
+static readonly MessagePack.Formatters.CharFormatter.Instance -> MessagePack.Formatters.CharFormatter!
+static readonly MessagePack.Formatters.ComplexFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Numerics.Complex>!
+static readonly MessagePack.Formatters.DateTimeArrayFormatter.Instance -> MessagePack.Formatters.DateTimeArrayFormatter!
+static readonly MessagePack.Formatters.DateTimeFormatter.Instance -> MessagePack.Formatters.DateTimeFormatter!
+static readonly MessagePack.Formatters.DateTimeOffsetFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.DateTimeOffset>!
+static readonly MessagePack.Formatters.DecimalFormatter.Instance -> MessagePack.Formatters.DecimalFormatter!
+static readonly MessagePack.Formatters.DoubleArrayFormatter.Instance -> MessagePack.Formatters.DoubleArrayFormatter!
+static readonly MessagePack.Formatters.DoubleFormatter.Instance -> MessagePack.Formatters.DoubleFormatter!
+static readonly MessagePack.Formatters.DynamicObjectTypeFallbackFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<object?>!
+static readonly MessagePack.Formatters.ForceByteBlockFormatter.Instance -> MessagePack.Formatters.ForceByteBlockFormatter!
+static readonly MessagePack.Formatters.ForceInt16BlockArrayFormatter.Instance -> MessagePack.Formatters.ForceInt16BlockArrayFormatter!
+static readonly MessagePack.Formatters.ForceInt16BlockFormatter.Instance -> MessagePack.Formatters.ForceInt16BlockFormatter!
+static readonly MessagePack.Formatters.ForceInt32BlockArrayFormatter.Instance -> MessagePack.Formatters.ForceInt32BlockArrayFormatter!
+static readonly MessagePack.Formatters.ForceInt32BlockFormatter.Instance -> MessagePack.Formatters.ForceInt32BlockFormatter!
+static readonly MessagePack.Formatters.ForceInt64BlockArrayFormatter.Instance -> MessagePack.Formatters.ForceInt64BlockArrayFormatter!
+static readonly MessagePack.Formatters.ForceInt64BlockFormatter.Instance -> MessagePack.Formatters.ForceInt64BlockFormatter!
+static readonly MessagePack.Formatters.ForceSByteBlockArrayFormatter.Instance -> MessagePack.Formatters.ForceSByteBlockArrayFormatter!
+static readonly MessagePack.Formatters.ForceSByteBlockFormatter.Instance -> MessagePack.Formatters.ForceSByteBlockFormatter!
+static readonly MessagePack.Formatters.ForceUInt16BlockArrayFormatter.Instance -> MessagePack.Formatters.ForceUInt16BlockArrayFormatter!
+static readonly MessagePack.Formatters.ForceUInt16BlockFormatter.Instance -> MessagePack.Formatters.ForceUInt16BlockFormatter!
+static readonly MessagePack.Formatters.ForceUInt32BlockArrayFormatter.Instance -> MessagePack.Formatters.ForceUInt32BlockArrayFormatter!
+static readonly MessagePack.Formatters.ForceUInt32BlockFormatter.Instance -> MessagePack.Formatters.ForceUInt32BlockFormatter!
+static readonly MessagePack.Formatters.ForceUInt64BlockArrayFormatter.Instance -> MessagePack.Formatters.ForceUInt64BlockArrayFormatter!
+static readonly MessagePack.Formatters.ForceUInt64BlockFormatter.Instance -> MessagePack.Formatters.ForceUInt64BlockFormatter!
+static readonly MessagePack.Formatters.GuidFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Guid>!
+static readonly MessagePack.Formatters.Int16ArrayFormatter.Instance -> MessagePack.Formatters.Int16ArrayFormatter!
+static readonly MessagePack.Formatters.Int16Formatter.Instance -> MessagePack.Formatters.Int16Formatter!
+static readonly MessagePack.Formatters.Int32ArrayFormatter.Instance -> MessagePack.Formatters.Int32ArrayFormatter!
+static readonly MessagePack.Formatters.Int32Formatter.Instance -> MessagePack.Formatters.Int32Formatter!
+static readonly MessagePack.Formatters.Int64ArrayFormatter.Instance -> MessagePack.Formatters.Int64ArrayFormatter!
+static readonly MessagePack.Formatters.Int64Formatter.Instance -> MessagePack.Formatters.Int64Formatter!
+static readonly MessagePack.Formatters.NativeDateTimeArrayFormatter.Instance -> MessagePack.Formatters.NativeDateTimeArrayFormatter!
+static readonly MessagePack.Formatters.NativeDateTimeFormatter.Instance -> MessagePack.Formatters.NativeDateTimeFormatter!
+static readonly MessagePack.Formatters.NativeDecimalFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<decimal>!
+static readonly MessagePack.Formatters.NativeGuidFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Guid>!
+static readonly MessagePack.Formatters.NilFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<MessagePack.Nil>!
+static readonly MessagePack.Formatters.NonGenericInterfaceDictionaryFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Collections.IDictionary?>!
+static readonly MessagePack.Formatters.NonGenericInterfaceListFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Collections.IList?>!
+static readonly MessagePack.Formatters.NullableBooleanFormatter.Instance -> MessagePack.Formatters.NullableBooleanFormatter!
+static readonly MessagePack.Formatters.NullableByteFormatter.Instance -> MessagePack.Formatters.NullableByteFormatter!
+static readonly MessagePack.Formatters.NullableCharFormatter.Instance -> MessagePack.Formatters.NullableCharFormatter!
+static readonly MessagePack.Formatters.NullableDateTimeFormatter.Instance -> MessagePack.Formatters.NullableDateTimeFormatter!
+static readonly MessagePack.Formatters.NullableDoubleFormatter.Instance -> MessagePack.Formatters.NullableDoubleFormatter!
+static readonly MessagePack.Formatters.NullableForceByteBlockFormatter.Instance -> MessagePack.Formatters.NullableForceByteBlockFormatter!
+static readonly MessagePack.Formatters.NullableForceInt16BlockFormatter.Instance -> MessagePack.Formatters.NullableForceInt16BlockFormatter!
+static readonly MessagePack.Formatters.NullableForceInt32BlockFormatter.Instance -> MessagePack.Formatters.NullableForceInt32BlockFormatter!
+static readonly MessagePack.Formatters.NullableForceInt64BlockFormatter.Instance -> MessagePack.Formatters.NullableForceInt64BlockFormatter!
+static readonly MessagePack.Formatters.NullableForceSByteBlockFormatter.Instance -> MessagePack.Formatters.NullableForceSByteBlockFormatter!
+static readonly MessagePack.Formatters.NullableForceUInt16BlockFormatter.Instance -> MessagePack.Formatters.NullableForceUInt16BlockFormatter!
+static readonly MessagePack.Formatters.NullableForceUInt32BlockFormatter.Instance -> MessagePack.Formatters.NullableForceUInt32BlockFormatter!
+static readonly MessagePack.Formatters.NullableForceUInt64BlockFormatter.Instance -> MessagePack.Formatters.NullableForceUInt64BlockFormatter!
+static readonly MessagePack.Formatters.NullableInt16Formatter.Instance -> MessagePack.Formatters.NullableInt16Formatter!
+static readonly MessagePack.Formatters.NullableInt32Formatter.Instance -> MessagePack.Formatters.NullableInt32Formatter!
+static readonly MessagePack.Formatters.NullableInt64Formatter.Instance -> MessagePack.Formatters.NullableInt64Formatter!
+static readonly MessagePack.Formatters.NullableNilFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<MessagePack.Nil?>!
+static readonly MessagePack.Formatters.NullableSByteFormatter.Instance -> MessagePack.Formatters.NullableSByteFormatter!
+static readonly MessagePack.Formatters.NullableSingleFormatter.Instance -> MessagePack.Formatters.NullableSingleFormatter!
+static readonly MessagePack.Formatters.NullableStringArrayFormatter.Instance -> MessagePack.Formatters.NullableStringArrayFormatter!
+static readonly MessagePack.Formatters.NullableStringFormatter.Instance -> MessagePack.Formatters.NullableStringFormatter!
+static readonly MessagePack.Formatters.NullableUInt16Formatter.Instance -> MessagePack.Formatters.NullableUInt16Formatter!
+static readonly MessagePack.Formatters.NullableUInt32Formatter.Instance -> MessagePack.Formatters.NullableUInt32Formatter!
+static readonly MessagePack.Formatters.NullableUInt64Formatter.Instance -> MessagePack.Formatters.NullableUInt64Formatter!
+static readonly MessagePack.Formatters.PrimitiveObjectFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<object?>!
+static readonly MessagePack.Formatters.SByteArrayFormatter.Instance -> MessagePack.Formatters.SByteArrayFormatter!
+static readonly MessagePack.Formatters.SByteFormatter.Instance -> MessagePack.Formatters.SByteFormatter!
+static readonly MessagePack.Formatters.SingleArrayFormatter.Instance -> MessagePack.Formatters.SingleArrayFormatter!
+static readonly MessagePack.Formatters.SingleFormatter.Instance -> MessagePack.Formatters.SingleFormatter!
+static readonly MessagePack.Formatters.StringBuilderFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Text.StringBuilder?>!
+static readonly MessagePack.Formatters.TimeSpanFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.TimeSpan>!
+static readonly MessagePack.Formatters.TypelessFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<object?>!
+static readonly MessagePack.Formatters.UInt16ArrayFormatter.Instance -> MessagePack.Formatters.UInt16ArrayFormatter!
+static readonly MessagePack.Formatters.UInt16Formatter.Instance -> MessagePack.Formatters.UInt16Formatter!
+static readonly MessagePack.Formatters.UInt32ArrayFormatter.Instance -> MessagePack.Formatters.UInt32ArrayFormatter!
+static readonly MessagePack.Formatters.UInt32Formatter.Instance -> MessagePack.Formatters.UInt32Formatter!
+static readonly MessagePack.Formatters.UInt64ArrayFormatter.Instance -> MessagePack.Formatters.UInt64ArrayFormatter!
+static readonly MessagePack.Formatters.UInt64Formatter.Instance -> MessagePack.Formatters.UInt64Formatter!
+static readonly MessagePack.Formatters.UriFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Uri?>!
+static readonly MessagePack.Formatters.VersionFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Version?>!
+static readonly MessagePack.Internal.AutomataKeyGen.GetKeyMethod -> System.Reflection.MethodInfo!
+static readonly MessagePack.Internal.RuntimeTypeHandleEqualityComparer.Default -> System.Collections.Generic.IEqualityComparer<System.RuntimeTypeHandle>!
+static readonly MessagePack.Internal.UnsafeMemory.Is32Bit -> bool
+static readonly MessagePack.Nil.Default -> MessagePack.Nil
+static readonly MessagePack.Resolvers.AttributeFormatterResolver.Instance -> MessagePack.Resolvers.AttributeFormatterResolver!
+static readonly MessagePack.Resolvers.BuiltinResolver.Instance -> MessagePack.Resolvers.BuiltinResolver!
+static readonly MessagePack.Resolvers.ContractlessStandardResolver.Instance -> MessagePack.Resolvers.ContractlessStandardResolver!
+static readonly MessagePack.Resolvers.ContractlessStandardResolver.Options -> MessagePack.MessagePackSerializerOptions!
+static readonly MessagePack.Resolvers.ContractlessStandardResolverAllowPrivate.Instance -> MessagePack.Resolvers.ContractlessStandardResolverAllowPrivate!
+static readonly MessagePack.Resolvers.ContractlessStandardResolverAllowPrivate.Options -> MessagePack.MessagePackSerializerOptions!
+static readonly MessagePack.Resolvers.DynamicContractlessObjectResolver.Instance -> MessagePack.Resolvers.DynamicContractlessObjectResolver!
+static readonly MessagePack.Resolvers.DynamicContractlessObjectResolverAllowPrivate.Instance -> MessagePack.Resolvers.DynamicContractlessObjectResolverAllowPrivate!
+static readonly MessagePack.Resolvers.DynamicEnumAsStringResolver.Instance -> MessagePack.Resolvers.DynamicEnumAsStringResolver!
+static readonly MessagePack.Resolvers.DynamicEnumAsStringResolver.Options -> MessagePack.MessagePackSerializerOptions!
+static readonly MessagePack.Resolvers.DynamicEnumResolver.Instance -> MessagePack.Resolvers.DynamicEnumResolver!
+static readonly MessagePack.Resolvers.DynamicGenericResolver.Instance -> MessagePack.Resolvers.DynamicGenericResolver!
+static readonly MessagePack.Resolvers.DynamicObjectResolver.Instance -> MessagePack.Resolvers.DynamicObjectResolver!
+static readonly MessagePack.Resolvers.DynamicObjectResolver.Options -> MessagePack.MessagePackSerializerOptions!
+static readonly MessagePack.Resolvers.DynamicObjectResolverAllowPrivate.Instance -> MessagePack.Resolvers.DynamicObjectResolverAllowPrivate!
+static readonly MessagePack.Resolvers.DynamicUnionResolver.Instance -> MessagePack.Resolvers.DynamicUnionResolver!
+static readonly MessagePack.Resolvers.DynamicUnionResolver.Options -> MessagePack.MessagePackSerializerOptions!
+static readonly MessagePack.Resolvers.NativeDateTimeResolver.Instance -> MessagePack.Resolvers.NativeDateTimeResolver!
+static readonly MessagePack.Resolvers.NativeDateTimeResolver.Options -> MessagePack.MessagePackSerializerOptions!
+static readonly MessagePack.Resolvers.NativeDecimalResolver.Instance -> MessagePack.Resolvers.NativeDecimalResolver!
+static readonly MessagePack.Resolvers.NativeGuidResolver.Instance -> MessagePack.Resolvers.NativeGuidResolver!
+static readonly MessagePack.Resolvers.PrimitiveObjectResolver.Instance -> MessagePack.Resolvers.PrimitiveObjectResolver!
+static readonly MessagePack.Resolvers.PrimitiveObjectResolver.Options -> MessagePack.MessagePackSerializerOptions!
+static readonly MessagePack.Resolvers.StandardResolver.Instance -> MessagePack.Resolvers.StandardResolver!
+static readonly MessagePack.Resolvers.StandardResolver.Options -> MessagePack.MessagePackSerializerOptions!
+static readonly MessagePack.Resolvers.StandardResolverAllowPrivate.Instance -> MessagePack.Resolvers.StandardResolverAllowPrivate!
+static readonly MessagePack.Resolvers.StandardResolverAllowPrivate.Options -> MessagePack.MessagePackSerializerOptions!
+static readonly MessagePack.Resolvers.StaticCompositeResolver.Instance -> MessagePack.Resolvers.StaticCompositeResolver!
+static readonly MessagePack.Resolvers.TypelessContractlessStandardResolver.Instance -> MessagePack.Resolvers.TypelessContractlessStandardResolver!
+static readonly MessagePack.Resolvers.TypelessContractlessStandardResolver.Options -> MessagePack.MessagePackSerializerOptions!
+static readonly MessagePack.Resolvers.TypelessObjectResolver.Instance -> MessagePack.IFormatterResolver!
+virtual MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TEnumerator, TCollection>.GetCount(TCollection sequence) -> int?
+virtual MessagePack.MessagePackSerializerOptions.Clone() -> MessagePack.MessagePackSerializerOptions!
+virtual MessagePack.MessagePackSerializerOptions.LoadType(string! typeName) -> System.Type?
+virtual MessagePack.MessagePackSerializerOptions.ThrowIfDeserializingTypeIsDisallowed(System.Type! type) -> void
+MessagePack.ExtensionHeader.Equals(MessagePack.ExtensionHeader other) -> bool
+MessagePack.Formatters.InterfaceCollectionFormatter2<T>
+MessagePack.Formatters.InterfaceCollectionFormatter2<T>.InterfaceCollectionFormatter2() -> void
+MessagePack.Formatters.InterfaceListFormatter2<T>
+MessagePack.Formatters.InterfaceListFormatter2<T>.InterfaceListFormatter2() -> void
+MessagePack.MessagePackReader.Depth.get -> int
+MessagePack.MessagePackReader.Depth.set -> void
+MessagePack.MessagePackReader.ReadDateTime(MessagePack.ExtensionHeader header) -> System.DateTime
+MessagePack.MessagePackReader.TryReadArrayHeader(out int count) -> bool
+MessagePack.MessagePackReader.TryReadExtensionFormatHeader(out MessagePack.ExtensionHeader extensionHeader) -> bool
+MessagePack.MessagePackReader.TryReadMapHeader(out int count) -> bool
+MessagePack.MessagePackSecurity
+MessagePack.MessagePackSecurity.DepthStep(ref MessagePack.MessagePackReader reader) -> void
+MessagePack.MessagePackSecurity.GetEqualityComparer() -> System.Collections.IEqualityComparer!
+MessagePack.MessagePackSecurity.GetEqualityComparer<T>() -> System.Collections.Generic.IEqualityComparer<T>!
+MessagePack.MessagePackSecurity.HashCollisionResistant.get -> bool
+MessagePack.MessagePackSecurity.MaximumObjectGraphDepth.get -> int
+MessagePack.MessagePackSecurity.MessagePackSecurity(MessagePack.MessagePackSecurity! copyFrom) -> void
+MessagePack.MessagePackSecurity.WithHashCollisionResistant(bool hashCollisionResistant) -> MessagePack.MessagePackSecurity!
+MessagePack.MessagePackSecurity.WithMaximumObjectGraphDepth(int maximumObjectGraphDepth) -> MessagePack.MessagePackSecurity!
+MessagePack.MessagePackSerializerOptions.Security.get -> MessagePack.MessagePackSecurity!
+MessagePack.MessagePackSerializerOptions.WithSecurity(MessagePack.MessagePackSecurity! security) -> MessagePack.MessagePackSerializerOptions!
+MessagePack.MessagePackStreamReader.DiscardBufferedData() -> void
+MessagePack.MessagePackStreamReader.MessagePackStreamReader(System.IO.Stream! stream, bool leaveOpen) -> void
+MessagePack.MessagePackStreamReader.ReadArrayAsync(System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<System.Buffers.ReadOnlySequence<byte>>!
+MessagePack.MessagePackWriter.WriteBinHeader(int length) -> void
+MessagePack.MessagePackWriter.WriteStringHeader(int byteCount) -> void
+static readonly MessagePack.MessagePackSecurity.TrustedData -> MessagePack.MessagePackSecurity!
+static readonly MessagePack.MessagePackSecurity.UntrustedData -> MessagePack.MessagePackSecurity!
+virtual MessagePack.MessagePackSecurity.Clone() -> MessagePack.MessagePackSecurity!
+virtual MessagePack.MessagePackSecurity.GetHashCollisionResistantEqualityComparer() -> System.Collections.IEqualityComparer!
+virtual MessagePack.MessagePackSecurity.GetHashCollisionResistantEqualityComparer<T>() -> System.Collections.Generic.IEqualityComparer<T>!
+MessagePack.Formatters.ByteMemoryFormatter
+MessagePack.Formatters.ByteMemoryFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Memory<byte>
+MessagePack.Formatters.ByteMemoryFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Memory<byte> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ByteReadOnlyMemoryFormatter
+MessagePack.Formatters.ByteReadOnlyMemoryFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.ReadOnlyMemory<byte>
+MessagePack.Formatters.ByteReadOnlyMemoryFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.ReadOnlyMemory<byte> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ByteReadOnlySequenceFormatter
+MessagePack.Formatters.ByteReadOnlySequenceFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Buffers.ReadOnlySequence<byte>
+MessagePack.Formatters.ByteReadOnlySequenceFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Buffers.ReadOnlySequence<byte> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ExpandoObjectFormatter
+MessagePack.Formatters.ExpandoObjectFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Dynamic.ExpandoObject?
+MessagePack.Formatters.ExpandoObjectFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Dynamic.ExpandoObject? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ForceTypelessFormatter<T>
+MessagePack.Formatters.ForceTypelessFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T?
+MessagePack.Formatters.ForceTypelessFormatter<T>.ForceTypelessFormatter() -> void
+MessagePack.Formatters.ForceTypelessFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.MemoryFormatter<T>
+MessagePack.Formatters.MemoryFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Memory<T>
+MessagePack.Formatters.MemoryFormatter<T>.MemoryFormatter() -> void
+MessagePack.Formatters.MemoryFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, System.Memory<T> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NonGenericInterfaceCollectionFormatter
+MessagePack.Formatters.NonGenericInterfaceCollectionFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Collections.ICollection?
+MessagePack.Formatters.NonGenericInterfaceCollectionFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Collections.ICollection? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.NonGenericInterfaceEnumerableFormatter
+MessagePack.Formatters.NonGenericInterfaceEnumerableFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Collections.IEnumerable?
+MessagePack.Formatters.NonGenericInterfaceEnumerableFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Collections.IEnumerable? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.PrimitiveObjectFormatter.PrimitiveObjectFormatter() -> void
+MessagePack.Formatters.ReadOnlyMemoryFormatter<T>
+MessagePack.Formatters.ReadOnlyMemoryFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.ReadOnlyMemory<T>
+MessagePack.Formatters.ReadOnlyMemoryFormatter<T>.ReadOnlyMemoryFormatter() -> void
+MessagePack.Formatters.ReadOnlyMemoryFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, System.ReadOnlyMemory<T> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.ReadOnlySequenceFormatter<T>
+MessagePack.Formatters.ReadOnlySequenceFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Buffers.ReadOnlySequence<T>
+MessagePack.Formatters.ReadOnlySequenceFormatter<T>.ReadOnlySequenceFormatter() -> void
+MessagePack.Formatters.ReadOnlySequenceFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, System.Buffers.ReadOnlySequence<T> value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TypeFormatter<T>
+MessagePack.Formatters.TypeFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> T?
+MessagePack.Formatters.TypeFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.TypelessFormatter.TypelessFormatter() -> void
+MessagePack.ImmutableCollection.ImmutableArrayFormatter<T>
+~MessagePack.ImmutableCollection.ImmutableArrayFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions options) -> System.Collections.Immutable.ImmutableArray<T>
+MessagePack.ImmutableCollection.ImmutableArrayFormatter<T>.ImmutableArrayFormatter() -> void
+~MessagePack.ImmutableCollection.ImmutableArrayFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, System.Collections.Immutable.ImmutableArray<T> value, MessagePack.MessagePackSerializerOptions options) -> void
+MessagePack.ImmutableCollection.ImmutableCollectionResolver
+MessagePack.ImmutableCollection.ImmutableCollectionResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+MessagePack.ImmutableCollection.ImmutableDictionaryFormatter<TKey, TValue>
+MessagePack.ImmutableCollection.ImmutableDictionaryFormatter<TKey, TValue>.ImmutableDictionaryFormatter() -> void
+MessagePack.ImmutableCollection.ImmutableHashSetFormatter<T>
+MessagePack.ImmutableCollection.ImmutableHashSetFormatter<T>.ImmutableHashSetFormatter() -> void
+MessagePack.ImmutableCollection.ImmutableListFormatter<T>
+MessagePack.ImmutableCollection.ImmutableListFormatter<T>.ImmutableListFormatter() -> void
+MessagePack.ImmutableCollection.ImmutableQueueBuilder<T>
+MessagePack.ImmutableCollection.ImmutableQueueBuilder<T>.Add(T value) -> void
+MessagePack.ImmutableCollection.ImmutableQueueBuilder<T>.ImmutableQueueBuilder() -> void
+~MessagePack.ImmutableCollection.ImmutableQueueBuilder<T>.Q.get -> System.Collections.Immutable.ImmutableQueue<T>
+~MessagePack.ImmutableCollection.ImmutableQueueBuilder<T>.Q.set -> void
+MessagePack.ImmutableCollection.ImmutableQueueFormatter<T>
+MessagePack.ImmutableCollection.ImmutableQueueFormatter<T>.ImmutableQueueFormatter() -> void
+MessagePack.ImmutableCollection.ImmutableSortedDictionaryFormatter<TKey, TValue>
+MessagePack.ImmutableCollection.ImmutableSortedDictionaryFormatter<TKey, TValue>.ImmutableSortedDictionaryFormatter() -> void
+MessagePack.ImmutableCollection.ImmutableSortedSetFormatter<T>
+MessagePack.ImmutableCollection.ImmutableSortedSetFormatter<T>.ImmutableSortedSetFormatter() -> void
+MessagePack.ImmutableCollection.ImmutableStackFormatter<T>
+MessagePack.ImmutableCollection.ImmutableStackFormatter<T>.ImmutableStackFormatter() -> void
+MessagePack.ImmutableCollection.InterfaceImmutableDictionaryFormatter<TKey, TValue>
+MessagePack.ImmutableCollection.InterfaceImmutableDictionaryFormatter<TKey, TValue>.InterfaceImmutableDictionaryFormatter() -> void
+MessagePack.ImmutableCollection.InterfaceImmutableListFormatter<T>
+MessagePack.ImmutableCollection.InterfaceImmutableListFormatter<T>.InterfaceImmutableListFormatter() -> void
+MessagePack.ImmutableCollection.InterfaceImmutableQueueFormatter<T>
+MessagePack.ImmutableCollection.InterfaceImmutableQueueFormatter<T>.InterfaceImmutableQueueFormatter() -> void
+MessagePack.ImmutableCollection.InterfaceImmutableSetFormatter<T>
+MessagePack.ImmutableCollection.InterfaceImmutableSetFormatter<T>.InterfaceImmutableSetFormatter() -> void
+MessagePack.ImmutableCollection.InterfaceImmutableStackFormatter<T>
+MessagePack.ImmutableCollection.InterfaceImmutableStackFormatter<T>.InterfaceImmutableStackFormatter() -> void
+MessagePack.Resolvers.ExpandoObjectResolver
+~override MessagePack.ImmutableCollection.ImmutableDictionaryFormatter<TKey, TValue>.Add(System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder collection, int index, TKey key, TValue value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.ImmutableDictionaryFormatter<TKey, TValue>.Complete(System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder intermediateCollection) -> System.Collections.Immutable.ImmutableDictionary<TKey, TValue>
+~override MessagePack.ImmutableCollection.ImmutableDictionaryFormatter<TKey, TValue>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder
+~override MessagePack.ImmutableCollection.ImmutableDictionaryFormatter<TKey, TValue>.GetSourceEnumerator(System.Collections.Immutable.ImmutableDictionary<TKey, TValue> source) -> System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Enumerator
+~override MessagePack.ImmutableCollection.ImmutableHashSetFormatter<T>.Add(System.Collections.Immutable.ImmutableHashSet<T>.Builder collection, int index, T value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.ImmutableHashSetFormatter<T>.Complete(System.Collections.Immutable.ImmutableHashSet<T>.Builder intermediateCollection) -> System.Collections.Immutable.ImmutableHashSet<T>
+~override MessagePack.ImmutableCollection.ImmutableHashSetFormatter<T>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> System.Collections.Immutable.ImmutableHashSet<T>.Builder
+~override MessagePack.ImmutableCollection.ImmutableHashSetFormatter<T>.GetSourceEnumerator(System.Collections.Immutable.ImmutableHashSet<T> source) -> System.Collections.Immutable.ImmutableHashSet<T>.Enumerator
+~override MessagePack.ImmutableCollection.ImmutableListFormatter<T>.Add(System.Collections.Immutable.ImmutableList<T>.Builder collection, int index, T value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.ImmutableListFormatter<T>.Complete(System.Collections.Immutable.ImmutableList<T>.Builder intermediateCollection) -> System.Collections.Immutable.ImmutableList<T>
+~override MessagePack.ImmutableCollection.ImmutableListFormatter<T>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> System.Collections.Immutable.ImmutableList<T>.Builder
+~override MessagePack.ImmutableCollection.ImmutableListFormatter<T>.GetSourceEnumerator(System.Collections.Immutable.ImmutableList<T> source) -> System.Collections.Immutable.ImmutableList<T>.Enumerator
+~override MessagePack.ImmutableCollection.ImmutableQueueFormatter<T>.Add(MessagePack.ImmutableCollection.ImmutableQueueBuilder<T> collection, int index, T value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.ImmutableQueueFormatter<T>.Complete(MessagePack.ImmutableCollection.ImmutableQueueBuilder<T> intermediateCollection) -> System.Collections.Immutable.ImmutableQueue<T>
+~override MessagePack.ImmutableCollection.ImmutableQueueFormatter<T>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> MessagePack.ImmutableCollection.ImmutableQueueBuilder<T>
+~override MessagePack.ImmutableCollection.ImmutableSortedDictionaryFormatter<TKey, TValue>.Add(System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder collection, int index, TKey key, TValue value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.ImmutableSortedDictionaryFormatter<TKey, TValue>.Complete(System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder intermediateCollection) -> System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>
+~override MessagePack.ImmutableCollection.ImmutableSortedDictionaryFormatter<TKey, TValue>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder
+~override MessagePack.ImmutableCollection.ImmutableSortedDictionaryFormatter<TKey, TValue>.GetSourceEnumerator(System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> source) -> System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Enumerator
+~override MessagePack.ImmutableCollection.ImmutableSortedSetFormatter<T>.Add(System.Collections.Immutable.ImmutableSortedSet<T>.Builder collection, int index, T value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.ImmutableSortedSetFormatter<T>.Complete(System.Collections.Immutable.ImmutableSortedSet<T>.Builder intermediateCollection) -> System.Collections.Immutable.ImmutableSortedSet<T>
+~override MessagePack.ImmutableCollection.ImmutableSortedSetFormatter<T>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> System.Collections.Immutable.ImmutableSortedSet<T>.Builder
+~override MessagePack.ImmutableCollection.ImmutableSortedSetFormatter<T>.GetSourceEnumerator(System.Collections.Immutable.ImmutableSortedSet<T> source) -> System.Collections.Immutable.ImmutableSortedSet<T>.Enumerator
+~override MessagePack.ImmutableCollection.ImmutableStackFormatter<T>.Add(T[] collection, int index, T value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.ImmutableStackFormatter<T>.Complete(T[] intermediateCollection) -> System.Collections.Immutable.ImmutableStack<T>
+~override MessagePack.ImmutableCollection.ImmutableStackFormatter<T>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> T[]
+~override MessagePack.ImmutableCollection.InterfaceImmutableDictionaryFormatter<TKey, TValue>.Add(System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder collection, int index, TKey key, TValue value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.InterfaceImmutableDictionaryFormatter<TKey, TValue>.Complete(System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder intermediateCollection) -> System.Collections.Immutable.IImmutableDictionary<TKey, TValue>
+~override MessagePack.ImmutableCollection.InterfaceImmutableDictionaryFormatter<TKey, TValue>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder
+~override MessagePack.ImmutableCollection.InterfaceImmutableListFormatter<T>.Add(System.Collections.Immutable.ImmutableList<T>.Builder collection, int index, T value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.InterfaceImmutableListFormatter<T>.Complete(System.Collections.Immutable.ImmutableList<T>.Builder intermediateCollection) -> System.Collections.Immutable.IImmutableList<T>
+~override MessagePack.ImmutableCollection.InterfaceImmutableListFormatter<T>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> System.Collections.Immutable.ImmutableList<T>.Builder
+~override MessagePack.ImmutableCollection.InterfaceImmutableQueueFormatter<T>.Add(MessagePack.ImmutableCollection.ImmutableQueueBuilder<T> collection, int index, T value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.InterfaceImmutableQueueFormatter<T>.Complete(MessagePack.ImmutableCollection.ImmutableQueueBuilder<T> intermediateCollection) -> System.Collections.Immutable.IImmutableQueue<T>
+~override MessagePack.ImmutableCollection.InterfaceImmutableQueueFormatter<T>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> MessagePack.ImmutableCollection.ImmutableQueueBuilder<T>
+~override MessagePack.ImmutableCollection.InterfaceImmutableSetFormatter<T>.Add(System.Collections.Immutable.ImmutableHashSet<T>.Builder collection, int index, T value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.InterfaceImmutableSetFormatter<T>.Complete(System.Collections.Immutable.ImmutableHashSet<T>.Builder intermediateCollection) -> System.Collections.Immutable.IImmutableSet<T>
+~override MessagePack.ImmutableCollection.InterfaceImmutableSetFormatter<T>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> System.Collections.Immutable.ImmutableHashSet<T>.Builder
+~override MessagePack.ImmutableCollection.InterfaceImmutableStackFormatter<T>.Add(T[] collection, int index, T value, MessagePack.MessagePackSerializerOptions options) -> void
+~override MessagePack.ImmutableCollection.InterfaceImmutableStackFormatter<T>.Complete(T[] intermediateCollection) -> System.Collections.Immutable.IImmutableStack<T>
+~override MessagePack.ImmutableCollection.InterfaceImmutableStackFormatter<T>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> T[]
+static readonly MessagePack.Formatters.ByteMemoryFormatter.Instance -> MessagePack.Formatters.ByteMemoryFormatter!
+static readonly MessagePack.Formatters.ByteReadOnlyMemoryFormatter.Instance -> MessagePack.Formatters.ByteReadOnlyMemoryFormatter!
+static readonly MessagePack.Formatters.ByteReadOnlySequenceFormatter.Instance -> MessagePack.Formatters.ByteReadOnlySequenceFormatter!
+static readonly MessagePack.Formatters.ExpandoObjectFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Dynamic.ExpandoObject?>!
+static readonly MessagePack.Formatters.NonGenericInterfaceCollectionFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Collections.ICollection?>!
+static readonly MessagePack.Formatters.NonGenericInterfaceEnumerableFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Collections.IEnumerable?>!
+static readonly MessagePack.Formatters.TypeFormatter<T>.Instance -> MessagePack.Formatters.IMessagePackFormatter<T?>!
+static readonly MessagePack.ImmutableCollection.ImmutableCollectionResolver.Instance -> MessagePack.ImmutableCollection.ImmutableCollectionResolver!
+static readonly MessagePack.Resolvers.ExpandoObjectResolver.Instance -> MessagePack.IFormatterResolver!
+static readonly MessagePack.Resolvers.ExpandoObjectResolver.Options -> MessagePack.MessagePackSerializerOptions!
+virtual MessagePack.Formatters.PrimitiveObjectFormatter.DeserializeMap(ref MessagePack.MessagePackReader reader, int length, MessagePack.MessagePackSerializerOptions! options) -> object!
+MessagePack.ExtensionHeader.ExtensionHeader() -> void
+MessagePack.ExtensionResult.ExtensionResult() -> void
+MessagePack.FormatterNotRegisteredException.FormatterNotRegisteredException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+MessagePack.MessagePackReader.MessagePackReader() -> void
+MessagePack.MessagePackSerializerOptions.SequencePool.get -> MessagePack.SequencePool!
+MessagePack.MessagePackSerializerOptions.WithPool(MessagePack.SequencePool! pool) -> MessagePack.MessagePackSerializerOptions!
+MessagePack.MessagePackStreamReader.MessagePackStreamReader(System.IO.Stream! stream, bool leaveOpen, MessagePack.SequencePool! sequencePool) -> void
+MessagePack.MessagePackStreamReader.ReadArrayHeaderAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<int>
+MessagePack.MessagePackStreamReader.ReadMapHeaderAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<int>
+MessagePack.MessagePackWriter.MessagePackWriter() -> void
+MessagePack.SequencePool
+MessagePack.SequencePool.SequencePool() -> void
+MessagePack.SequencePool.SequencePool(int maxSize) -> void
+MessagePack.SequencePool.SequencePool(int maxSize, System.Buffers.ArrayPool<byte>! arrayPool) -> void
+MessagePack.TinyJsonException.TinyJsonException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+static MessagePack.Nil.operator !=(MessagePack.Nil left, MessagePack.Nil right) -> bool
+static MessagePack.Nil.operator ==(MessagePack.Nil left, MessagePack.Nil right) -> bool
+virtual MessagePack.MessagePackStreamReader.Dispose(bool disposing) -> void
+MessagePack.Formatters.GenericEnumerableFormatter<TElement, TCollection>
+MessagePack.Formatters.GenericEnumerableFormatter<TElement, TCollection>.GenericEnumerableFormatter() -> void
+MessagePack.Formatters.GenericReadOnlyDictionaryFormatter<TKey, TValue, TDictionary>
+MessagePack.Formatters.GenericReadOnlyDictionaryFormatter<TKey, TValue, TDictionary>.GenericReadOnlyDictionaryFormatter() -> void
+MessagePack.Formatters.StringInterningFormatter
+MessagePack.Formatters.StringInterningFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> string?
+MessagePack.Formatters.StringInterningFormatter.Serialize(ref MessagePack.MessagePackWriter writer, string? value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.StringInterningFormatter.StringInterningFormatter() -> void
+MessagePack.MessagePackSerializerOptions.CompressionMinLength.get -> int
+MessagePack.MessagePackSerializerOptions.SuggestedContiguousMemorySize.get -> int
+MessagePack.MessagePackSerializerOptions.WithCompressionMinLength(int compressionMinLength) -> MessagePack.MessagePackSerializerOptions!
+MessagePack.MessagePackSerializerOptions.WithSuggestedContiguousMemorySize(int suggestedContiguousMemorySize) -> MessagePack.MessagePackSerializerOptions!
+static MessagePack.MessagePackWriter.GetEncodedLength(long value) -> int
+static MessagePack.MessagePackWriter.GetEncodedLength(ulong value) -> int

--- a/src/MessagePack/net472/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,38 @@
+MessagePack.CompositeResolverAttribute
+MessagePack.CompositeResolverAttribute.CompositeResolverAttribute(params System.Type![]! resolvers) -> void
+MessagePack.Formatters.Matrix3x2Formatter
+MessagePack.Formatters.Matrix3x2Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Numerics.Matrix3x2
+MessagePack.Formatters.Matrix3x2Formatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Numerics.Matrix3x2 value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.Matrix4x4Formatter
+MessagePack.Formatters.Matrix4x4Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Numerics.Matrix4x4
+MessagePack.Formatters.Matrix4x4Formatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Numerics.Matrix4x4 value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.QuaternionFormatter
+MessagePack.Formatters.QuaternionFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Numerics.Quaternion
+MessagePack.Formatters.QuaternionFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Numerics.Quaternion value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.Vector2Formatter
+MessagePack.Formatters.Vector2Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Numerics.Vector2
+MessagePack.Formatters.Vector2Formatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Numerics.Vector2 value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.Vector3Formatter
+MessagePack.Formatters.Vector3Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Numerics.Vector3
+MessagePack.Formatters.Vector3Formatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Numerics.Vector3 value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.Formatters.Vector4Formatter
+MessagePack.Formatters.Vector4Formatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions! options) -> System.Numerics.Vector4
+MessagePack.Formatters.Vector4Formatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Numerics.Vector4 value, MessagePack.MessagePackSerializerOptions! options) -> void
+MessagePack.GeneratedMessagePackResolverAttribute
+MessagePack.GeneratedMessagePackResolverAttribute.GeneratedMessagePackResolverAttribute() -> void
+MessagePack.GeneratedMessagePackResolverAttribute.UseMapMode.get -> bool
+MessagePack.GeneratedMessagePackResolverAttribute.UseMapMode.set -> void
+MessagePack.Internal.GeneratedAssemblyMessagePackResolverAttribute
+MessagePack.Internal.GeneratedAssemblyMessagePackResolverAttribute.GeneratedAssemblyMessagePackResolverAttribute(System.Type! resolverType, int majorVersion, int minorVersion) -> void
+MessagePack.Internal.GeneratedAssemblyMessagePackResolverAttribute.MajorVersion.get -> int
+MessagePack.Internal.GeneratedAssemblyMessagePackResolverAttribute.MinorVersion.get -> int
+MessagePack.Internal.GeneratedAssemblyMessagePackResolverAttribute.ResolverType.get -> System.Type!
+MessagePack.Resolvers.SourceGeneratedFormatterResolver
+MessagePack.Resolvers.SourceGeneratedFormatterResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>?
+static readonly MessagePack.Formatters.Matrix3x2Formatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Numerics.Matrix3x2>!
+static readonly MessagePack.Formatters.Matrix4x4Formatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Numerics.Matrix4x4>!
+static readonly MessagePack.Formatters.QuaternionFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Numerics.Quaternion>!
+static readonly MessagePack.Formatters.Vector2Formatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Numerics.Vector2>!
+static readonly MessagePack.Formatters.Vector3Formatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Numerics.Vector3>!
+static readonly MessagePack.Formatters.Vector4Formatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Numerics.Vector4>!
+static readonly MessagePack.Resolvers.SourceGeneratedFormatterResolver.Instance -> MessagePack.Resolvers.SourceGeneratedFormatterResolver!

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>
+    <NonShipping>true</NonShipping>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
 
 </Project>

--- a/tests/MessagePack.Tests/ContractlessStandardResolverConstructorTests.cs
+++ b/tests/MessagePack.Tests/ContractlessStandardResolverConstructorTests.cs
@@ -85,8 +85,55 @@ namespace MessagePack.Tests
             }
         }
 
+        public class TestConstructor3
+        {
+            private Guid x;
+            private Guid y;
+
+            public TestConstructor3(Guid x, Guid y)
+            {
+                this.x = x;
+                this.y = y;
+                this.CalledConstructorParameterCount = 2;
+            }
+
+            public int CalledConstructorParameterCount { get; }
+
+            public Guid X
+            {
+                get => this.x;
+                set => this.x = value;
+            }
+
+            public Guid Y
+            {
+                get => this.y;
+                set => this.y = value;
+            }
+        }
+
+        [Fact]
+        public void UseConstructor3()
+        {
+            var ctor = new TestConstructor3(Guid.NewGuid(), Guid.NewGuid());
+            var bin = MessagePackSerializer.Serialize(ctor, ContractlessStandardResolverAllowPrivate.Options);
+            var r = MessagePackSerializer.Deserialize<TestConstructor3>(bin, ContractlessStandardResolverAllowPrivate.Options)!;
+
+            r.CalledConstructorParameterCount.Is(2);
+        }
+
         [Fact]
         public void UseConstructor()
+        {
+            var ctor = new TestConstructor1(10, 20, 30);
+            var bin = MessagePackSerializer.Serialize(ctor, ContractlessStandardResolver.Options);
+            var r = MessagePackSerializer.Deserialize<TestConstructor1>(bin, ContractlessStandardResolver.Options);
+
+            r.CalledConstructorParameterCount.Is(3);
+        }
+
+        [Fact]
+        public void UseConstructor2()
         {
             var ctor = new TestConstructor1(10, 20, 30);
             var bin = MessagePackSerializer.Serialize(ctor, ContractlessStandardResolver.Options);


### PR DESCRIPTION
- fixing issue with backing field naming and serialization failing
- Remove commented code
- Verify empty dictionary is fine to deserialize
- Do for loop only if any elements
- [Formatting] Respect to nesting
- Compute formatters only if elements are there
- enable ignoring fields by using [NonSerialized]
- #1811 tweak dependencies.
- Add conditions for polyfil dependencies so are not promoted from being transitive.
- Drop dependency to v6
- Fix build breaks
- Avoid unsupported net461 target framework
- Add .NET Framework target to drop dependencies
