### PR TITLE
Move BuildTypeName() from TypelessFormatter to MessagePackSerializerOptions

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/TypelessFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/TypelessFormatter.cs
@@ -115,27 +115,6 @@ namespace MessagePack.Formatters
             Deserializers.TryAdd(typeof(object), _ => (object p1, ref MessagePackReader p2, MessagePackSerializerOptions p3) => new object());
         }
 
-        private string BuildTypeName(Type type, MessagePackSerializerOptions options)
-        {
-            if (options.OmitAssemblyVersion)
-            {
-                string full = type.AssemblyQualifiedName!;
-
-                var shortened = MessagePackSerializerOptions.AssemblyNameVersionSelectorRegex.Replace(full, string.Empty);
-                if (Type.GetType(shortened, false) == null)
-                {
-                    // if type cannot be found with shortened name - use full name
-                    shortened = full;
-                }
-
-                return shortened;
-            }
-            else
-            {
-                return type.AssemblyQualifiedName!;
-            }
-        }
-
         public void Serialize(ref MessagePackWriter writer, object? value, MessagePackSerializerOptions options)
         {
             if (value == null)
@@ -156,7 +135,7 @@ namespace MessagePack.Formatters
                 }
                 else
                 {
-                    typeName = StringEncoding.UTF8.GetBytes(this.BuildTypeName(type, options));
+                    typeName = StringEncoding.UTF8.GetBytes(options.BuildTypeName(type));
                 }
 
                 typeNameCache.TryAdd(type, typeName);

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializerOptions.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializerOptions.cs
@@ -164,6 +164,38 @@ namespace MessagePack
         }
 
         /// <summary>
+        /// Gets a string representation of the given type.
+        /// This is virtual, allowing users to set up overrides via deriving from MessagePackSerializerOptions.
+        /// A typical use case for this would be, in conjunction with overriding LoadType(), to provide the option to move types between namespaces and assemblies
+        /// without breaking binary compatibility with other processes that are writing to, and reading from, the same storage.
+        /// * overriding LoadType() allows legacy-format binary serialization to be read into the new namespace and assembly
+        /// * overriding BuildTypeName() allows the new namespace and assembly to write legacy-format binary serialization.
+        /// In the CLR, the System.Runtime.Serialization.SerializationBinder methods BindToName() and BindToType() provide this capability.
+        /// </summary>
+        /// <param name="type">The type to get a string representation of</param>
+        /// <returns></returns>
+        public virtual string BuildTypeName(Type type)
+        {
+            if (this.OmitAssemblyVersion)
+            {
+                string full = type.AssemblyQualifiedName!;
+
+                var shortened = AssemblyNameVersionSelectorRegex.Replace(full, string.Empty);
+                if (Type.GetType(shortened, false) == null)
+                {
+                    // if type cannot be found with shortened name - use full name
+                    shortened = full;
+                }
+
+                return shortened;
+            }
+            else
+            {
+                return type.AssemblyQualifiedName!;
+            }
+        }
+
+        /// <summary>
         /// Checks whether a given type may be deserialized.
         /// </summary>
         /// <param name="type">The type to be instantiated.</param>


### PR DESCRIPTION
`TypelessFormatter` currently has an extensibility point for mapping typeName -> type (via `virtual MessagePackSerializerOptions.LoadType()`, added in https://github.com/MessagePack-CSharp/MessagePack-CSharp/pull/589) but not for mapping type -> typeName.

However, **both** mapping directions are useful when dealing with the problem of types that are moving namespaces and/or assembly but are not otherwise changing in any way. If you can override both typeName -> type and type -> typeName in such cases, you can refactor code without having to break binary compatibility with existing clients who only know about the old namespace and assembly.

The CLR `System.Runtime.Serialization.SerializationBinder` class has (overriable) methods `BindToName()` and `BindToType()` which can be used together for exactly this purpose.

By moving `BuildTypeName()` from `TypelessFormatter` to `MessagePackSerializerOptions`, and making it `virtual`, we create an externsion point for type -> typeName mapping, making it possible to change type namespaces and/or assembly when refactoring while maintaining backwards compatibility.