### PR TITLE
Raise perf tracking events when formatters are dynamically generated

### DIFF
--- a/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
+++ b/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
@@ -70,6 +70,9 @@
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\ExtensionResult.cs">
       <Link>Code\ExtensionResult.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\MessagePackEventSource.cs">
+      <Link>Code\MessagePackEventSource.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\MessagePackSerializerOptions.cs">
       <Link>Code\MessagePackSerializerOptions.cs</Link>
     </Compile>

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackEventSource.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackEventSource.cs
@@ -1,0 +1,65 @@
+// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+using System;
+using System.Diagnostics.Tracing;
+
+namespace MessagePack
+{
+    [EventSource(Name = "MessagePack")]
+    internal class MessagePackEventSource : EventSource
+    {
+        internal static readonly MessagePackEventSource Instance = new();
+
+        private const int FormatterDynamicallyGeneratedStartEvent = 1;
+        private const int FormatterDynamicallyGeneratedStopEvent = 2;
+
+        private MessagePackEventSource()
+        {
+        }
+
+        [Event(FormatterDynamicallyGeneratedStartEvent, Task = Tasks.FormatterDynamicallyGenerated, Opcode = EventOpcode.Start)]
+        public void FormatterDynamicallyGeneratedStart()
+        {
+            WriteEvent(FormatterDynamicallyGeneratedStartEvent);
+        }
+
+        [Event(FormatterDynamicallyGeneratedStopEvent, Task = Tasks.FormatterDynamicallyGenerated, Opcode = EventOpcode.Stop)]
+        public void FormatterDynamicallyGeneratedStop(string? dataType)
+        {
+            WriteEvent(FormatterDynamicallyGeneratedStopEvent, dataType);
+        }
+
+        /// <summary>
+        /// Names of constants in this class make up the middle term in the event name
+        /// E.g.: MessagePack/InvokeMethod/Start.
+        /// </summary>
+        /// <remarks>Name of this class is important for EventSource.</remarks>
+        public static class Tasks
+        {
+            public const EventTask FormatterDynamicallyGenerated = (EventTask)1;
+        }
+    }
+
+    /// <summary>
+    /// Helper methods for <see cref="MessagePackEventSource"/>.
+    /// </summary>
+    /// <remarks>
+    /// This methods may contain parameter types that are not allowed on the
+    /// <see cref="MessagePackEventSource"/> class itself.
+    /// If these methods were to be moved to the class itself,
+    /// eventing would silently fail at runtime, observable only by watching the events (e.g. with PerfView).
+    /// </remarks>
+    internal static class MessagePackEventSourceExtensions
+    {
+        internal static void FormatterDynamicallyGeneratedStop(this MessagePackEventSource source, Type dataType)
+        {
+            if (source.IsEnabled(EventLevel.Informational, EventKeywords.None))
+            {
+                source.FormatterDynamicallyGeneratedStop(dataType.AssemblyQualifiedName);
+            }
+        }
+    }
+}

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackEventSource.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackEventSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5440a3bb490544dd87f9f31d0b90f008
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicEnumResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicEnumResolver.cs
@@ -90,40 +90,48 @@ namespace MessagePack.Resolvers
             Type underlyingType = Enum.GetUnderlyingType(enumType);
             Type formatterType = typeof(IMessagePackFormatter<>).MakeGenericType(enumType);
 
-            using (MonoProtection.EnterRefEmitLock())
+            MessagePackEventSource.Instance.FormatterDynamicallyGeneratedStart();
+            try
             {
-                TypeBuilder typeBuilder = DynamicAssembly.Value.DefineType("MessagePack.Formatters." + enumType.FullName!.Replace(".", "_") + "Formatter" + Interlocked.Increment(ref nameSequence), TypeAttributes.Public | TypeAttributes.Sealed, null, new[] { formatterType });
-
-                // void Serialize(ref MessagePackWriter writer, T value, MessagePackSerializerOptions options);
+                using (MonoProtection.EnterRefEmitLock())
                 {
-                    MethodBuilder method = typeBuilder.DefineMethod(
-                        "Serialize",
-                        MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.Virtual,
-                        null,
-                        new Type[] { typeof(MessagePackWriter).MakeByRefType(), enumType, typeof(MessagePackSerializerOptions) });
+                    TypeBuilder typeBuilder = DynamicAssembly.Value.DefineType("MessagePack.Formatters." + enumType.FullName!.Replace(".", "_") + "Formatter" + Interlocked.Increment(ref nameSequence), TypeAttributes.Public | TypeAttributes.Sealed, null, new[] { formatterType });
 
-                    ILGenerator il = method.GetILGenerator();
-                    il.Emit(OpCodes.Ldarg_1);
-                    il.Emit(OpCodes.Ldarg_2);
-                    il.Emit(OpCodes.Call, typeof(MessagePackWriter).GetRuntimeMethod(nameof(MessagePackWriter.Write), new[] { underlyingType })!);
-                    il.Emit(OpCodes.Ret);
+                    // void Serialize(ref MessagePackWriter writer, T value, MessagePackSerializerOptions options);
+                    {
+                        MethodBuilder method = typeBuilder.DefineMethod(
+                            "Serialize",
+                            MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.Virtual,
+                            null,
+                            new Type[] { typeof(MessagePackWriter).MakeByRefType(), enumType, typeof(MessagePackSerializerOptions) });
+
+                        ILGenerator il = method.GetILGenerator();
+                        il.Emit(OpCodes.Ldarg_1);
+                        il.Emit(OpCodes.Ldarg_2);
+                        il.Emit(OpCodes.Call, typeof(MessagePackWriter).GetRuntimeMethod(nameof(MessagePackWriter.Write), new[] { underlyingType })!);
+                        il.Emit(OpCodes.Ret);
+                    }
+
+                    // T Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options);
+                    {
+                        MethodBuilder method = typeBuilder.DefineMethod(
+                            "Deserialize",
+                            MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.Virtual,
+                            enumType,
+                            new Type[] { typeof(MessagePackReader).MakeByRefType(), typeof(MessagePackSerializerOptions) });
+
+                        ILGenerator il = method.GetILGenerator();
+                        il.Emit(OpCodes.Ldarg_1);
+                        il.Emit(OpCodes.Call, typeof(MessagePackReader).GetRuntimeMethod("Read" + underlyingType.Name, Type.EmptyTypes)!);
+                        il.Emit(OpCodes.Ret);
+                    }
+
+                    return typeBuilder.CreateTypeInfo()!;
                 }
-
-                // T Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options);
-                {
-                    MethodBuilder method = typeBuilder.DefineMethod(
-                        "Deserialize",
-                        MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.Virtual,
-                        enumType,
-                        new Type[] { typeof(MessagePackReader).MakeByRefType(), typeof(MessagePackSerializerOptions) });
-
-                    ILGenerator il = method.GetILGenerator();
-                    il.Emit(OpCodes.Ldarg_1);
-                    il.Emit(OpCodes.Call, typeof(MessagePackReader).GetRuntimeMethod("Read" + underlyingType.Name, Type.EmptyTypes)!);
-                    il.Emit(OpCodes.Ret);
-                }
-
-                return typeBuilder.CreateTypeInfo()!;
+            }
+            finally
+            {
+                MessagePackEventSource.Instance.FormatterDynamicallyGeneratedStop(enumType);
             }
         }
     }


### PR DESCRIPTION
In anticipation for MessagePack v3, where AOT formatter generation is on by default, we'd like apps using v2 and possibly migrating to v3 to be able to track perf impact of the change by observing the number of dynamically generated formatters that are generated by their application now and in the future.

Raising these events has almost no perf impact unless there is a process that is actually listening for them, and even then, they are designed by the OS to be extremely lightweight.

Here is a sample of the result, when the events are activated and traced by PerfView:

![image](https://github.com/MessagePack-CSharp/MessagePack-CSharp/assets/3548/87e23c56-1eb0-4416-b9c6-e1b6c582b606)

