### PR TITLE
Allow writing to init property setters of generic classes on .NET 6+

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -2312,7 +2312,12 @@ namespace MessagePack.Internal
             /// <see href="https://github.com/neuecc/MessagePack-CSharp/issues/1134">A bug</see> in <see cref="MethodBuilder"/>
             /// blocks its ability to invoke property init accessors when in a generic class.
             /// </remarks>
-            internal bool IsProblematicInitProperty => this.PropertyInfo is PropertyInfo property && property.DeclaringType!.IsGenericType && this.IsInitOnly;
+            internal bool IsProblematicInitProperty
+#if NET6_0_OR_GREATER
+                => false;
+#else
+                => this.PropertyInfo is PropertyInfo property && property.DeclaringType!.IsGenericType && this.IsInitOnly;
+#endif
 
             public MessagePackFormatterAttribute? GetMessagePackFormatterAttribute()
             {


### PR DESCRIPTION
Only .NET 6 has the fix to `MethodBuilder` required for this to work. .NET Framework has not been fixed.

Closes #1134 (once again)