### PR TITLE
Offer code fix to ignore unattribute members of MessagePackObject types

### DIFF
--- a/src/MessagePack.Analyzers.CodeFixes/CodeFixes/MessagePackCodeFixProvider.cs
+++ b/src/MessagePack.Analyzers.CodeFixes/CodeFixes/MessagePackCodeFixProvider.cs
@@ -11,7 +11,7 @@ public class MessagePackCodeFixProvider : CodeFixProvider
         get
         {
             return ImmutableArray.Create(
-                MsgPack00xMessagePackAnalyzer.PublicMemberNeedsKey.Id,
+                MsgPack00xMessagePackAnalyzer.MemberNeedsKey.Id,
                 MsgPack00xMessagePackAnalyzer.TypeMustBeMessagePackObject.Id);
         }
     }

--- a/src/MessagePack.SourceGenerator/AnalyzerReleases.Unshipped.md
+++ b/src/MessagePack.SourceGenerator/AnalyzerReleases.Unshipped.md
@@ -8,7 +8,7 @@ Rule ID | Category | Severity | Notes
 MsgPack001 | Reliability | Disabled | MsgPack001SpecifyOptionsAnalyzer
 MsgPack002 | Reliability | Disabled | MsgPack002UseConstantOptionsAnalyzer
 MsgPack003 | Usage | Error | MsgPack00xMessagePackAnalyzer
-MsgPack004 | Usage | Error | MsgPack00xMessagePackAnalyzer
+MsgPack004 | Usage | Error | Member needs Key or IgnoreMember attribute
 MsgPack005 | Usage | Error | MsgPack00xMessagePackAnalyzer
 MsgPack006 | Usage | Error | MsgPack00xMessagePackAnalyzer
 MsgPack007 | Usage | Error | MsgPack00xMessagePackAnalyzer

--- a/src/MessagePack.SourceGenerator/Analyzers/MsgPack00xMessagePackAnalyzer.cs
+++ b/src/MessagePack.SourceGenerator/Analyzers/MsgPack00xMessagePackAnalyzer.cs
@@ -53,7 +53,7 @@ public class MsgPack00xMessagePackAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         helpLinkUri: AnalyzerUtilities.GetHelpLink(MessagePackFormatterMustBeMessagePackFormatterId));
 
-    public static readonly DiagnosticDescriptor PublicMemberNeedsKey = new DiagnosticDescriptor(
+    public static readonly DiagnosticDescriptor MemberNeedsKey = new DiagnosticDescriptor(
         id: AttributeMessagePackObjectMembersId,
         title: "Attribute properties and fields of MessagePack objects",
         category: Category,
@@ -258,7 +258,7 @@ public class MsgPack00xMessagePackAnalyzer : DiagnosticAnalyzer
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
         TypeMustBeMessagePackObject,
         MessageFormatterMustBeMessagePackFormatter,
-        PublicMemberNeedsKey,
+        MemberNeedsKey,
         BaseTypeContainsUnattributedPublicMembers,
         InvalidMessagePackObject,
         BothStringAndIntKeyAreNull,

--- a/src/MessagePack.SourceGenerator/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.SourceGenerator/CodeAnalysis/TypeCollector.cs
@@ -779,7 +779,7 @@ public class TypeCollector
                             var syntax = item.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax();
                             var identifier = (syntax as PropertyDeclarationSyntax)?.Identifier ?? (syntax as ParameterSyntax)?.Identifier;
 
-                            this.reportDiagnostic?.Invoke(Diagnostic.Create(MsgPack00xMessagePackAnalyzer.PublicMemberNeedsKey, identifier?.GetLocation(), formattedType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), item.Name));
+                            this.reportDiagnostic?.Invoke(Diagnostic.Create(MsgPack00xMessagePackAnalyzer.MemberNeedsKey, identifier?.GetLocation(), formattedType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), item.Name));
                         }
                         else if (formattedType.BaseType is not null)
                         {
@@ -881,7 +881,7 @@ public class TypeCollector
                 {
                     if (contractAttr is not null)
                     {
-                        this.reportDiagnostic?.Invoke(Diagnostic.Create(MsgPack00xMessagePackAnalyzer.PublicMemberNeedsKey, item.DeclaringSyntaxReferences[0].GetSyntax().GetLocation(), formattedType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), item.Name));
+                        this.reportDiagnostic?.Invoke(Diagnostic.Create(MsgPack00xMessagePackAnalyzer.MemberNeedsKey, item.DeclaringSyntaxReferences[0].GetSyntax().GetLocation(), formattedType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), item.Name));
                     }
                 }
                 else

--- a/tests/MessagePack.SourceGenerator.Tests/MessagePackAnalyzerTests.cs
+++ b/tests/MessagePack.SourceGenerator.Tests/MessagePackAnalyzerTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using MessagePack.SourceGenerator.Analyzers;
+using MessagePack.Analyzers.CodeFixes;
 using Microsoft.CodeAnalysis.Testing;
 using VerifyCS = CSharpCodeFixVerifier<MessagePack.SourceGenerator.Analyzers.MsgPack00xMessagePackAnalyzer, MessagePack.Analyzers.CodeFixes.MessagePackCodeFixProvider>;
 
@@ -118,6 +118,43 @@ public class Foo
             TestCode = input,
             FixedCode = output,
             MarkupOptions = MarkupOptions.UseFirstDescriptor,
+            CodeActionEquivalenceKey = MessagePackCodeFixProvider.AddKeyAttributeEquivanceKey,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task AddIgnoreAttributesToMembers()
+    {
+        string input = Preamble + @"
+[MessagePackObject]
+public class Foo
+{
+    internal string {|MsgPack004:member1 = null|};
+    internal string {|MsgPack004:member2 = null|};
+    [Key(0)]
+    public string Member3 { get; set; }
+}
+";
+
+        string output = Preamble + @"
+[MessagePackObject]
+public class Foo
+{
+    [IgnoreMember]
+    internal string member1 = null;
+    [IgnoreMember]
+    internal string member2 = null;
+    [Key(0)]
+    public string Member3 { get; set; }
+}
+";
+
+        await new VerifyCS.Test
+        {
+            TestCode = input,
+            FixedCode = output,
+            MarkupOptions = MarkupOptions.UseFirstDescriptor,
+            CodeActionEquivalenceKey = MessagePackCodeFixProvider.AddIgnoreMemberAttributeEquivalenceKey,
         }.RunAsync();
     }
 
@@ -148,6 +185,7 @@ public class Foo
             TestCode = input,
             FixedCode = output,
             MarkupOptions = MarkupOptions.UseFirstDescriptor,
+            CodeActionEquivalenceKey = MessagePackCodeFixProvider.AddKeyAttributeEquivanceKey,
         }.RunAsync();
     }
 
@@ -185,7 +223,13 @@ public class Bar
 }
 ";
 
-        await VerifyCS.VerifyCodeFixAsync(input, output);
+        await new VerifyCS.Test
+        {
+            TestCode = input,
+            FixedCode = output,
+            MarkupOptions = MarkupOptions.UseFirstDescriptor,
+            CodeActionEquivalenceKey = MessagePackCodeFixProvider.AddKeyAttributeEquivanceKey,
+        }.RunAsync();
     }
 
     [Fact]
@@ -222,7 +266,13 @@ public record Bar
 }
 ";
 
-        await VerifyCS.VerifyCodeFixAsync(input, output);
+        await new VerifyCS.Test
+        {
+            TestCode = input,
+            FixedCode = output,
+            MarkupOptions = MarkupOptions.UseFirstDescriptor,
+            CodeActionEquivalenceKey = MessagePackCodeFixProvider.AddKeyAttributeEquivanceKey,
+        }.RunAsync();
     }
 
     [Fact]
@@ -259,7 +309,13 @@ public record Bar
 }
 ";
 
-        await VerifyCS.VerifyCodeFixAsync(input, output);
+        await new VerifyCS.Test
+        {
+            TestCode = input,
+            FixedCode = output,
+            MarkupOptions = MarkupOptions.UseFirstDescriptor,
+            CodeActionEquivalenceKey = MessagePackCodeFixProvider.AddKeyAttributeEquivanceKey,
+        }.RunAsync();
     }
 
     [Fact]
@@ -302,7 +358,13 @@ namespace System.Runtime.CompilerServices
 }
 ";
 
-        await VerifyCS.VerifyCodeFixAsync(input, output);
+        await new VerifyCS.Test
+        {
+            TestCode = input,
+            FixedCode = output,
+            MarkupOptions = MarkupOptions.UseFirstDescriptor,
+            CodeActionEquivalenceKey = MessagePackCodeFixProvider.AddKeyAttributeEquivanceKey,
+        }.RunAsync();
     }
 
     [Fact]
@@ -353,6 +415,7 @@ public class Bar : Foo
                 Sources = { output1, output2 },
             },
             MarkupOptions = MarkupOptions.UseFirstDescriptor,
+            CodeActionEquivalenceKey = MessagePackCodeFixProvider.AddKeyAttributeEquivanceKey,
         }.RunAsync();
     }
 
@@ -396,6 +459,12 @@ public class Bar : Foo
             }
             """;
 
-        await VerifyCS.VerifyCodeFixAsync(input, output);
+        await new VerifyCS.Test
+        {
+            TestCode = input,
+            FixedCode = output,
+            MarkupOptions = MarkupOptions.UseFirstDescriptor,
+            CodeActionEquivalenceKey = MessagePackCodeFixProvider.AddKeyAttributeEquivanceKey,
+        }.RunAsync();
     }
 }


### PR DESCRIPTION
This is important for v2->v3 migration because all the non-public members that v2 would ignore are no longer ignored in v3 and will produce errors or warnings.

Closes #1849