### PR TITLE
Fix some source generator issues

### DIFF
--- a/src/MessagePack.SourceGenerator/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.SourceGenerator/CodeAnalysis/TypeCollector.cs
@@ -455,7 +455,7 @@ public class TypeCollector
 
         var info = GenericSerializationInfo.Create(array, this.options.Generator.Resolver) with
         {
-            Formatter = new QualifiedTypeName("MsgPack::Formatters", null, TypeKind.Class, formatterName, ImmutableArray.Create(elementTypeName.GetQualifiedName())),
+            Formatter = new QualifiedTypeName("MsgPack::Formatters", null, TypeKind.Class, formatterName, ImmutableArray.Create(elementTypeName.GetQualifiedName(genericStyle: GenericParameterStyle.Arguments))),
         };
         this.collectedGenericInfo.Add(info);
         return true;

--- a/src/MessagePack.SourceGenerator/Utils/AnalyzerUtilities.cs
+++ b/src/MessagePack.SourceGenerator/Utils/AnalyzerUtilities.cs
@@ -128,6 +128,12 @@ public static class AnalyzerUtilities
                     }
                 }
 
+                // If the resolver has GeneratedMessagePackResolverAttribute, it has static Instance property
+                if (r.GetAttributes().Any(x => x.AttributeClass?.Name == GeneratedMessagePackResolverAttributeName && x.AttributeClass?.ContainingNamespace.GetFullNamespaceName() == AttributeNamespace))
+                {
+                    return $"{r.GetCanonicalTypeFullName()}.Instance";
+                }
+
                 // Fallback to instantiating the resolver, if a constructor is available.
                 if (r.InstanceConstructors.FirstOrDefault(c => c.Parameters.Length == 0) is IMethodSymbol ctor)
                 {

--- a/tests/MessagePack.SourceGenerator.ExecutionTests/GeneratedCompositeResolverTests.cs
+++ b/tests/MessagePack.SourceGenerator.ExecutionTests/GeneratedCompositeResolverTests.cs
@@ -16,7 +16,7 @@ public class GeneratedCompositeResolverTests
 
 namespace Tests
 {
-    [CompositeResolver(typeof(NativeGuidResolver), typeof(NativeDecimalResolver))]
+    [CompositeResolver(typeof(GeneratedMessagePackResolver), typeof(NativeGuidResolver), typeof(NativeDecimalResolver))]
     internal partial class MyGeneratedCompositeResolver
     {
     }

--- a/tests/MessagePack.SourceGenerator.Tests/GenerationTests.cs
+++ b/tests/MessagePack.SourceGenerator.Tests/GenerationTests.cs
@@ -266,12 +266,16 @@ internal class MyMessagePackObject
     {
         string testSource = """
 using MessagePack;
+using System.Collections.Generic;
 
 [MessagePackObject]
 internal class ContainerObject
 {
     [Key(0)]
     internal SubObject[] ArrayOfCustomObjects { get; set; }
+
+    [Key(1)]
+    internal List<SubObject>[] ArrayOfCustomObjectList { get; set; }
 }
 
 [MessagePackObject]

--- a/tests/MessagePack.SourceGenerator.Tests/Resources/ArrayTypedProperty/Formatters.MessagePack.GeneratedMessagePackResolver.ContainerObjectFormatter.g.cs
+++ b/tests/MessagePack.SourceGenerator.Tests/Resources/ArrayTypedProperty/Formatters.MessagePack.GeneratedMessagePackResolver.ContainerObjectFormatter.g.cs
@@ -21,8 +21,9 @@ partial class GeneratedMessagePackResolver {
 			}
 
 			MsgPack::IFormatterResolver formatterResolver = options.Resolver;
-			writer.WriteArrayHeader(1);
+			writer.WriteArrayHeader(2);
 			MsgPack::FormatterResolverExtensions.GetFormatterWithVerify<global::SubObject[]>(formatterResolver).Serialize(ref writer, value.ArrayOfCustomObjects, options);
+			MsgPack::FormatterResolverExtensions.GetFormatterWithVerify<global::System.Collections.Generic.List<global::SubObject>[]>(formatterResolver).Serialize(ref writer, value.ArrayOfCustomObjectList, options);
 		}
 
 		public global::ContainerObject Deserialize(ref MsgPack::MessagePackReader reader, MsgPack::MessagePackSerializerOptions options)
@@ -43,6 +44,9 @@ partial class GeneratedMessagePackResolver {
 				{
 					case 0:
 						____result.ArrayOfCustomObjects = MsgPack::FormatterResolverExtensions.GetFormatterWithVerify<global::SubObject[]>(formatterResolver).Deserialize(ref reader, options);
+						break;
+					case 1:
+						____result.ArrayOfCustomObjectList = MsgPack::FormatterResolverExtensions.GetFormatterWithVerify<global::System.Collections.Generic.List<global::SubObject>[]>(formatterResolver).Deserialize(ref reader, options);
 						break;
 					default:
 						reader.Skip();

--- a/tests/MessagePack.SourceGenerator.Tests/Resources/ArrayTypedProperty/MessagePack.GeneratedMessagePackResolver.g.cs
+++ b/tests/MessagePack.SourceGenerator.Tests/Resources/ArrayTypedProperty/MessagePack.GeneratedMessagePackResolver.g.cs
@@ -39,11 +39,13 @@ partial class GeneratedMessagePackResolver : MsgPack::IFormatterResolver
 
 	private static class GeneratedMessagePackResolverGetFormatterHelper
 	{
-		private static readonly global::System.Collections.Generic.Dictionary<global::System.Type, int> closedTypeLookup = new(3)
+		private static readonly global::System.Collections.Generic.Dictionary<global::System.Type, int> closedTypeLookup = new(5)
 		{
 			{ typeof(global::SubObject[]), 0 },
-			{ typeof(global::ContainerObject), 1 },
-			{ typeof(global::SubObject), 2 },
+			{ typeof(global::System.Collections.Generic.List<global::SubObject>[]), 1 },
+			{ typeof(global::System.Collections.Generic.List<global::SubObject>), 2 },
+			{ typeof(global::ContainerObject), 3 },
+			{ typeof(global::SubObject), 4 },
 		};
 
 		internal static object GetFormatter(global::System.Type t)
@@ -53,8 +55,10 @@ partial class GeneratedMessagePackResolver : MsgPack::IFormatterResolver
 				return closedKey switch
 				{
 					0 => new MsgPack::Formatters.ArrayFormatter<global::SubObject>(),
-					1 => new global::MessagePack.GeneratedMessagePackResolver.ContainerObjectFormatter(),
-					2 => new global::MessagePack.GeneratedMessagePackResolver.SubObjectFormatter(),
+					1 => new MsgPack::Formatters.ArrayFormatter<global::System.Collections.Generic.List<global::SubObject>>(),
+					2 => new MsgPack::Formatters.ListFormatter<global::SubObject>(),
+					3 => new global::MessagePack.GeneratedMessagePackResolver.ContainerObjectFormatter(),
+					4 => new global::MessagePack.GeneratedMessagePackResolver.SubObjectFormatter(),
 					_ => null, // unreachable
 				};
 			}


### PR DESCRIPTION
Fix two issues:
1. Source generator generates incorrect code for `List<SubObject>[]` in resolver:
`1 => new MsgPack::Formatters.ArrayFormatter<global::System.Collections.Generic.List<T>>(),`
2. Generated resolver can't be used in `CompositeResolverAttribute` in the same assembly