### PR TITLE
Adjusted MsgPack004 to support records

### DIFF
--- a/src/MessagePackAnalyzer/MessagePackAnalyzer.cs
+++ b/src/MessagePackAnalyzer/MessagePackAnalyzer.cs
@@ -80,7 +80,14 @@ namespace MessagePackAnalyzer
             {
                 if (ReferenceSymbols.TryCreate(ctxt.Compilation, out ReferenceSymbols? typeReferences))
                 {
-                    ctxt.RegisterSyntaxNodeAction(c => Analyze(c, typeReferences), SyntaxKind.ClassDeclaration, SyntaxKind.StructDeclaration, SyntaxKind.InterfaceDeclaration);
+                    var relevantSyntaxKinds = new[]
+                    {
+                         SyntaxKind.ClassDeclaration,
+                         SyntaxKind.StructDeclaration,
+                         SyntaxKind.InterfaceDeclaration,
+                         SyntaxKind.RecordDeclaration,
+                    };
+                    ctxt.RegisterSyntaxNodeAction(c => Analyze(c, typeReferences), relevantSyntaxKinds);
                 }
             });
         }

--- a/src/MessagePackAnalyzer/MessagePackCodeFixProvider.cs
+++ b/src/MessagePackAnalyzer/MessagePackCodeFixProvider.cs
@@ -154,7 +154,8 @@ namespace MessagePackAnalyzer
 
             foreach (ISymbol member in targets)
             {
-                if (member.GetAttributes().FindAttributeShortName(MessagePackAnalyzer.KeyAttributeShortName) is null)
+                if (!member.IsImplicitlyDeclared &&
+                    member.GetAttributes().FindAttributeShortName(MessagePackAnalyzer.KeyAttributeShortName) is null)
                 {
                     SyntaxNode node = await member.DeclaringSyntaxReferences[0].GetSyntaxAsync(cancellationToken).ConfigureAwait(false);
                     var documentEditor = await solutionEditor.GetDocumentEditorAsync(document.Project.Solution.GetDocumentId(node.SyntaxTree), cancellationToken).ConfigureAwait(false);

--- a/tests/MessagePackAnalyzer.Tests/Helpers/CSharpCodeFixVerifier`2.cs
+++ b/tests/MessagePackAnalyzer.Tests/Helpers/CSharpCodeFixVerifier`2.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -22,26 +23,26 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
     public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
         => new DiagnosticResult(descriptor);
 
-    public static Task VerifyAnalyzerWithoutMessagePackReferenceAsync(string source)
+    public static Task VerifyAnalyzerWithoutMessagePackReferenceAsync([StringSyntax("c#-test")] string source)
     {
         var test = new Test { TestCode = source, ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net472.Default };
         return test.RunAsync();
     }
 
-    public static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+    public static Task VerifyAnalyzerAsync([StringSyntax("c#-test")] string source, params DiagnosticResult[] expected)
     {
         var test = new Test { TestCode = source };
         test.ExpectedDiagnostics.AddRange(expected);
         return test.RunAsync();
     }
 
-    public static Task VerifyCodeFixAsync(string source, string fixedSource)
+    public static Task VerifyCodeFixAsync([StringSyntax("c#-test")] string source, [StringSyntax("c#-test")] string fixedSource)
         => VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
 
-    public static Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
+    public static Task VerifyCodeFixAsync([StringSyntax("c#-test")] string source, DiagnosticResult expected, [StringSyntax("c#-test")] string fixedSource)
         => VerifyCodeFixAsync(source, new[] { expected }, fixedSource);
 
-    public static Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource)
+    public static Task VerifyCodeFixAsync([StringSyntax("c#-test")] string source, DiagnosticResult[] expected, [StringSyntax("c#-test")] string fixedSource)
     {
         var test = new Test
         {
@@ -53,7 +54,7 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
         return test.RunAsync();
     }
 
-    public static Task VerifyCodeFixAsync(string[] source, string[] fixedSource)
+    public static Task VerifyCodeFixAsync([StringSyntax("c#-test")] string[] source, [StringSyntax("c#-test")] string[] fixedSource)
     {
         var test = new Test
         {

--- a/tests/MessagePackAnalyzer.Tests/MessagePackAnalyzerTests.cs
+++ b/tests/MessagePackAnalyzer.Tests/MessagePackAnalyzerTests.cs
@@ -221,7 +221,7 @@ public record Foo
 ";
 
         var context = new CSharpCodeFixTest<MessagePackAnalyzer.MessagePackAnalyzer, MessagePackAnalyzer.MessagePackCodeFixProvider, DefaultVerifier>();
-        context.ReferenceAssemblies = ReferenceAssemblies.Net.Net60.WithPackages(ImmutableArray.Create(new PackageIdentity("MessagePack", "2.0.335"))); ;
+        context.ReferenceAssemblies = ReferenceAssemblies.Net.Net60.WithPackages(ImmutableArray.Create(new PackageIdentity("MessagePack", "2.0.335")));
         context.CompilerDiagnostics = CompilerDiagnostics.Errors;
         context.SolutionTransforms.Add(static (solution, projectId) =>
         {
@@ -247,7 +247,7 @@ public record Foo(
         string output = input; // No fix for this
 
         var context = new CSharpCodeFixTest<MessagePackAnalyzer.MessagePackAnalyzer, MessagePackAnalyzer.MessagePackCodeFixProvider, DefaultVerifier>();
-        context.ReferenceAssemblies = ReferenceAssemblies.Net.Net60.WithPackages(ImmutableArray.Create(new PackageIdentity("MessagePack", "2.0.335"))); ;
+        context.ReferenceAssemblies = ReferenceAssemblies.Net.Net60.WithPackages(ImmutableArray.Create(new PackageIdentity("MessagePack", "2.0.335")));
         context.CompilerDiagnostics = CompilerDiagnostics.Errors;
         context.SolutionTransforms.Add(static (solution, projectId) =>
         {

--- a/tests/MessagePackAnalyzer.Tests/MessagePackAnalyzerTests.cs
+++ b/tests/MessagePackAnalyzer.Tests/MessagePackAnalyzerTests.cs
@@ -219,19 +219,20 @@ public record Foo
     public string Member2 { get; set; }
 }
 ";
-
-        var context = new CSharpCodeFixTest<MessagePackAnalyzer.MessagePackAnalyzer, MessagePackAnalyzer.MessagePackCodeFixProvider, DefaultVerifier>();
-        context.ReferenceAssemblies = ReferenceAssemblies.Net.Net60.WithPackages(ImmutableArray.Create(new PackageIdentity("MessagePack", "2.0.335")));
-        context.CompilerDiagnostics = CompilerDiagnostics.Errors;
-        context.SolutionTransforms.Add(static (solution, projectId) =>
+        await new VerifyCS.Test
         {
-            return solution.WithProjectParseOptions(projectId, new CSharpParseOptions(languageVersion: LanguageVersion.CSharp9));
-        });
-
-        context.TestCode = input;
-        context.FixedCode = output;
-
-        await context.RunAsync();
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net60.WithPackages(ImmutableArray.Create(new PackageIdentity("MessagePack", "2.0.335"))),
+            CompilerDiagnostics = CompilerDiagnostics.Errors,
+            SolutionTransforms =
+            {
+                static (solution, projectId) =>
+                {
+                    return solution.WithProjectParseOptions(projectId, new CSharpParseOptions(languageVersion: LanguageVersion.CSharp11));
+                },
+            },
+            TestCode = input,
+            FixedCode = output,
+        }.RunAsync();
     }
 
     [Fact]
@@ -246,17 +247,19 @@ public record Foo(
 
         string output = input; // No fix for this
 
-        var context = new CSharpCodeFixTest<MessagePackAnalyzer.MessagePackAnalyzer, MessagePackAnalyzer.MessagePackCodeFixProvider, DefaultVerifier>();
-        context.ReferenceAssemblies = ReferenceAssemblies.Net.Net60.WithPackages(ImmutableArray.Create(new PackageIdentity("MessagePack", "2.0.335")));
-        context.CompilerDiagnostics = CompilerDiagnostics.Errors;
-        context.SolutionTransforms.Add(static (solution, projectId) =>
+        await new VerifyCS.Test
         {
-            return solution.WithProjectParseOptions(projectId, new CSharpParseOptions(languageVersion: LanguageVersion.CSharp11));
-        });
-
-        context.TestCode = input;
-        context.FixedCode = output;
-
-        await context.RunAsync();
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net60.WithPackages(ImmutableArray.Create(new PackageIdentity("MessagePack", "2.0.335"))),
+            CompilerDiagnostics = CompilerDiagnostics.Errors,
+            SolutionTransforms =
+            {
+                static (solution, projectId) =>
+                {
+                    return solution.WithProjectParseOptions(projectId, new CSharpParseOptions(languageVersion: LanguageVersion.CSharp11));
+                },
+            },
+            TestCode = input,
+            FixedCode = output,
+        }.RunAsync();
     }
 }

--- a/tests/MessagePackAnalyzer.Tests/MessagePackAnalyzerTests.cs
+++ b/tests/MessagePackAnalyzer.Tests/MessagePackAnalyzerTests.cs
@@ -245,7 +245,12 @@ public record Foo(
     string {|MsgPack004:Member2|});
 ";
 
-        string output = input; // No fix for this
+        string output = Preamble + /* lang=c#-test */ @"
+[MessagePackObject]
+public record Foo(
+    [property: Key(0)] string {|MsgPack004:Member1|},
+    [property: Key(1)] string {|MsgPack004:Member2|});
+";
 
         await new VerifyCS.Test
         {


### PR DESCRIPTION
Fixes #1924 

Added corresponding tests.

Note: For records with a primary constructor we do not generate a code fix at the moment, since we can not specify the target  of the generated attribute (since  [AttributeSyntax.WithTarget](https://learn.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.visualbasic.syntax.attributesyntax.withtarget?view=roslyn-dotnet-4.7.0) is missing).