### PR TITLE
Honor key name overrides in source-generated formatters

### DIFF
--- a/src/MessagePack.Annotations/Attributes.cs
+++ b/src/MessagePack.Annotations/Attributes.cs
@@ -14,7 +14,7 @@ namespace MessagePack
         /// <summary>
         /// Gets a value indicating whether to automatically serialize all internal and public fields and properties using their property name as the key in a map.
         /// </summary>
-        public bool KeyAsPropertyName { get; private set; }
+        public bool KeyAsPropertyName { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MessagePackObjectAttribute"/> class.
@@ -46,9 +46,9 @@ namespace MessagePack
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
     public class KeyAttribute : Attribute
     {
-        public int? IntKey { get; private set; }
+        public int? IntKey { get; }
 
-        public string? StringKey { get; private set; }
+        public string? StringKey { get; }
 
         public KeyAttribute(int x)
         {
@@ -72,12 +72,12 @@ namespace MessagePack
         /// <summary>
         /// Gets the distinguishing value that identifies a particular subtype.
         /// </summary>
-        public int Key { get; private set; }
+        public int Key { get; }
 
         /// <summary>
         /// Gets the derived or implementing type.
         /// </summary>
-        public Type SubType { get; private set; }
+        public Type SubType { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UnionAttribute"/> class.
@@ -110,9 +110,9 @@ namespace MessagePack
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface | AttributeTargets.Enum | AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter | AttributeTargets.ReturnValue, AllowMultiple = false, Inherited = true)]
     public class MessagePackFormatterAttribute : Attribute
     {
-        public Type FormatterType { get; private set; }
+        public Type FormatterType { get; }
 
-        public object?[]? Arguments { get; private set; }
+        public object?[]? Arguments { get; }
 
         public MessagePackFormatterAttribute(Type formatterType)
         {

--- a/tests/MessagePack.SourceGenerator.MapModeExecutionTests/StringKeyOverrideTests.cs
+++ b/tests/MessagePack.SourceGenerator.MapModeExecutionTests/StringKeyOverrideTests.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+public class StringKeyOverrideTests(ITestOutputHelper logger)
+{
+    [Fact]
+    public void KeyOnSettableProperty()
+    {
+        SettableProperty original = new() { TheMessage = "hi" };
+        var deserialized = AssertSerializedName(original);
+        Assert.Equal(original.TheMessage, deserialized.TheMessage);
+    }
+
+    [Fact]
+    public void KeyOnReadOnlyProperty()
+    {
+        ReadOnlyProperty original = new("hi");
+        var deserialized = AssertSerializedName(original);
+        Assert.Equal(original.TheMessage, deserialized.TheMessage);
+    }
+
+    [Fact]
+    public void KeyOnReadOnlyField()
+    {
+        ReadOnlyField original = new("hi");
+        var deserialized = AssertSerializedName(original);
+        Assert.Equal(original.TheMessage, deserialized.TheMessage);
+    }
+
+    [Fact]
+    public void KeyOnSettableField()
+    {
+        SettableField original = new() { TheMessage = "hi" };
+        var deserialized = AssertSerializedName(original);
+        Assert.Equal(original.TheMessage, deserialized.TheMessage);
+    }
+
+    private T AssertSerializedName<T>(T value)
+    {
+        byte[] msgpack = MessagePackSerializer.Serialize(value, MessagePackSerializerOptions.Standard);
+
+        logger.WriteLine(MessagePackSerializer.ConvertToJson(msgpack));
+
+        MessagePackReader reader = new(msgpack);
+        Assert.Equal(1, reader.ReadMapHeader());
+        Assert.Equal("message", reader.ReadString());
+        return MessagePackSerializer.Deserialize<T>(msgpack, MessagePackSerializerOptions.Standard);
+    }
+
+    [MessagePackObject]
+    public struct ReadOnlyProperty
+    {
+        [Key("message")]
+        public string TheMessage { get; }
+
+        [SerializationConstructor]
+        public ReadOnlyProperty(string theMessage) => this.TheMessage = theMessage;
+    }
+
+    [MessagePackObject]
+    public struct SettableProperty
+    {
+        [Key("message")]
+        public string TheMessage { get; set; }
+    }
+
+    [MessagePackObject]
+    public struct ReadOnlyField
+    {
+        [Key("message")]
+        public readonly string TheMessage;
+
+        [SerializationConstructor]
+        public ReadOnlyField(string theMessage) => this.TheMessage = theMessage;
+    }
+
+    [MessagePackObject]
+    public struct SettableField
+    {
+        [Key("message")]
+        public string TheMessage;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/MessagePack-CSharp/MessagePack-CSharp/issues/1955