### PR TITLE
Fix detecting duplicate keys

### DIFF
--- a/src/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1753,8 +1753,8 @@ namespace MessagePack.Internal
                         if (member.PropertyInfo is not null && conflictingMember.PropertyInfo is not null
                             && member.PropertyInfo.Name == conflictingMember.PropertyInfo.Name)
                         {
-                            // Implicit interface implementations of get/set methods are marked 'virtual final'
-                            // Therefore an overridable property should be 'IsVirtual == true && IsFinal == false'
+                            // According to MethodBase.IsVirtual docs an overridable property should be 'IsVirtual == true && IsFinal == false'.
+                            // Property methods can be marked 'virtual final' in case of 'sealed override' or when implementing interface implicitly.
                             var isGetMethodOverridable = (conflictingMember.PropertyInfo.GetMethod?.IsVirtual ?? false) && !(conflictingMember.PropertyInfo.GetMethod?.IsFinal ?? false);
                             var isSetMethodOverridable = (conflictingMember.PropertyInfo.SetMethod?.IsVirtual ?? false) && !(conflictingMember.PropertyInfo.SetMethod?.IsFinal ?? false);
                             if (isGetMethodOverridable || isSetMethodOverridable)

--- a/src/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1750,9 +1750,17 @@ namespace MessagePack.Internal
                     if (isIntKeyMode ? intMembers.TryGetValue(member.IntKey, out var conflictingMember) : stringMembers.TryGetValue(member.StringKey!, out conflictingMember))
                     {
                         // Quietly skip duplicate if this is an override property.
-                        if (member.PropertyInfo != null && ((conflictingMember.PropertyInfo?.SetMethod?.IsVirtual ?? false) || (conflictingMember.PropertyInfo?.GetMethod?.IsVirtual ?? false)))
+                        if (member.PropertyInfo is not null && conflictingMember.PropertyInfo is not null
+                            && member.PropertyInfo.Name == conflictingMember.PropertyInfo.Name)
                         {
-                            return false;
+                            // Implicit interface implementations of get/set methods are marked 'virtual final'
+                            // Therefore an overridable property should be 'IsVirtual == true && IsFinal == false'
+                            var isGetMethodOverridable = (conflictingMember.PropertyInfo.GetMethod?.IsVirtual ?? false) && !(conflictingMember.PropertyInfo.GetMethod?.IsFinal ?? false);
+                            var isSetMethodOverridable = (conflictingMember.PropertyInfo.SetMethod?.IsVirtual ?? false) && !(conflictingMember.PropertyInfo.SetMethod?.IsFinal ?? false);
+                            if (isGetMethodOverridable || isSetMethodOverridable)
+                            {
+                                return false;
+                            }
                         }
 
                         var memberInfo = (MemberInfo?)member.PropertyInfo ?? member.FieldInfo;

--- a/tests/MessagePack.Tests/DynamicObjectResolverDuplicateKeyTests.cs
+++ b/tests/MessagePack.Tests/DynamicObjectResolverDuplicateKeyTests.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Runtime.Serialization;
+using MessagePack.Resolvers;
+using Xunit;
+
+namespace MessagePack.Tests
+{
+    public class DynamicObjectResolverDuplicateKeyTests : TestBase
+    {
+        [Fact]
+        public void TestPlainType()
+        {
+            AssertDetectsDuplicateKey<Request_IntKey>();
+            AssertDetectsDuplicateKey<Request_StringKey>();
+            AssertDetectsDuplicateKey<Request_IntKey_DataContract>();
+            AssertDetectsDuplicateKey<Request_StringKey_DataContract>();
+        }
+
+        [Fact]
+        public void TestTypeWithInterface()
+        {
+            // Implicit interface implementation property methods have IsVirtual == True && IsFinal == True
+            AssertDetectsDuplicateKey<RequestWithInterface_IntKey>();
+            AssertDetectsDuplicateKey<RequestWithInterface_StringKey>();
+            AssertDetectsDuplicateKey<RequestWithInterface_IntKey_DataContract>();
+            AssertDetectsDuplicateKey<RequestWithInterface_StringKey_DataContract>();
+        }
+
+        [Fact]
+        public void TestTypeWithVirtualProps()
+        {
+            AssertDetectsDuplicateKey<RequestWithVirtualProps_IntKey>();
+            AssertDetectsDuplicateKey<RequestWithVirtualProps_StringKey>();
+            AssertDetectsDuplicateKey<RequestWithVirtualProps_IntKey_DataContract>();
+            AssertDetectsDuplicateKey<RequestWithVirtualProps_StringKey_DataContract>();
+        }
+
+        private static void AssertDetectsDuplicateKey<T>()
+        {
+            var resolver = StandardResolver.Instance;
+            var ex = Assert.Throws<TypeInitializationException>(resolver.GetFormatterWithVerify<T>);
+            Assert.Contains("duplicated", ex.InnerException.Message);
+        }
+
+        [MessagePackObject]
+        public class Request_IntKey
+        {
+            [Key(1)]
+            public string Id { get; set; }
+
+            [Key(1)]
+            public string ClientIp { get; set; }
+        }
+
+        [MessagePackObject]
+        public class Request_StringKey
+        {
+            [Key("1")]
+            public string Id { get; set; }
+
+            [Key("1")]
+            public string ClientIp { get; set; }
+        }
+
+        [DataContract]
+        public class Request_IntKey_DataContract
+        {
+            [DataMember(Order = 1)]
+            public string Id { get; set; }
+
+            [DataMember(Order = 1)]
+            public string ClientIp { get; set; }
+        }
+
+        [DataContract]
+        public class Request_StringKey_DataContract
+        {
+            [DataMember(Name = "1")]
+            public string Id { get; set; }
+
+            [DataMember(Name = "1")]
+            public string ClientIp { get; set; }
+        }
+
+        public interface IRequest
+        {
+            public string Id { get; set; }
+
+            public string ClientIp { get; set; }
+        }
+
+        [MessagePackObject]
+        public class RequestWithInterface_IntKey : IRequest
+        {
+            [Key(1)]
+            public string Id { get; set; }
+
+            [Key(1)]
+            public string ClientIp { get; set; }
+        }
+
+        [MessagePackObject]
+        public class RequestWithInterface_StringKey : IRequest
+        {
+            [Key("1")]
+            public string Id { get; set; }
+
+            [Key("1")]
+            public string ClientIp { get; set; }
+        }
+
+        [DataContract]
+        public class RequestWithInterface_IntKey_DataContract : IRequest
+        {
+            [DataMember(Order = 1)]
+            public string Id { get; set; }
+
+            [DataMember(Order = 1)]
+            public string ClientIp { get; set; }
+        }
+
+        [DataContract]
+        public class RequestWithInterface_StringKey_DataContract : IRequest
+        {
+            [DataMember(Name = "1")]
+            public string Id { get; set; }
+
+            [DataMember(Name = "1")]
+            public string ClientIp { get; set; }
+        }
+
+        [MessagePackObject]
+        public class RequestWithVirtualProps_IntKey
+        {
+            [Key(1)]
+            public virtual string Id { get; set; }
+
+            [Key(1)]
+            public virtual string ClientIp { get; set; }
+        }
+
+        [MessagePackObject]
+        public class RequestWithVirtualProps_StringKey
+        {
+            [Key("1")]
+            public virtual string Id { get; set; }
+
+            [Key("1")]
+            public virtual string ClientIp { get; set; }
+        }
+
+        [DataContract]
+        public class RequestWithVirtualProps_IntKey_DataContract
+        {
+            [DataMember(Order = 1)]
+            public virtual string Id { get; set; }
+
+            [DataMember(Order = 1)]
+            public virtual string ClientIp { get; set; }
+        }
+
+        [DataContract]
+        public class RequestWithVirtualProps_StringKey_DataContract
+        {
+            [DataMember(Name = "1")]
+            public virtual string Id { get; set; }
+
+            [DataMember(Name = "1")]
+            public virtual string ClientIp { get; set; }
+        }
+    }
+}

--- a/tests/MessagePack.Tests/DynamicObjectResolverDuplicateKeyTests.cs
+++ b/tests/MessagePack.Tests/DynamicObjectResolverDuplicateKeyTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Runtime.Serialization;
 using MessagePack.Resolvers;
 using Xunit;


### PR DESCRIPTION
Runtime code generation doesn't detect duplicate keys for properties with virtual attribute. Seems like issue was introduced in #1083. This issue can be reproduced on both `v2.5` and `v3`.
For types attributed with `[MessagePackObject]` this issue is covered by analyzer which prevents duplicate keys. However if there is no reference to analyzer or `[DataContract]` attribute is used, then duplicate keys will be not detected.
```cs
[MessagePackObject]
public class Request2
{
    [Key(1)]
    public virtual string Id { get; set; }

    [Key(1)]
    public virtual string ClientIp { get; set; }
}
```
It can be very confusing when you use interfaces. As CLR requires interface implementations to be marked as `virtual`. See [MethodBase.IsVirtual](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.methodbase.isvirtual) remarks.
```cs
public interface IRequest
{
    public string Id { get; set; }

    public string ClientIp { get; set; }
}

[MessagePackObject]
public class Request1 : IRequest
{
    [Key(1)]
    public string Id { get; set; }

    [Key(1)]
    public string ClientIp { get; set; }
}
```