### PR TITLE
Update DynamicAssembly usage to honor different AssemblyLoadContext's

### DIFF
--- a/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
+++ b/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
@@ -52,6 +52,9 @@
     <Compile Include="..\..\src\MessagePack\Internal\DynamicAssembly.cs">
       <Link>Code\DynamicAssembly.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\MessagePack\Internal\DynamicAssemblyFactory.cs">
+      <Link>Code\DynamicAssemblyFactory.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\MessagePack\Internal\ExpressionUtility.cs">
       <Link>Code\ExpressionUtility.cs</Link>
     </Compile>

--- a/src/MessagePack/Internal/DynamicAssembly.cs
+++ b/src/MessagePack/Internal/DynamicAssembly.cs
@@ -24,6 +24,11 @@ namespace MessagePack.Internal
         // don't expose ModuleBuilder
         //// public ModuleBuilder ModuleBuilder { get { return moduleBuilder; } }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicAssembly"/> class.
+        /// Please use <see cref="DynamicAssemblyFactory"/> instead in order to work across different AssemblyLoadContext that may have duplicate modules.
+        /// </summary>
+        /// <param name="moduleName">Name of the module to be generated.</param>
         public DynamicAssembly(string moduleName)
         {
 #if NETFRAMEWORK // We don't ship a net472 target, but we might add one for debugging purposes

--- a/src/MessagePack/Internal/DynamicAssemblyFactory.cs
+++ b/src/MessagePack/Internal/DynamicAssemblyFactory.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+#if NET6_0_OR_GREATER
+using System.Runtime.Loader;
+#endif
+
+namespace MessagePack.Internal
+{
+    /// <summary>
+    /// This class is responsible for managing DynamicAssembly instance creation taking into account
+    /// AssemblyLoadContext when running under .Net.
+    /// </summary>
+    internal class DynamicAssemblyFactory
+    {
+        private readonly string moduleName;
+
+        private Lazy<DynamicAssembly> singletonAssembly;
+
+#if NET6_0_OR_GREATER
+        private Dictionary<AssemblyLoadContext, DynamicAssembly> alcCache;
+#endif
+
+        public DynamicAssemblyFactory(string moduleName)
+        {
+            this.moduleName = moduleName;
+            this.singletonAssembly = new Lazy<DynamicAssembly>(() => new DynamicAssembly(this.moduleName));
+
+#if NET6_0_OR_GREATER
+            this.alcCache = new Dictionary<AssemblyLoadContext, DynamicAssembly>();
+#endif
+        }
+
+#if NET6_0_OR_GREATER
+        public DynamicAssembly GetDynamicAssembly(Type? type)
+        {
+            if (type is null || AssemblyLoadContext.GetLoadContext(type.Assembly) is not AssemblyLoadContext loadContext)
+            {
+                return this.singletonAssembly.Value;
+            }
+            else
+            {
+                DynamicAssembly? assembly = null;
+                lock (alcCache)
+                {
+                    if (!this.alcCache.TryGetValue(loadContext, out assembly))
+                    {
+                        assembly = new DynamicAssembly(this.moduleName);
+                        this.alcCache[loadContext] = assembly;
+                    }
+
+                    return assembly;
+                }
+            }
+        }
+#else
+        public DynamicAssembly GetDynamicAssembly(Type? type)
+        {
+            return this.singletonAssembly.Value;
+        }
+#endif
+    }
+}

--- a/src/MessagePack/Internal/DynamicAssemblyFactory.cs
+++ b/src/MessagePack/Internal/DynamicAssemblyFactory.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 
-#if NET6_0_OR_GREATER
+#if NET
 using System.Runtime.Loader;
 #endif
 
@@ -13,29 +13,25 @@ namespace MessagePack.Internal
 {
     /// <summary>
     /// This class is responsible for managing DynamicAssembly instance creation taking into account
-    /// AssemblyLoadContext when running under .Net.
+    /// AssemblyLoadContext when running under .NET.
     /// </summary>
     internal class DynamicAssemblyFactory
     {
         private readonly string moduleName;
 
-        private Lazy<DynamicAssembly> singletonAssembly;
+        private readonly Lazy<DynamicAssembly> singletonAssembly;
 
-#if NET6_0_OR_GREATER
-        private Dictionary<AssemblyLoadContext, DynamicAssembly> alcCache;
+#if NET
+        private readonly Dictionary<AssemblyLoadContext, DynamicAssembly> alcCache = new();
 #endif
 
         public DynamicAssemblyFactory(string moduleName)
         {
             this.moduleName = moduleName;
             this.singletonAssembly = new Lazy<DynamicAssembly>(() => new DynamicAssembly(this.moduleName));
-
-#if NET6_0_OR_GREATER
-            this.alcCache = new Dictionary<AssemblyLoadContext, DynamicAssembly>();
-#endif
         }
 
-#if NET6_0_OR_GREATER
+#if NET
         public DynamicAssembly GetDynamicAssembly(Type? type)
         {
             if (type is null || AssemblyLoadContext.GetLoadContext(type.Assembly) is not AssemblyLoadContext loadContext)
@@ -45,7 +41,7 @@ namespace MessagePack.Internal
             else
             {
                 DynamicAssembly? assembly = null;
-                lock (alcCache)
+                lock (this.alcCache)
                 {
                     if (!this.alcCache.TryGetValue(loadContext, out assembly))
                     {

--- a/src/MessagePack/Resolvers/DynamicEnumResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicEnumResolver.cs
@@ -23,7 +23,7 @@ namespace MessagePack.Resolvers
 
         private const string ModuleName = "MessagePack.Resolvers.DynamicEnumResolver";
 
-        private static readonly Lazy<DynamicAssembly> DynamicAssembly;
+        private static readonly DynamicAssemblyFactory DynamicAssemblyFactory;
 
         private static int nameSequence = 0;
 
@@ -33,13 +33,13 @@ namespace MessagePack.Resolvers
 
         static DynamicEnumResolver()
         {
-            DynamicAssembly = new Lazy<DynamicAssembly>(() => new DynamicAssembly(ModuleName));
+            DynamicAssemblyFactory = new DynamicAssemblyFactory(ModuleName);
         }
 
 #if NETFRAMEWORK
         internal AssemblyBuilder Save()
         {
-            return DynamicAssembly.Value.Save();
+            return DynamicAssemblyFactory.GetDynamicAssembly(type: null).Save();
         }
 #endif
 
@@ -93,7 +93,7 @@ namespace MessagePack.Resolvers
             {
                 using (MonoProtection.EnterRefEmitLock())
                 {
-                    TypeBuilder typeBuilder = DynamicAssembly.Value.DefineType("MessagePack.Formatters." + enumType.FullName!.Replace(".", "_") + "Formatter" + Interlocked.Increment(ref nameSequence), TypeAttributes.Public | TypeAttributes.Sealed, null, new[] { formatterType });
+                    TypeBuilder typeBuilder = DynamicAssemblyFactory.GetDynamicAssembly(enumType).DefineType("MessagePack.Formatters." + enumType.FullName!.Replace(".", "_") + "Formatter" + Interlocked.Increment(ref nameSequence), TypeAttributes.Public | TypeAttributes.Sealed, null, new[] { formatterType });
 
                     // void Serialize(ref MessagePackWriter writer, T value, MessagePackSerializerOptions options);
                     {

--- a/src/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -36,13 +36,13 @@ namespace MessagePack.Resolvers
         /// </summary>
         public static readonly MessagePackSerializerOptions Options;
 
-        internal static readonly Lazy<DynamicAssembly> DynamicAssembly;
+        internal static readonly DynamicAssemblyFactory DynamicAssemblyFactory;
 
         static DynamicObjectResolver()
         {
             Instance = new DynamicObjectResolver();
             Options = new MessagePackSerializerOptions(Instance);
-            DynamicAssembly = new Lazy<DynamicAssembly>(() => new DynamicAssembly(ModuleName));
+            DynamicAssemblyFactory = new DynamicAssemblyFactory(ModuleName);
         }
 
         private DynamicObjectResolver()
@@ -52,7 +52,7 @@ namespace MessagePack.Resolvers
 #if NETFRAMEWORK
         internal AssemblyBuilder Save()
         {
-            return DynamicAssembly.Value.Save();
+            return DynamicAssemblyFactory.GetDynamicAssembly(type: null).Save();
         }
 #endif
 
@@ -97,7 +97,7 @@ namespace MessagePack.Resolvers
                 TypeInfo? formatterTypeInfo;
                 try
                 {
-                    formatterTypeInfo = DynamicObjectTypeBuilder.BuildType(DynamicAssembly.Value, typeof(T), false, false);
+                    formatterTypeInfo = DynamicObjectTypeBuilder.BuildType(DynamicAssemblyFactory.GetDynamicAssembly(typeof(T)), typeof(T), false, false);
                 }
                 catch (InitAccessorInGenericClassNotSupportedException)
                 {
@@ -179,7 +179,7 @@ namespace MessagePack.Resolvers
 
         private const string ModuleName = "MessagePack.Resolvers.DynamicContractlessObjectResolver";
 
-        private static readonly Lazy<DynamicAssembly> DynamicAssembly;
+        private static readonly DynamicAssemblyFactory DynamicAssemblyFactory;
 
         private DynamicContractlessObjectResolver()
         {
@@ -187,13 +187,13 @@ namespace MessagePack.Resolvers
 
         static DynamicContractlessObjectResolver()
         {
-            DynamicAssembly = new Lazy<DynamicAssembly>(() => new DynamicAssembly(ModuleName));
+            DynamicAssemblyFactory = new DynamicAssemblyFactory(ModuleName);
         }
 
 #if NETFRAMEWORK
         internal AssemblyBuilder Save()
         {
-            return DynamicAssembly.Value.Save();
+            return DynamicAssemblyFactory.GetDynamicAssembly(type: null).Save();
         }
 #endif
 
@@ -240,7 +240,7 @@ namespace MessagePack.Resolvers
                     return;
                 }
 
-                TypeInfo? formatterTypeInfo = DynamicObjectTypeBuilder.BuildType(DynamicAssembly.Value, typeof(T), true, true);
+                TypeInfo? formatterTypeInfo = DynamicObjectTypeBuilder.BuildType(DynamicAssemblyFactory.GetDynamicAssembly(typeof(T)), typeof(T), true, true);
                 if (formatterTypeInfo == null)
                 {
                     return;

--- a/src/MessagePack/Resolvers/DynamicUnionResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicUnionResolver.cs
@@ -35,7 +35,7 @@ namespace MessagePack.Resolvers
         /// </summary>
         public static readonly MessagePackSerializerOptions Options;
 
-        private static readonly Lazy<DynamicAssembly> DynamicAssembly;
+        private static readonly DynamicAssemblyFactory DynamicAssemblyFactory;
 
         private static int nameSequence = 0;
 
@@ -43,7 +43,7 @@ namespace MessagePack.Resolvers
         {
             Instance = new DynamicUnionResolver();
             Options = new MessagePackSerializerOptions(Instance);
-            DynamicAssembly = new Lazy<DynamicAssembly>(() => new DynamicAssembly(ModuleName));
+            DynamicAssemblyFactory = new DynamicAssemblyFactory(ModuleName);
         }
 
         private DynamicUnionResolver()
@@ -53,7 +53,7 @@ namespace MessagePack.Resolvers
 #if NETFRAMEWORK
         internal AssemblyBuilder Save()
         {
-            return DynamicAssembly.Value.Save();
+            return DynamicAssemblyFactory.GetDynamicAssembly(type: null).Save();
         }
 #endif
 
@@ -131,7 +131,7 @@ namespace MessagePack.Resolvers
                 Type formatterType = typeof(IMessagePackFormatter<>).MakeGenericType(type);
                 using (MonoProtection.EnterRefEmitLock())
                 {
-                    TypeBuilder typeBuilder = DynamicAssembly.Value.DefineType("MessagePack.Formatters." + DynamicObjectTypeBuilder.SubtractFullNameRegex.Replace(type.FullName!, string.Empty).Replace(".", "_") + "Formatter" + +Interlocked.Increment(ref nameSequence), TypeAttributes.Public | TypeAttributes.Sealed, null, new[] { formatterType });
+                    TypeBuilder typeBuilder = DynamicAssemblyFactory.GetDynamicAssembly(type).DefineType("MessagePack.Formatters." + DynamicObjectTypeBuilder.SubtractFullNameRegex.Replace(type.FullName!, string.Empty).Replace(".", "_") + "Formatter" + +Interlocked.Increment(ref nameSequence), TypeAttributes.Public | TypeAttributes.Sealed, null, new[] { formatterType });
 
                     FieldBuilder? typeToKeyAndJumpMap = null; // Dictionary<RuntimeTypeHandle, KeyValuePair<int, int>>
                     FieldBuilder? keyToJumpMap = null; // Dictionary<int, int>

--- a/tests/MessagePack.Tests/AssemblyLoadContextTests.cs
+++ b/tests/MessagePack.Tests/AssemblyLoadContextTests.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NET6_0_OR_GREATER
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Text;
+using System.Threading.Tasks;
+using ComplexdUnion;
+using MessagePack;
+using MessagePack.Formatters;
+using MessagePack.Resolvers;
+using SharedData;
+using Xunit;
+
+#pragma warning disable SA1302 // Interface names should begin with I
+#pragma warning disable SA1403 // File may only contain a single namespace
+
+namespace MessagePack.Tests
+{
+    public class AssemblyLoadContextTests : IDisposable
+    {
+        private readonly AssemblyLoadContext loadContext;
+        private readonly Stream sharedAssemblyStream;
+
+        public AssemblyLoadContextTests()
+        {
+            this.loadContext = new AssemblyLoadContext("TestContext", isCollectible: true);
+            this.sharedAssemblyStream = this.GetSharedDataAssemblyStream();
+        }
+
+        public void Dispose()
+        {
+            this.loadContext.Unload();
+            this.sharedAssemblyStream.Dispose();
+        }
+
+        [Fact]
+        public void DynamicUnionResolverWorksAcrossAssemblyLoadContexts()
+        {
+            RootUnionType unionTypeInMainLoadContext = new SubUnionType1();
+            var options = this.CreateSerializerOptions();
+
+            var buffer1 = MessagePackSerializer.Serialize(unionTypeInMainLoadContext, options: options);
+            var o1 = MessagePackSerializer.Deserialize<RootUnionType>(buffer1, options: options);
+
+            Assert.True(o1 is SubUnionType1);
+
+            var assembly = this.loadContext.LoadFromStream(sharedAssemblyStream);
+            object unionTypeInOtherContext = assembly.CreateInstance(typeof(SubUnionType1).FullName);
+            Type rootUnionType = assembly.GetType(typeof(RootUnionType).FullName);
+
+            var buffer2 = MessagePackSerializer.Serialize(rootUnionType, unionTypeInOtherContext, options: options);
+            var o2 = MessagePackSerializer.Deserialize(rootUnionType, buffer2, options: options);
+
+            Assert.True(o2.GetType().IsAssignableTo(rootUnionType));
+        }
+
+        [Fact]
+        public void DynamicEnumResolverWorksAcrossAssemblyLoadContexts()
+        {
+            ByteEnum e1 = ByteEnum.A;
+            var options = this.CreateSerializerOptions();
+
+            var b1 = MessagePackSerializer.Serialize(e1, options: options);
+            var o1 = MessagePackSerializer.Deserialize<ByteEnum>(b1, options: options);
+
+            Assert.Equal(typeof(ByteEnum), o1.GetType());
+
+            var assembly = this.loadContext.LoadFromStream(sharedAssemblyStream);
+            Type enumType = assembly.GetType(typeof(ByteEnum).FullName);
+            object e2 = Enum.GetValues(enumType).GetValue(1);
+
+            var b2 = MessagePackSerializer.Serialize(enumType, e2, options: options);
+            var o2 = MessagePackSerializer.Deserialize(enumType, b2, options: options);
+
+            Assert.Equal(o2.GetType(), e2.GetType());
+        }
+
+        [Fact]
+        public void DynamicObjectResolverWorksAcrossAssemblyLoadContexts()
+        {
+            FirstSimpleData e1 = new FirstSimpleData();
+            var options = this.CreateSerializerOptions();
+
+            var b1 = MessagePackSerializer.Serialize(e1, options: options);
+            var o1 = MessagePackSerializer.Deserialize<FirstSimpleData>(b1, options: options);
+
+            Assert.Equal(typeof(FirstSimpleData), o1.GetType());
+
+            var assembly = this.loadContext.LoadFromStream(sharedAssemblyStream);
+            Type objectType = assembly.GetType(typeof(FirstSimpleData).FullName);
+            object e2 = assembly.CreateInstance(typeof(FirstSimpleData).FullName);
+
+            var b2 = MessagePackSerializer.Serialize(objectType, e2, options: options);
+            var o2 = MessagePackSerializer.Deserialize(objectType, b2, options: options);
+
+            Assert.Equal(o2.GetType(), e2.GetType());
+        }
+
+        [Fact]
+        public void DynamicContractlessObjectResolverWorksAcrossAssemblyLoadContexts()
+        {
+            FirstSimpleData e1 = new FirstSimpleData();
+            var options = new MessagePackSerializerOptions(
+                CompositeResolver.Create(
+                    BuiltinResolver.Instance,
+                    PrimitiveObjectResolver.Instance,
+                    DynamicContractlessObjectResolver.Instance));
+
+            var b1 = MessagePackSerializer.Serialize(e1, options: options);
+            var o1 = MessagePackSerializer.Deserialize<FirstSimpleData>(b1, options: options);
+
+            Assert.Equal(typeof(FirstSimpleData), o1.GetType());
+
+            var assembly = this.loadContext.LoadFromStream(sharedAssemblyStream);
+            Type objectType = assembly.GetType(typeof(FirstSimpleData).FullName);
+            object e2 = assembly.CreateInstance(typeof(FirstSimpleData).FullName);
+
+            var b2 = MessagePackSerializer.Serialize(objectType, e2, options: options);
+            var o2 = MessagePackSerializer.Deserialize(objectType, b2, options: options);
+
+            Assert.Equal(o2.GetType(), e2.GetType());
+        }
+
+        private Stream GetSharedDataAssemblyStream()
+        {
+            string assemblyPath = typeof(RootUnionType).Assembly.Location;
+            MemoryStream stream = new MemoryStream();
+            using (var sourceStream = File.OpenRead(assemblyPath))
+            {
+                sourceStream.CopyTo(stream);
+            }
+
+            stream.Seek(0, SeekOrigin.Begin);
+            return stream;
+        }
+
+        private MessagePackSerializerOptions CreateSerializerOptions()
+        {
+            // Avoid default options as it will use source generated formatter which works in this scenario.
+            return new MessagePackSerializerOptions(
+                CompositeResolver.Create(
+                    BuiltinResolver.Instance,
+                    AttributeFormatterResolver.Instance,
+                    DynamicEnumResolver.Instance,
+                    DynamicGenericResolver.Instance,
+                    DynamicUnionResolver.Instance,
+                    DynamicObjectResolver.Instance,
+                    PrimitiveObjectResolver.Instance));
+        }
+    }
+}
+
+#endif

--- a/tests/MessagePack.Tests/AssemblyLoadContextTests.cs
+++ b/tests/MessagePack.Tests/AssemblyLoadContextTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NET6_0_OR_GREATER
+#if NET
 
 using System;
 using System.Collections.Generic;
@@ -21,139 +21,136 @@ using Xunit;
 #pragma warning disable SA1302 // Interface names should begin with I
 #pragma warning disable SA1403 // File may only contain a single namespace
 
-namespace MessagePack.Tests
+public class AssemblyLoadContextTests : IDisposable
 {
-    public class AssemblyLoadContextTests : IDisposable
+    private readonly AssemblyLoadContext loadContext;
+    private readonly Stream sharedAssemblyStream;
+
+    public AssemblyLoadContextTests()
     {
-        private readonly AssemblyLoadContext loadContext;
-        private readonly Stream sharedAssemblyStream;
+        this.loadContext = new AssemblyLoadContext("TestContext", isCollectible: true);
+        this.sharedAssemblyStream = this.GetSharedDataAssemblyStream();
+    }
 
-        public AssemblyLoadContextTests()
+    public void Dispose()
+    {
+        this.loadContext.Unload();
+        this.sharedAssemblyStream.Dispose();
+    }
+
+    [Fact]
+    public void DynamicUnionResolverWorksAcrossAssemblyLoadContexts()
+    {
+        RootUnionType unionTypeInMainLoadContext = new SubUnionType1();
+        var options = this.CreateSerializerOptions();
+
+        var buffer1 = MessagePackSerializer.Serialize(unionTypeInMainLoadContext, options: options);
+        var o1 = MessagePackSerializer.Deserialize<RootUnionType>(buffer1, options: options);
+
+        Assert.True(o1 is SubUnionType1);
+
+        var assembly = this.loadContext.LoadFromStream(sharedAssemblyStream);
+        object unionTypeInOtherContext = assembly.CreateInstance(typeof(SubUnionType1).FullName);
+        Type rootUnionType = assembly.GetType(typeof(RootUnionType).FullName);
+
+        var buffer2 = MessagePackSerializer.Serialize(rootUnionType, unionTypeInOtherContext, options: options);
+        var o2 = MessagePackSerializer.Deserialize(rootUnionType, buffer2, options: options);
+
+        Assert.True(o2.GetType().IsAssignableTo(rootUnionType));
+    }
+
+    [Fact]
+    public void DynamicEnumResolverWorksAcrossAssemblyLoadContexts()
+    {
+        ByteEnum e1 = ByteEnum.A;
+        var options = this.CreateSerializerOptions();
+
+        var b1 = MessagePackSerializer.Serialize(e1, options: options);
+        var o1 = MessagePackSerializer.Deserialize<ByteEnum>(b1, options: options);
+
+        Assert.Equal(typeof(ByteEnum), o1.GetType());
+
+        var assembly = this.loadContext.LoadFromStream(sharedAssemblyStream);
+        Type enumType = assembly.GetType(typeof(ByteEnum).FullName);
+        object e2 = Enum.GetValues(enumType).GetValue(1);
+
+        var b2 = MessagePackSerializer.Serialize(enumType, e2, options: options);
+        var o2 = MessagePackSerializer.Deserialize(enumType, b2, options: options);
+
+        Assert.Equal(o2.GetType(), e2.GetType());
+    }
+
+    [Fact]
+    public void DynamicObjectResolverWorksAcrossAssemblyLoadContexts()
+    {
+        FirstSimpleData e1 = new FirstSimpleData();
+        var options = this.CreateSerializerOptions();
+
+        var b1 = MessagePackSerializer.Serialize(e1, options: options);
+        var o1 = MessagePackSerializer.Deserialize<FirstSimpleData>(b1, options: options);
+
+        Assert.Equal(typeof(FirstSimpleData), o1.GetType());
+
+        var assembly = this.loadContext.LoadFromStream(sharedAssemblyStream);
+        Type objectType = assembly.GetType(typeof(FirstSimpleData).FullName);
+        object e2 = assembly.CreateInstance(typeof(FirstSimpleData).FullName);
+
+        var b2 = MessagePackSerializer.Serialize(objectType, e2, options: options);
+        var o2 = MessagePackSerializer.Deserialize(objectType, b2, options: options);
+
+        Assert.Equal(o2.GetType(), e2.GetType());
+    }
+
+    [Fact]
+    public void DynamicContractlessObjectResolverWorksAcrossAssemblyLoadContexts()
+    {
+        FirstSimpleData e1 = new FirstSimpleData();
+        var options = new MessagePackSerializerOptions(
+            CompositeResolver.Create(
+                BuiltinResolver.Instance,
+                PrimitiveObjectResolver.Instance,
+                DynamicContractlessObjectResolver.Instance));
+
+        var b1 = MessagePackSerializer.Serialize(e1, options: options);
+        var o1 = MessagePackSerializer.Deserialize<FirstSimpleData>(b1, options: options);
+
+        Assert.Equal(typeof(FirstSimpleData), o1.GetType());
+
+        var assembly = this.loadContext.LoadFromStream(sharedAssemblyStream);
+        Type objectType = assembly.GetType(typeof(FirstSimpleData).FullName);
+        object e2 = assembly.CreateInstance(typeof(FirstSimpleData).FullName);
+
+        var b2 = MessagePackSerializer.Serialize(objectType, e2, options: options);
+        var o2 = MessagePackSerializer.Deserialize(objectType, b2, options: options);
+
+        Assert.Equal(o2.GetType(), e2.GetType());
+    }
+
+    private Stream GetSharedDataAssemblyStream()
+    {
+        string assemblyPath = typeof(RootUnionType).Assembly.Location;
+        MemoryStream stream = new MemoryStream();
+        using (var sourceStream = File.OpenRead(assemblyPath))
         {
-            this.loadContext = new AssemblyLoadContext("TestContext", isCollectible: true);
-            this.sharedAssemblyStream = this.GetSharedDataAssemblyStream();
+            sourceStream.CopyTo(stream);
         }
 
-        public void Dispose()
-        {
-            this.loadContext.Unload();
-            this.sharedAssemblyStream.Dispose();
-        }
+        stream.Seek(0, SeekOrigin.Begin);
+        return stream;
+    }
 
-        [Fact]
-        public void DynamicUnionResolverWorksAcrossAssemblyLoadContexts()
-        {
-            RootUnionType unionTypeInMainLoadContext = new SubUnionType1();
-            var options = this.CreateSerializerOptions();
-
-            var buffer1 = MessagePackSerializer.Serialize(unionTypeInMainLoadContext, options: options);
-            var o1 = MessagePackSerializer.Deserialize<RootUnionType>(buffer1, options: options);
-
-            Assert.True(o1 is SubUnionType1);
-
-            var assembly = this.loadContext.LoadFromStream(sharedAssemblyStream);
-            object unionTypeInOtherContext = assembly.CreateInstance(typeof(SubUnionType1).FullName);
-            Type rootUnionType = assembly.GetType(typeof(RootUnionType).FullName);
-
-            var buffer2 = MessagePackSerializer.Serialize(rootUnionType, unionTypeInOtherContext, options: options);
-            var o2 = MessagePackSerializer.Deserialize(rootUnionType, buffer2, options: options);
-
-            Assert.True(o2.GetType().IsAssignableTo(rootUnionType));
-        }
-
-        [Fact]
-        public void DynamicEnumResolverWorksAcrossAssemblyLoadContexts()
-        {
-            ByteEnum e1 = ByteEnum.A;
-            var options = this.CreateSerializerOptions();
-
-            var b1 = MessagePackSerializer.Serialize(e1, options: options);
-            var o1 = MessagePackSerializer.Deserialize<ByteEnum>(b1, options: options);
-
-            Assert.Equal(typeof(ByteEnum), o1.GetType());
-
-            var assembly = this.loadContext.LoadFromStream(sharedAssemblyStream);
-            Type enumType = assembly.GetType(typeof(ByteEnum).FullName);
-            object e2 = Enum.GetValues(enumType).GetValue(1);
-
-            var b2 = MessagePackSerializer.Serialize(enumType, e2, options: options);
-            var o2 = MessagePackSerializer.Deserialize(enumType, b2, options: options);
-
-            Assert.Equal(o2.GetType(), e2.GetType());
-        }
-
-        [Fact]
-        public void DynamicObjectResolverWorksAcrossAssemblyLoadContexts()
-        {
-            FirstSimpleData e1 = new FirstSimpleData();
-            var options = this.CreateSerializerOptions();
-
-            var b1 = MessagePackSerializer.Serialize(e1, options: options);
-            var o1 = MessagePackSerializer.Deserialize<FirstSimpleData>(b1, options: options);
-
-            Assert.Equal(typeof(FirstSimpleData), o1.GetType());
-
-            var assembly = this.loadContext.LoadFromStream(sharedAssemblyStream);
-            Type objectType = assembly.GetType(typeof(FirstSimpleData).FullName);
-            object e2 = assembly.CreateInstance(typeof(FirstSimpleData).FullName);
-
-            var b2 = MessagePackSerializer.Serialize(objectType, e2, options: options);
-            var o2 = MessagePackSerializer.Deserialize(objectType, b2, options: options);
-
-            Assert.Equal(o2.GetType(), e2.GetType());
-        }
-
-        [Fact]
-        public void DynamicContractlessObjectResolverWorksAcrossAssemblyLoadContexts()
-        {
-            FirstSimpleData e1 = new FirstSimpleData();
-            var options = new MessagePackSerializerOptions(
-                CompositeResolver.Create(
-                    BuiltinResolver.Instance,
-                    PrimitiveObjectResolver.Instance,
-                    DynamicContractlessObjectResolver.Instance));
-
-            var b1 = MessagePackSerializer.Serialize(e1, options: options);
-            var o1 = MessagePackSerializer.Deserialize<FirstSimpleData>(b1, options: options);
-
-            Assert.Equal(typeof(FirstSimpleData), o1.GetType());
-
-            var assembly = this.loadContext.LoadFromStream(sharedAssemblyStream);
-            Type objectType = assembly.GetType(typeof(FirstSimpleData).FullName);
-            object e2 = assembly.CreateInstance(typeof(FirstSimpleData).FullName);
-
-            var b2 = MessagePackSerializer.Serialize(objectType, e2, options: options);
-            var o2 = MessagePackSerializer.Deserialize(objectType, b2, options: options);
-
-            Assert.Equal(o2.GetType(), e2.GetType());
-        }
-
-        private Stream GetSharedDataAssemblyStream()
-        {
-            string assemblyPath = typeof(RootUnionType).Assembly.Location;
-            MemoryStream stream = new MemoryStream();
-            using (var sourceStream = File.OpenRead(assemblyPath))
-            {
-                sourceStream.CopyTo(stream);
-            }
-
-            stream.Seek(0, SeekOrigin.Begin);
-            return stream;
-        }
-
-        private MessagePackSerializerOptions CreateSerializerOptions()
-        {
-            // Avoid default options as it will use source generated formatter which works in this scenario.
-            return new MessagePackSerializerOptions(
-                CompositeResolver.Create(
-                    BuiltinResolver.Instance,
-                    AttributeFormatterResolver.Instance,
-                    DynamicEnumResolver.Instance,
-                    DynamicGenericResolver.Instance,
-                    DynamicUnionResolver.Instance,
-                    DynamicObjectResolver.Instance,
-                    PrimitiveObjectResolver.Instance));
-        }
+    private MessagePackSerializerOptions CreateSerializerOptions()
+    {
+        // Avoid default options as it will use source generated formatter which works in this scenario.
+        return new MessagePackSerializerOptions(
+            CompositeResolver.Create(
+                BuiltinResolver.Instance,
+                AttributeFormatterResolver.Instance,
+                DynamicEnumResolver.Instance,
+                DynamicGenericResolver.Instance,
+                DynamicUnionResolver.Instance,
+                DynamicObjectResolver.Instance,
+                PrimitiveObjectResolver.Instance));
     }
 }
 

--- a/tests/MessagePack.Tests/UnionResolverTest.cs
+++ b/tests/MessagePack.Tests/UnionResolverTest.cs
@@ -4,17 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using ComplexdUnion;
 using MessagePack;
 using SharedData;
 using Xunit;
-
-#if NET6_0_OR_GREATER
-using System.Runtime.Loader;
-#endif
 
 #pragma warning disable SA1302 // Interface names should begin with I
 #pragma warning disable SA1403 // File may only contain a single namespace

--- a/tests/MessagePack.Tests/UnionResolverTest.cs
+++ b/tests/MessagePack.Tests/UnionResolverTest.cs
@@ -4,12 +4,17 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using ComplexdUnion;
 using MessagePack;
 using SharedData;
 using Xunit;
+
+#if NET6_0_OR_GREATER
+using System.Runtime.Loader;
+#endif
 
 #pragma warning disable SA1302 // Interface names should begin with I
 #pragma warning disable SA1403 // File may only contain a single namespace


### PR DESCRIPTION
This change resolves issue #1952 where dynamic resolvers did not work where same assembly in different locations was loaded in different AssemblyLoadContext's.

DynamicAssembly creation now happens per unique AssemblyLoadContext so that types are recognized correctly.