### PR TITLE
Allow trimming of benchmarked frameworks

### DIFF
--- a/sandbox/PerfBenchmarkDotNet/DeserializeBenchmark.cs
+++ b/sandbox/PerfBenchmarkDotNet/DeserializeBenchmark.cs
@@ -96,6 +96,7 @@ namespace PerfBenchmarkDotNet
             return (StringKeySerializerTarget)newmsgpack.MessagePack.MessagePackSerializer.Typeless.Deserialize(typelessWithStringKeyObj);
         }
 
+#if MsgPackCli
         [Benchmark]
         public IntKeySerializerTarget MsgPackCliMap()
         {
@@ -107,7 +108,9 @@ namespace PerfBenchmarkDotNet
         {
             return arrayContext.GetSerializer<IntKeySerializerTarget>().UnpackSingleObject(arrayObj);
         }
+#endif
 
+#if Protobuf
         [Benchmark]
         public IntKeySerializerTarget ProtobufNet()
         {
@@ -116,7 +119,9 @@ namespace PerfBenchmarkDotNet
                 return ProtoBuf.Serializer.Deserialize<IntKeySerializerTarget>(ms);
             }
         }
+#endif
 
+#if Hyperion
         [Benchmark]
         public IntKeySerializerTarget Hyperion()
         {
@@ -125,7 +130,9 @@ namespace PerfBenchmarkDotNet
                 return hyperionSerializer.Deserialize<IntKeySerializerTarget>(ms);
             }
         }
+#endif
 
+#if NewtonsoftJson
         [Benchmark]
         public IntKeySerializerTarget JsonNetString()
         {
@@ -142,7 +149,9 @@ namespace PerfBenchmarkDotNet
                 return jsonSerialzier.Deserialize<IntKeySerializerTarget>(jr);
             }
         }
+#endif
 
+#if Jil
         [Benchmark]
         public IntKeySerializerTarget JilString()
         {
@@ -158,9 +167,6 @@ namespace PerfBenchmarkDotNet
                 return Jil.JSON.Deserialize<IntKeySerializerTarget>(sr);
             }
         }
+#endif
     }
 }
-
-#pragma warning restore SA1200 // Using directives should be placed correctly
-#pragma warning restore SA1403 // File may only contain a single namespace
-

--- a/sandbox/PerfBenchmarkDotNet/Lz4Benchmark.cs
+++ b/sandbox/PerfBenchmarkDotNet/Lz4Benchmark.cs
@@ -53,7 +53,3 @@ namespace PerfBenchmarkDotNet
         public StringKeySerializerTarget2[] DeserializeLz4BlockArray() => MessagePackSerializer.Deserialize<StringKeySerializerTarget2[]>(binLz4ContiguousBlock, lz4ContiguousBlockOptions);
     }
 }
-
-#pragma warning restore SA1200 // Using directives should be placed correctly
-#pragma warning restore SA1403 // File may only contain a single namespace
-

--- a/sandbox/PerfBenchmarkDotNet/Lz4PrimitiveBenchmark.cs
+++ b/sandbox/PerfBenchmarkDotNet/Lz4PrimitiveBenchmark.cs
@@ -50,7 +50,3 @@ namespace PerfBenchmarkDotNet
         public int DeserializeLz4BlockArray() => MessagePackSerializer.Deserialize<int>(binLz4ContiguousBlock, lz4ContiguousBlockOptions);
     }
 }
-
-#pragma warning restore SA1200 // Using directives should be placed correctly
-#pragma warning restore SA1403 // File may only contain a single namespace
-

--- a/sandbox/PerfBenchmarkDotNet/PerfBenchmarkDotNet.csproj
+++ b/sandbox/PerfBenchmarkDotNet/PerfBenchmarkDotNet.csproj
@@ -5,6 +5,22 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
+  <PropertyGroup>
+    <IncludeAll Condition="'$(IncludeAll)'==''">true</IncludeAll>
+    <IncludeJil Condition="'$(IncludeJil)'=='' and '$(IncludeAll)'=='true'">true</IncludeJil>
+    <IncludeMsgPackCli Condition="'$(IncludeMsgPackCli)'=='' and '$(IncludeAll)'=='true'">true</IncludeMsgPackCli>
+    <IncludeProtobuf Condition="'$(IncludeProtobuf)'=='' and '$(IncludeAll)'=='true'">true</IncludeProtobuf>
+    <IncludeZeroFormatter Condition="'$(IncludeZeroFormatter)'=='' and '$(IncludeAll)'=='true'">true</IncludeZeroFormatter>
+    <IncludeNewtonsoftJson Condition="'$(IncludeNewtonsoftJson)'=='' and '$(IncludeAll)'=='true'">true</IncludeNewtonsoftJson>
+    <IncludeHyperion Condition="'$(IncludeHyperion)'=='' and '$(IncludeAll)'=='true'">true</IncludeHyperion>
+
+    <DefineConstants Condition="'$(IncludeJil)'=='true'">$(DefineConstants);Jil</DefineConstants>
+    <DefineConstants Condition="'$(IncludeMsgPackCli)'=='true'">$(DefineConstants);MsgPackCli</DefineConstants>
+    <DefineConstants Condition="'$(IncludeProtobuf)'=='true'">$(DefineConstants);Protobuf</DefineConstants>
+    <DefineConstants Condition="'$(IncludeZeroFormatter)'=='true'">$(DefineConstants);ZeroFormatter</DefineConstants>
+    <DefineConstants Condition="'$(IncludeNewtonsoftJson)'=='true'">$(DefineConstants);NewtonsoftJson</DefineConstants>
+    <DefineConstants Condition="'$(IncludeHyperion)'=='true'">$(DefineConstants);Hyperion</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="MessagePack_1_6_0_3, Version=1.6.0.3, Culture=neutral, PublicKeyToken=b4a0369545f0a1be, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -17,13 +33,11 @@
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" />
     <PackageReference Include="Hyperion" />
     <PackageReference Include="Jil" />
-    <PackageReference Include="MessagePack" VersionOverride="1.4.3" />
     <PackageReference Include="MsgPack.Cli" />
     <PackageReference Include="Nerdbank.Streams" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="protobuf-net" />
     <PackageReference Include="RandomFixtureKit" />
-    <PackageReference Include="Sigil" />
     <PackageReference Include="ZeroFormatter" />
   </ItemGroup>
   <ItemGroup>

--- a/sandbox/PerfBenchmarkDotNet/SerializeBenchmark.cs
+++ b/sandbox/PerfBenchmarkDotNet/SerializeBenchmark.cs
@@ -22,7 +22,7 @@ namespace PerfBenchmarkDotNet
     {
         private static MsgPack.Serialization.SerializationContext mapContext = new MsgPack.Serialization.SerializationContext { SerializationMethod = SerializationMethod.Map };
         private static MsgPack.Serialization.SerializationContext arrayContext = new MsgPack.Serialization.SerializationContext { SerializationMethod = SerializationMethod.Array };
-        private static JsonSerializer jsonSerialzier = new JsonSerializer();
+        private static JsonSerializer jsonSerializer = new JsonSerializer();
         private static Hyperion.Serializer hyperionSerializer = new Hyperion.Serializer();
         private static newmsgpack::MessagePack.IFormatterResolver mpcGenFormatterResolver = new Resolver(new StringKeySerializerTargetFormatter_MpcGeneratedAutomata());
         private static newmsgpack::MessagePack.IFormatterResolver mpcGenDictFormatterResolver = new Resolver(new StringKeySerializerTargetFormatter_MpcGeneratedDictionary());
@@ -59,6 +59,7 @@ namespace PerfBenchmarkDotNet
             return newmsgpack.MessagePack.MessagePackSerializer.Typeless.Serialize(stringData);
         }
 
+#if MsgPackCli
         [Benchmark]
         public byte[] MsgPackCliMap()
         {
@@ -70,7 +71,9 @@ namespace PerfBenchmarkDotNet
         {
             return arrayContext.GetSerializer<IntKeySerializerTarget>().PackSingleObject(intData);
         }
+#endif
 
+#if Protobuf
         [Benchmark]
         public byte[] ProtobufNet()
         {
@@ -80,7 +83,9 @@ namespace PerfBenchmarkDotNet
                 return ms.ToArray();
             }
         }
+#endif
 
+#if Hyperion
         [Benchmark]
         public byte[] Hyperion()
         {
@@ -90,13 +95,17 @@ namespace PerfBenchmarkDotNet
                 return ms.ToArray();
             }
         }
+#endif
 
+#if ZeroFormatter
         [Benchmark]
         public byte[] ZeroFormatter()
         {
             return ZeroFormatterSerializer.Serialize(intData);
         }
+#endif
 
+#if NewtonsoftJson
         [Benchmark]
         public byte[] JsonNetString()
         {
@@ -111,13 +120,15 @@ namespace PerfBenchmarkDotNet
                 using (var sr = new StreamWriter(ms, Encoding.UTF8))
                 using (var jr = new JsonTextWriter(sr))
                 {
-                    jsonSerialzier.Serialize(jr, intData);
+                    jsonSerializer.Serialize(jr, intData);
                 }
 
                 return ms.ToArray();
             }
         }
+#endif
 
+#if Jil
         [Benchmark]
         public byte[] JilString()
         {
@@ -137,6 +148,7 @@ namespace PerfBenchmarkDotNet
                 return ms.ToArray();
             }
         }
+#endif
     }
 }
 

--- a/sandbox/PerfBenchmarkDotNet/TypelessDeserializeBenchmark.cs
+++ b/sandbox/PerfBenchmarkDotNet/TypelessDeserializeBenchmark.cs
@@ -73,7 +73,3 @@ namespace PerfBenchmarkDotNet
         }
     }
 }
-
-#pragma warning restore SA1200 // Using directives should be placed correctly
-#pragma warning restore SA1403 // File may only contain a single namespace
-

--- a/sandbox/PerfNetFramework/README.md
+++ b/sandbox/PerfNetFramework/README.md
@@ -10,7 +10,7 @@ When collecting ETL traces, use these settings in the Collect->Run dialog:
 
 | Setting     | Value |
 |-------------|-------|
-| Command     | `dotnet run -c release -p .\sandbox\PerfNetFramework\ -f net472 --no-build`
+| Command     | `dotnet run -c release --project .\sandbox\PerfNetFramework\ -f net472 --no-build`
 | Current Dir | `d:\git\messagepack-csharp` (or wherever your enlistment is)
 | Additional Providers | `*MessagePack-Benchmark`
 | No V3.X NGen | Checked


### PR DESCRIPTION
This allows the benchmarks to run faster and show just the data that you want.
