### PR TITLE
Fix embedded types being generated in resolver

### DIFF
--- a/src/MessagePack.SourceGenerator/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.SourceGenerator/CodeAnalysis/TypeCollector.cs
@@ -281,14 +281,15 @@ public class TypeCollector
             return result;
         }
 
-        FormattableType formattableType = new(typeSymbol, null);
-        if (formattableType.Name is QualifiedNamedTypeName { Name: string name } && EmbeddedTypes.Contains(name))
+        var typeSymbolString = typeSymbol.WithNullableAnnotation(NullableAnnotation.NotAnnotated).ToString();
+        if (!string.IsNullOrEmpty(typeSymbolString) && EmbeddedTypes.Contains(typeSymbolString))
         {
             result = true;
             this.alreadyCollected.Add(typeSymbol, result);
             return result;
         }
 
+        FormattableType formattableType = new(typeSymbol, null);
         if (this.options.AssumedFormattableTypes.Contains(formattableType) || this.options.AssumedFormattableTypes.Contains(formattableType with { IsFormatterInSameAssembly = true }))
         {
             result = true;

--- a/tests/MessagePack.SourceGenerator.Tests/Resources/Array2DJaggedProperty/MessagePack.GeneratedMessagePackResolver.g.cs
+++ b/tests/MessagePack.SourceGenerator.Tests/Resources/Array2DJaggedProperty/MessagePack.GeneratedMessagePackResolver.g.cs
@@ -39,11 +39,10 @@ partial class GeneratedMessagePackResolver : MsgPack::IFormatterResolver
 
 	private static class GeneratedMessagePackResolverGetFormatterHelper
 	{
-		private static readonly global::System.Collections.Generic.Dictionary<global::System.Type, int> closedTypeLookup = new global::System.Collections.Generic.Dictionary<global::System.Type, int>(3)
+		private static readonly global::System.Collections.Generic.Dictionary<global::System.Type, int> closedTypeLookup = new global::System.Collections.Generic.Dictionary<global::System.Type, int>(2)
 		{
 			{ typeof(global::System.Int32[][]), 0 },
-			{ typeof(global::System.Int32[]), 1 },
-			{ typeof(global::ContainerObject), 2 },
+			{ typeof(global::ContainerObject), 1 },
 		};
 
 		internal static object GetFormatter(global::System.Type t)
@@ -53,8 +52,7 @@ partial class GeneratedMessagePackResolver : MsgPack::IFormatterResolver
 				switch (closedKey)
 				{
 					case 0: return new MsgPack::Formatters.ArrayFormatter<global::System.Int32[]>();
-					case 1: return new MsgPack::Formatters.ArrayFormatter<global::System.Int32>();
-					case 2: return new global::MessagePack.GeneratedMessagePackResolver.ContainerObjectFormatter();
+					case 1: return new global::MessagePack.GeneratedMessagePackResolver.ContainerObjectFormatter();
 					default: return null; // unreachable
 				};
 			}

--- a/tests/MessagePack.SourceGenerator.Tests/Resources/GenericsUnionFormatter/MessagePack.GeneratedMessagePackResolver.g.cs
+++ b/tests/MessagePack.SourceGenerator.Tests/Resources/GenericsUnionFormatter/MessagePack.GeneratedMessagePackResolver.g.cs
@@ -39,13 +39,12 @@ partial class GeneratedMessagePackResolver : MsgPack::IFormatterResolver
 
 	private static class GeneratedMessagePackResolverGetFormatterHelper
 	{
-		private static readonly global::System.Collections.Generic.Dictionary<global::System.Type, int> closedTypeLookup = new global::System.Collections.Generic.Dictionary<global::System.Type, int>(5)
+		private static readonly global::System.Collections.Generic.Dictionary<global::System.Type, int> closedTypeLookup = new global::System.Collections.Generic.Dictionary<global::System.Type, int>(4)
 		{
-			{ typeof(global::System.Int32[]), 0 },
-			{ typeof(global::System.Collections.Generic.IEnumerable<global::System.Guid>), 1 },
-			{ typeof(global::TempProject.Wrapper<global::System.Collections.Generic.IEnumerable<global::System.Guid>>), 2 },
-			{ typeof(global::TempProject.Wrapper<int[]>), 3 },
-			{ typeof(global::TempProject.Wrapper<string>), 4 },
+			{ typeof(global::System.Collections.Generic.IEnumerable<global::System.Guid>), 0 },
+			{ typeof(global::TempProject.Wrapper<global::System.Collections.Generic.IEnumerable<global::System.Guid>>), 1 },
+			{ typeof(global::TempProject.Wrapper<int[]>), 2 },
+			{ typeof(global::TempProject.Wrapper<string>), 3 },
 		};
 		private static readonly global::System.Collections.Generic.Dictionary<global::System.Type, int> openTypeLookup = new global::System.Collections.Generic.Dictionary<global::System.Type, int>(1)
 		{
@@ -58,11 +57,10 @@ partial class GeneratedMessagePackResolver : MsgPack::IFormatterResolver
 			{
 				switch (closedKey)
 				{
-					case 0: return new MsgPack::Formatters.ArrayFormatter<global::System.Int32>();
-					case 1: return new MsgPack::Formatters.InterfaceEnumerableFormatter<global::System.Guid>();
-					case 2: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.WrapperFormatter<global::System.Collections.Generic.IEnumerable<global::System.Guid>>();
-					case 3: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.WrapperFormatter<int[]>();
-					case 4: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.WrapperFormatter<string>();
+					case 0: return new MsgPack::Formatters.InterfaceEnumerableFormatter<global::System.Guid>();
+					case 1: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.WrapperFormatter<global::System.Collections.Generic.IEnumerable<global::System.Guid>>();
+					case 2: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.WrapperFormatter<int[]>();
+					case 3: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.WrapperFormatter<string>();
 					default: return null; // unreachable
 				};
 			}

--- a/tests/MessagePack.SourceGenerator.Tests/Resources/GenericsUnionFormatter_Nested/MessagePack.GeneratedMessagePackResolver.g.cs
+++ b/tests/MessagePack.SourceGenerator.Tests/Resources/GenericsUnionFormatter_Nested/MessagePack.GeneratedMessagePackResolver.g.cs
@@ -39,22 +39,21 @@ partial class GeneratedMessagePackResolver : MsgPack::IFormatterResolver
 
 	private static class GeneratedMessagePackResolverGetFormatterHelper
 	{
-		private static readonly global::System.Collections.Generic.Dictionary<global::System.Type, int> closedTypeLookup = new global::System.Collections.Generic.Dictionary<global::System.Type, int>(14)
+		private static readonly global::System.Collections.Generic.Dictionary<global::System.Type, int> closedTypeLookup = new global::System.Collections.Generic.Dictionary<global::System.Type, int>(13)
 		{
-			{ typeof(global::System.Int32[]), 0 },
-			{ typeof(global::System.Collections.Generic.List<global::System.Collections.Generic.IEnumerable<global::System.Guid>>), 1 },
-			{ typeof(global::System.Collections.Generic.List<int[]>), 2 },
-			{ typeof(global::System.Collections.Generic.List<string>), 3 },
-			{ typeof(global::System.Collections.Generic.IEnumerable<global::System.Guid>), 4 },
-			{ typeof(global::TempProject.MyGenericObject<global::System.Collections.Generic.IEnumerable<global::System.Guid>>), 5 },
-			{ typeof(global::TempProject.MyGenericObject<int[]>), 6 },
-			{ typeof(global::TempProject.MyGenericObject<string>), 7 },
-			{ typeof(global::TempProject.MyInnerGenericObject<global::System.Collections.Generic.IEnumerable<global::System.Guid>>), 8 },
-			{ typeof(global::TempProject.MyInnerGenericObject<int[]>), 9 },
-			{ typeof(global::TempProject.MyInnerGenericObject<string>), 10 },
-			{ typeof(global::TempProject.Wrapper<global::System.Collections.Generic.IEnumerable<global::System.Guid>>), 11 },
-			{ typeof(global::TempProject.Wrapper<int[]>), 12 },
-			{ typeof(global::TempProject.Wrapper<string>), 13 },
+			{ typeof(global::System.Collections.Generic.List<global::System.Collections.Generic.IEnumerable<global::System.Guid>>), 0 },
+			{ typeof(global::System.Collections.Generic.List<int[]>), 1 },
+			{ typeof(global::System.Collections.Generic.List<string>), 2 },
+			{ typeof(global::System.Collections.Generic.IEnumerable<global::System.Guid>), 3 },
+			{ typeof(global::TempProject.MyGenericObject<global::System.Collections.Generic.IEnumerable<global::System.Guid>>), 4 },
+			{ typeof(global::TempProject.MyGenericObject<int[]>), 5 },
+			{ typeof(global::TempProject.MyGenericObject<string>), 6 },
+			{ typeof(global::TempProject.MyInnerGenericObject<global::System.Collections.Generic.IEnumerable<global::System.Guid>>), 7 },
+			{ typeof(global::TempProject.MyInnerGenericObject<int[]>), 8 },
+			{ typeof(global::TempProject.MyInnerGenericObject<string>), 9 },
+			{ typeof(global::TempProject.Wrapper<global::System.Collections.Generic.IEnumerable<global::System.Guid>>), 10 },
+			{ typeof(global::TempProject.Wrapper<int[]>), 11 },
+			{ typeof(global::TempProject.Wrapper<string>), 12 },
 		};
 		private static readonly global::System.Collections.Generic.Dictionary<global::System.Type, int> openTypeLookup = new global::System.Collections.Generic.Dictionary<global::System.Type, int>(3)
 		{
@@ -69,20 +68,19 @@ partial class GeneratedMessagePackResolver : MsgPack::IFormatterResolver
 			{
 				switch (closedKey)
 				{
-					case 0: return new MsgPack::Formatters.ArrayFormatter<global::System.Int32>();
-					case 1: return new MsgPack::Formatters.ListFormatter<global::System.Collections.Generic.IEnumerable<global::System.Guid>>();
-					case 2: return new MsgPack::Formatters.ListFormatter<int[]>();
-					case 3: return new MsgPack::Formatters.ListFormatter<string>();
-					case 4: return new MsgPack::Formatters.InterfaceEnumerableFormatter<global::System.Guid>();
-					case 5: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.MyGenericObjectFormatter<global::System.Collections.Generic.IEnumerable<global::System.Guid>>();
-					case 6: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.MyGenericObjectFormatter<int[]>();
-					case 7: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.MyGenericObjectFormatter<string>();
-					case 8: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.MyInnerGenericObjectFormatter<global::System.Collections.Generic.IEnumerable<global::System.Guid>>();
-					case 9: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.MyInnerGenericObjectFormatter<int[]>();
-					case 10: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.MyInnerGenericObjectFormatter<string>();
-					case 11: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.WrapperFormatter<global::System.Collections.Generic.IEnumerable<global::System.Guid>>();
-					case 12: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.WrapperFormatter<int[]>();
-					case 13: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.WrapperFormatter<string>();
+					case 0: return new MsgPack::Formatters.ListFormatter<global::System.Collections.Generic.IEnumerable<global::System.Guid>>();
+					case 1: return new MsgPack::Formatters.ListFormatter<int[]>();
+					case 2: return new MsgPack::Formatters.ListFormatter<string>();
+					case 3: return new MsgPack::Formatters.InterfaceEnumerableFormatter<global::System.Guid>();
+					case 4: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.MyGenericObjectFormatter<global::System.Collections.Generic.IEnumerable<global::System.Guid>>();
+					case 5: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.MyGenericObjectFormatter<int[]>();
+					case 6: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.MyGenericObjectFormatter<string>();
+					case 7: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.MyInnerGenericObjectFormatter<global::System.Collections.Generic.IEnumerable<global::System.Guid>>();
+					case 8: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.MyInnerGenericObjectFormatter<int[]>();
+					case 9: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.MyInnerGenericObjectFormatter<string>();
+					case 10: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.WrapperFormatter<global::System.Collections.Generic.IEnumerable<global::System.Guid>>();
+					case 11: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.WrapperFormatter<int[]>();
+					case 12: return new global::MessagePack.GeneratedMessagePackResolver.TempProject.WrapperFormatter<string>();
 					default: return null; // unreachable
 				};
 			}


### PR DESCRIPTION
The result of `FormattableType.Name.Name` is different from `ITypeSymbol.ToString`:
|     | ITypeSymbol.ToString | FormattableType.Name.Name |
| -------- | ------- | ------- |
| int| int    | Int32 |
| System.DateTime | System.DateTime     | DateTime |

It causes the branch handling embedded types becomes useless.