### PR TITLE
Add `scoped` modifier to `in` parameters of `ref struct`

### DIFF
--- a/src/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack/MessagePackReader.cs
@@ -47,7 +47,7 @@ namespace MessagePack
         /// Initializes a new instance of the <see cref="MessagePackReader"/> struct.
         /// </summary>
         /// <param name="readOnlySequence">The sequence to read from.</param>
-        public MessagePackReader(in ReadOnlySequence<byte> readOnlySequence)
+        public MessagePackReader(scoped in ReadOnlySequence<byte> readOnlySequence)
             : this()
         {
             this.reader = new SequenceReader<byte>(readOnlySequence);

--- a/src/MessagePack/SequenceReader.cs
+++ b/src/MessagePack/SequenceReader.cs
@@ -55,7 +55,7 @@ namespace MessagePack
         /// over the given <see cref="ReadOnlySequence{T}"/>.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public SequenceReader(in ReadOnlySequence<T> sequence)
+        public SequenceReader(scoped in ReadOnlySequence<T> sequence)
         {
             this.usingSequence = true;
             this.CurrentSpanIndex = 0;

--- a/src/MessagePack/net472/PublicAPI.Shipped.txt
+++ b/src/MessagePack/net472/PublicAPI.Shipped.txt
@@ -513,7 +513,7 @@ MessagePack.MessagePackReader.CreatePeekReader() -> MessagePack.MessagePackReade
 MessagePack.MessagePackReader.End.get -> bool
 MessagePack.MessagePackReader.IsNil.get -> bool
 MessagePack.MessagePackReader.MessagePackReader(System.ReadOnlyMemory<byte> memory) -> void
-MessagePack.MessagePackReader.MessagePackReader(in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> void
+MessagePack.MessagePackReader.MessagePackReader(scoped in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> void
 MessagePack.MessagePackReader.NextCode.get -> byte
 MessagePack.MessagePackReader.NextMessagePackType.get -> MessagePack.MessagePackType
 MessagePack.MessagePackReader.Position.get -> System.SequencePosition

--- a/src/MessagePack/net8.0/PublicAPI.Shipped.txt
+++ b/src/MessagePack/net8.0/PublicAPI.Shipped.txt
@@ -513,7 +513,7 @@ MessagePack.MessagePackReader.CreatePeekReader() -> MessagePack.MessagePackReade
 MessagePack.MessagePackReader.End.get -> bool
 MessagePack.MessagePackReader.IsNil.get -> bool
 MessagePack.MessagePackReader.MessagePackReader(System.ReadOnlyMemory<byte> memory) -> void
-MessagePack.MessagePackReader.MessagePackReader(in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> void
+MessagePack.MessagePackReader.MessagePackReader(scoped in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> void
 MessagePack.MessagePackReader.NextCode.get -> byte
 MessagePack.MessagePackReader.NextMessagePackType.get -> MessagePack.MessagePackType
 MessagePack.MessagePackReader.Position.get -> System.SequencePosition

--- a/src/MessagePack/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/MessagePack/netstandard2.0/PublicAPI.Shipped.txt
@@ -513,7 +513,7 @@ MessagePack.MessagePackReader.CreatePeekReader() -> MessagePack.MessagePackReade
 MessagePack.MessagePackReader.End.get -> bool
 MessagePack.MessagePackReader.IsNil.get -> bool
 MessagePack.MessagePackReader.MessagePackReader(System.ReadOnlyMemory<byte> memory) -> void
-MessagePack.MessagePackReader.MessagePackReader(in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> void
+MessagePack.MessagePackReader.MessagePackReader(scoped in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> void
 MessagePack.MessagePackReader.NextCode.get -> byte
 MessagePack.MessagePackReader.NextMessagePackType.get -> MessagePack.MessagePackType
 MessagePack.MessagePackReader.Position.get -> System.SequencePosition

--- a/src/MessagePack/netstandard2.1/PublicAPI.Shipped.txt
+++ b/src/MessagePack/netstandard2.1/PublicAPI.Shipped.txt
@@ -513,7 +513,7 @@ MessagePack.MessagePackReader.CreatePeekReader() -> MessagePack.MessagePackReade
 MessagePack.MessagePackReader.End.get -> bool
 MessagePack.MessagePackReader.IsNil.get -> bool
 MessagePack.MessagePackReader.MessagePackReader(System.ReadOnlyMemory<byte> memory) -> void
-MessagePack.MessagePackReader.MessagePackReader(in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> void
+MessagePack.MessagePackReader.MessagePackReader(scoped in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> void
 MessagePack.MessagePackReader.NextCode.get -> byte
 MessagePack.MessagePackReader.NextMessagePackType.get -> MessagePack.MessagePackType
 MessagePack.MessagePackReader.Position.get -> System.SequencePosition

--- a/tests/MessagePack.Tests/MessagePackReaderTests.cs
+++ b/tests/MessagePack.Tests/MessagePackReaderTests.cs
@@ -404,6 +404,23 @@ namespace MessagePack.Tests
             {
             }
         }
+
+        /// <summary>
+        /// Verifies that a ref struct can create and store a MessagePackReader given a short-lived copy of a
+        /// <see cref="ReadOnlySequence{T}"/>.
+        /// </summary>
+        /// <remarks>
+        /// This is a 'test' simply by being declared, since C# won't compile it if it's not valid.
+        /// </remarks>
+        private ref struct MySequenceReader
+        {
+            private MessagePackReader reader;
+
+            public MySequenceReader(ReadOnlySequence<byte> seq)
+            {
+                this.reader = new MessagePackReader(seq);
+            }
+        }
     }
 
     internal static class MessagePackWriterExtensions


### PR DESCRIPTION
This is critical for v3 where we're compiling using C# 12, which holds out callers at a higher standard to not pass in `ReadOnlySequence<byte>` that might not live as long as the `ref struct` because of using the `in` parameter modifier.