### PR TITLE
Ignore abstract implementations of `IMessagePackFormatter<T>`

### DIFF
--- a/src/MessagePack.SourceGenerator/CodeAnalysis/AnalyzerOptions.cs
+++ b/src/MessagePack.SourceGenerator/CodeAnalysis/AnalyzerOptions.cs
@@ -218,6 +218,12 @@ public record FormatterDescriptor(QualifiedNamedTypeName Name, string? InstanceP
     /// <returns><see langword="true"/> if <paramref name="type"/> represents a formatter.</returns>
     public static bool TryCreate(INamedTypeSymbol type, [NotNullWhen(true)] out FormatterDescriptor? formatter)
     {
+        if (type.IsAbstract)
+        {
+            formatter = null;
+            return false;
+        }
+
         var formattedTypes =
             AnalyzerUtilities.SearchTypeForFormatterImplementations(type)
             .Select(i => new FormattableType(i, type.ContainingAssembly))

--- a/tests/MessagePack.SourceGenerator.Tests/MsgPack00xAnalyzerTests.cs
+++ b/tests/MessagePack.SourceGenerator.Tests/MsgPack00xAnalyzerTests.cs
@@ -908,4 +908,27 @@ public class Bar : Foo
 
         await VerifyCS.VerifyAnalyzerAsync(test);
     }
+
+    [Fact]
+    public async Task AbstractFormatterDoesNotAttractAttention()
+    {
+        string test = /* lang=c#-test */ """
+            using MessagePack;
+            using MessagePack.Formatters;
+
+            public abstract class AbstractFormatter1 : IMessagePackFormatter<object>
+            {
+                public abstract void Serialize(ref MessagePackWriter writer, object value, MessagePackSerializerOptions options);
+                public abstract object Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options);
+            }
+
+            public abstract class AbstractFormatter2 : IMessagePackFormatter<object>
+            {
+                public abstract void Serialize(ref MessagePackWriter writer, object value, MessagePackSerializerOptions options);
+                public abstract object Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options);
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
 }


### PR DESCRIPTION
Fixes #2017
