### PR TITLE
Apply scoped in more places

### DIFF
--- a/src/MessagePack/Internal/CodeGenHelpers.cs
+++ b/src/MessagePack/Internal/CodeGenHelpers.cs
@@ -68,7 +68,7 @@ namespace MessagePack.Internal
         /// </summary>
         /// <param name="sequence">The sequence to get a span for.</param>
         /// <returns>The span.</returns>
-        public static ReadOnlySpan<byte> GetSpanFromSequence(in ReadOnlySequence<byte> sequence)
+        public static ReadOnlySpan<byte> GetSpanFromSequence(scoped in ReadOnlySequence<byte> sequence)
         {
             if (sequence.IsSingleSegment)
             {
@@ -84,7 +84,7 @@ namespace MessagePack.Internal
         /// </summary>
         /// <param name="reader">The reader to use.</param>
         /// <returns>The span of UTF-8 encoded characters.</returns>
-        public static ReadOnlySpan<byte> ReadStringSpan(ref MessagePackReader reader)
+        public static ReadOnlySpan<byte> ReadStringSpan(scoped ref MessagePackReader reader)
         {
             if (!reader.TryReadStringSpan(out ReadOnlySpan<byte> result))
             {

--- a/src/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack/MessagePackReader.cs
@@ -117,7 +117,7 @@ namespace MessagePack
         /// </summary>
         /// <param name="readOnlySequence">The sequence to read from.</param>
         /// <returns>The new reader.</returns>
-        public MessagePackReader Clone(in ReadOnlySequence<byte> readOnlySequence) => new MessagePackReader(readOnlySequence)
+        public MessagePackReader Clone(scoped in ReadOnlySequence<byte> readOnlySequence) => new MessagePackReader(readOnlySequence)
         {
             CancellationToken = this.CancellationToken,
             Depth = this.Depth,

--- a/src/MessagePack/net472/PublicAPI.Shipped.txt
+++ b/src/MessagePack/net472/PublicAPI.Shipped.txt
@@ -507,7 +507,7 @@ MessagePack.MessagePackRange
 MessagePack.MessagePackReader
 MessagePack.MessagePackReader.CancellationToken.get -> System.Threading.CancellationToken
 MessagePack.MessagePackReader.CancellationToken.set -> void
-MessagePack.MessagePackReader.Clone(in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> MessagePack.MessagePackReader
+MessagePack.MessagePackReader.Clone(scoped in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> MessagePack.MessagePackReader
 MessagePack.MessagePackReader.Consumed.get -> long
 MessagePack.MessagePackReader.CreatePeekReader() -> MessagePack.MessagePackReader
 MessagePack.MessagePackReader.End.get -> bool
@@ -753,8 +753,8 @@ static MessagePack.Formatters.PrimitiveObjectFormatter.IsSupportedType(System.Ty
 static MessagePack.Internal.AutomataKeyGen.GetKey(ref System.ReadOnlySpan<byte> span) -> ulong
 static MessagePack.Internal.CodeGenHelpers.GetArrayFromNullableSequence(in System.Buffers.ReadOnlySequence<byte>? sequence) -> byte[]?
 static MessagePack.Internal.CodeGenHelpers.GetEncodedStringBytes(string! value) -> byte[]!
-static MessagePack.Internal.CodeGenHelpers.GetSpanFromSequence(in System.Buffers.ReadOnlySequence<byte> sequence) -> System.ReadOnlySpan<byte>
-static MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref MessagePack.MessagePackReader reader) -> System.ReadOnlySpan<byte>
+static MessagePack.Internal.CodeGenHelpers.GetSpanFromSequence(scoped in System.Buffers.ReadOnlySequence<byte> sequence) -> System.ReadOnlySpan<byte>
+static MessagePack.Internal.CodeGenHelpers.ReadStringSpan(scoped ref MessagePack.MessagePackReader reader) -> System.ReadOnlySpan<byte>
 static MessagePack.Internal.UnsafeMemory32.WriteRaw1(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
 static MessagePack.Internal.UnsafeMemory32.WriteRaw10(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
 static MessagePack.Internal.UnsafeMemory32.WriteRaw11(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void

--- a/src/MessagePack/net8.0/PublicAPI.Shipped.txt
+++ b/src/MessagePack/net8.0/PublicAPI.Shipped.txt
@@ -507,7 +507,7 @@ MessagePack.MessagePackRange
 MessagePack.MessagePackReader
 MessagePack.MessagePackReader.CancellationToken.get -> System.Threading.CancellationToken
 MessagePack.MessagePackReader.CancellationToken.set -> void
-MessagePack.MessagePackReader.Clone(in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> MessagePack.MessagePackReader
+MessagePack.MessagePackReader.Clone(scoped in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> MessagePack.MessagePackReader
 MessagePack.MessagePackReader.Consumed.get -> long
 MessagePack.MessagePackReader.CreatePeekReader() -> MessagePack.MessagePackReader
 MessagePack.MessagePackReader.End.get -> bool
@@ -753,8 +753,8 @@ static MessagePack.Formatters.PrimitiveObjectFormatter.IsSupportedType(System.Ty
 static MessagePack.Internal.AutomataKeyGen.GetKey(ref System.ReadOnlySpan<byte> span) -> ulong
 static MessagePack.Internal.CodeGenHelpers.GetArrayFromNullableSequence(in System.Buffers.ReadOnlySequence<byte>? sequence) -> byte[]?
 static MessagePack.Internal.CodeGenHelpers.GetEncodedStringBytes(string! value) -> byte[]!
-static MessagePack.Internal.CodeGenHelpers.GetSpanFromSequence(in System.Buffers.ReadOnlySequence<byte> sequence) -> System.ReadOnlySpan<byte>
-static MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref MessagePack.MessagePackReader reader) -> System.ReadOnlySpan<byte>
+static MessagePack.Internal.CodeGenHelpers.GetSpanFromSequence(scoped in System.Buffers.ReadOnlySequence<byte> sequence) -> System.ReadOnlySpan<byte>
+static MessagePack.Internal.CodeGenHelpers.ReadStringSpan(scoped ref MessagePack.MessagePackReader reader) -> System.ReadOnlySpan<byte>
 static MessagePack.Internal.UnsafeMemory32.WriteRaw1(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
 static MessagePack.Internal.UnsafeMemory32.WriteRaw10(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
 static MessagePack.Internal.UnsafeMemory32.WriteRaw11(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void

--- a/src/MessagePack/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/MessagePack/netstandard2.0/PublicAPI.Shipped.txt
@@ -507,7 +507,7 @@ MessagePack.MessagePackRange
 MessagePack.MessagePackReader
 MessagePack.MessagePackReader.CancellationToken.get -> System.Threading.CancellationToken
 MessagePack.MessagePackReader.CancellationToken.set -> void
-MessagePack.MessagePackReader.Clone(in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> MessagePack.MessagePackReader
+MessagePack.MessagePackReader.Clone(scoped in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> MessagePack.MessagePackReader
 MessagePack.MessagePackReader.Consumed.get -> long
 MessagePack.MessagePackReader.CreatePeekReader() -> MessagePack.MessagePackReader
 MessagePack.MessagePackReader.End.get -> bool
@@ -753,8 +753,8 @@ static MessagePack.Formatters.PrimitiveObjectFormatter.IsSupportedType(System.Ty
 static MessagePack.Internal.AutomataKeyGen.GetKey(ref System.ReadOnlySpan<byte> span) -> ulong
 static MessagePack.Internal.CodeGenHelpers.GetArrayFromNullableSequence(in System.Buffers.ReadOnlySequence<byte>? sequence) -> byte[]?
 static MessagePack.Internal.CodeGenHelpers.GetEncodedStringBytes(string! value) -> byte[]!
-static MessagePack.Internal.CodeGenHelpers.GetSpanFromSequence(in System.Buffers.ReadOnlySequence<byte> sequence) -> System.ReadOnlySpan<byte>
-static MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref MessagePack.MessagePackReader reader) -> System.ReadOnlySpan<byte>
+static MessagePack.Internal.CodeGenHelpers.GetSpanFromSequence(scoped in System.Buffers.ReadOnlySequence<byte> sequence) -> System.ReadOnlySpan<byte>
+static MessagePack.Internal.CodeGenHelpers.ReadStringSpan(scoped ref MessagePack.MessagePackReader reader) -> System.ReadOnlySpan<byte>
 static MessagePack.Internal.UnsafeMemory32.WriteRaw1(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
 static MessagePack.Internal.UnsafeMemory32.WriteRaw10(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
 static MessagePack.Internal.UnsafeMemory32.WriteRaw11(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void

--- a/src/MessagePack/netstandard2.1/PublicAPI.Shipped.txt
+++ b/src/MessagePack/netstandard2.1/PublicAPI.Shipped.txt
@@ -507,7 +507,7 @@ MessagePack.MessagePackRange
 MessagePack.MessagePackReader
 MessagePack.MessagePackReader.CancellationToken.get -> System.Threading.CancellationToken
 MessagePack.MessagePackReader.CancellationToken.set -> void
-MessagePack.MessagePackReader.Clone(in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> MessagePack.MessagePackReader
+MessagePack.MessagePackReader.Clone(scoped in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> MessagePack.MessagePackReader
 MessagePack.MessagePackReader.Consumed.get -> long
 MessagePack.MessagePackReader.CreatePeekReader() -> MessagePack.MessagePackReader
 MessagePack.MessagePackReader.End.get -> bool
@@ -753,8 +753,8 @@ static MessagePack.Formatters.PrimitiveObjectFormatter.IsSupportedType(System.Ty
 static MessagePack.Internal.AutomataKeyGen.GetKey(ref System.ReadOnlySpan<byte> span) -> ulong
 static MessagePack.Internal.CodeGenHelpers.GetArrayFromNullableSequence(in System.Buffers.ReadOnlySequence<byte>? sequence) -> byte[]?
 static MessagePack.Internal.CodeGenHelpers.GetEncodedStringBytes(string! value) -> byte[]!
-static MessagePack.Internal.CodeGenHelpers.GetSpanFromSequence(in System.Buffers.ReadOnlySequence<byte> sequence) -> System.ReadOnlySpan<byte>
-static MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref MessagePack.MessagePackReader reader) -> System.ReadOnlySpan<byte>
+static MessagePack.Internal.CodeGenHelpers.GetSpanFromSequence(scoped in System.Buffers.ReadOnlySequence<byte> sequence) -> System.ReadOnlySpan<byte>
+static MessagePack.Internal.CodeGenHelpers.ReadStringSpan(scoped ref MessagePack.MessagePackReader reader) -> System.ReadOnlySpan<byte>
 static MessagePack.Internal.UnsafeMemory32.WriteRaw1(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
 static MessagePack.Internal.UnsafeMemory32.WriteRaw10(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
 static MessagePack.Internal.UnsafeMemory32.WriteRaw11(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void


### PR DESCRIPTION
More APIs that will benefit from having `scoped` applied to arguments. These APIs fall into the pattern of `in / ref` parameter of `ref struct` and return `ref struct`. The `scoped` prevents the `ref` being calculated as part of the return lifetime. This makes the API easier to use as it allows `in / ref` to stack bound values to be used without that poisoning the return.