### PR TITLE
Revert untrusted data default

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,16 +665,11 @@ Untrusted data might come from over the network from an untrusted source (e.g. a
 
 Please be very mindful of these attack scenarios; many projects and companies, and serialization library users in general, have been bitten by untrusted user data deserialization in the past.
 
-You should also avoid the Typeless serializer/formatters/resolvers for untrusted data as that opens the door for the untrusted data to potentially deserialize unanticipated types that can compromise security.
-
-MessagePack v3 assumes the data you deserialize is untrusted and takes mitigating steps including use of collision resistant hash functions when deserializing dictionaries.
-The `UntrustedData` default mode merely hardens against some common attacks, but is no fully secure solution in itself.
-
-When you are deserializing data that you already trust and wish to use faster (insecure) hash functions, you can switch to trusted data mode by configuring your `MessagePackSerializerOptions.Security` property:
+When deserializing untrusted data, put MessagePack into a more secure mode by configuring your `MessagePackSerializerOptions.Security` property:
 
 ```cs
 var options = MessagePackSerializerOptions.Standard
-    .WithSecurity(MessagePackSecurity.TrustedData);
+    .WithSecurity(MessagePackSecurity.UntrustedData);
 
 // Pass the options explicitly for the greatest control.
 T object = MessagePackSerializer.Deserialize<T>(data, options);
@@ -683,8 +678,9 @@ T object = MessagePackSerializer.Deserialize<T>(data, options);
 MessagePackSerializer.DefaultOptions = options;
 ```
 
-You can also derive your own type from the `MessagePackSecurity` class to customize security decisions and hash functions.
-Provide an instance of your derived type to the `MessagePackSerializationOptions` type to use it in your deserialization.
+You should also avoid the Typeless serializer/formatters/resolvers for untrusted data as that opens the door for the untrusted data to potentially deserialize unanticipated types that can compromise security.
+
+The `UntrustedData` mode merely hardens against some common attacks, but is no fully secure solution in itself.
 
 ## Performance
 

--- a/doc/migrating_v2-v3.md
+++ b/doc/migrating_v2-v3.md
@@ -9,10 +9,6 @@ v3 adds many new diagnostic providers to the set of analyzers as well, with gene
 
 ## Breaking Changes
 
-- Secure by default: `MessagePackSerializerOptions.Security` defaults to `MessagePackSecurity.UntrustedData` instead of the v2 default of `MessagePackSecurity.TrustedData`.
-  This may have a small negative perf impact for deserialization.
-  It may also cause deserialization to fail if the object model requires hashing deserialized data for which no collision resistant hash function is known by the library.
-  [Learn more about security switches and customization](../README.md#security).
 - `MessagePackAnalyzer.json` is no longer used to configure the analyzer.
   Use `GeneratedMessagePackResolverAttribute`, `MessagePackKnownFormatterAttribute` and `MessagePackAssumedFormattableAttribute` instead.
 - The `mpc` CLI tool is no longer used to generate ahead-of-time (AOT) formatters and resolver.

--- a/src/MessagePack/MessagePackSecurity.cs
+++ b/src/MessagePack/MessagePackSecurity.cs
@@ -20,7 +20,8 @@ namespace MessagePack
     public class MessagePackSecurity
     {
         /// <summary>
-        /// Gets an instance preconfigured with settings that omit all protections. Useful for deserializing fully-trusted and valid msgpack sequences.
+        /// Gets an instance preconfigured with settings that omit hash collision resistance protections.
+        /// Useful for deserializing fully-trusted and valid msgpack sequences.
         /// </summary>
         public static readonly MessagePackSecurity TrustedData = new MessagePackSecurity();
 
@@ -79,7 +80,7 @@ namespace MessagePack
         /// Since stack space occupied may vary by the kind of object deserialized, a conservative value for this property to defend against stack overflow attacks might be 500.
         /// </para>
         /// </remarks>
-        public int MaximumObjectGraphDepth { get; private set; } = int.MaxValue;
+        public int MaximumObjectGraphDepth { get; private set; } = 500;
 
         /// <summary>
         /// Gets a copy of these options with the <see cref="MaximumObjectGraphDepth"/> property set to a new value.

--- a/src/MessagePack/MessagePackSerializerOptions.cs
+++ b/src/MessagePack/MessagePackSerializerOptions.cs
@@ -135,7 +135,7 @@ namespace MessagePack
         /// <value>
         /// The default value is to use <see cref="MessagePackSecurity.TrustedData"/>.
         /// </value>
-        public MessagePackSecurity Security { get; private set; } = MessagePackSecurity.UntrustedData;
+        public MessagePackSecurity Security { get; private set; } = MessagePackSecurity.TrustedData;
 
         /// <summary>
         /// Gets a thread-safe pool of reusable <see cref="Sequence{T}"/> objects.

--- a/tests/MessagePack.Tests/MessagePackSerializerOptionsTests.cs
+++ b/tests/MessagePack.Tests/MessagePackSerializerOptionsTests.cs
@@ -75,8 +75,8 @@ public class MessagePackSerializerOptionsTests
     [Fact]
     public void Security()
     {
-        Assert.Same(MessagePackSecurity.UntrustedData, MessagePackSerializerOptions.Standard.Security);
-        Assert.Same(MessagePackSecurity.TrustedData, MessagePackSerializerOptions.Standard.WithSecurity(MessagePackSecurity.TrustedData).Security);
+        Assert.Same(MessagePackSecurity.TrustedData, MessagePackSerializerOptions.Standard.Security);
+        Assert.Same(MessagePackSecurity.UntrustedData, MessagePackSerializerOptions.Standard.WithSecurity(MessagePackSecurity.UntrustedData).Security);
     }
 
     [Fact]


### PR DESCRIPTION
- Revert to v2's insecure-by-default mode (effectively reverts #2013)
- Limit stack depth to 500 even for trusted data