### PR TITLE
Add MessagePackReader/Writer(Span<byte>) overload

### DIFF
--- a/src/MessagePack/MessagePackWriter.cs
+++ b/src/MessagePack/MessagePackWriter.cs
@@ -45,6 +45,17 @@ namespace MessagePack
         /// <summary>
         /// Initializes a new instance of the <see cref="MessagePackWriter"/> struct.
         /// </summary>
+        /// <param name="span">The writer to use.</param>
+        public MessagePackWriter(Span<byte> span)
+            : this()
+        {
+            this.writer = new BufferWriter(span);
+            this.OldSpec = false;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessagePackWriter"/> struct.
+        /// </summary>
         /// <param name="sequencePool">The pool from which to draw an <see cref="IBufferWriter{T}"/> if required..</param>
         /// <param name="array">An array to start with so we can avoid accessing the <paramref name="sequencePool"/> if possible.</param>
         internal MessagePackWriter(SequencePool sequencePool, byte[] array)
@@ -63,6 +74,8 @@ namespace MessagePack
         /// Gets or sets a value indicating whether to write in <see href="https://github.com/msgpack/msgpack/blob/master/spec-old.md">old spec</see> compatibility mode.
         /// </summary>
         public bool OldSpec { get; set; }
+
+        public long WrittenCount => writer.WrittenCount;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MessagePackWriter"/> struct,

--- a/tests/MessagePack.Tests/MessagePackReaderWriterSpanTest.cs
+++ b/tests/MessagePack.Tests/MessagePackReaderWriterSpanTest.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Xunit;
+
+namespace MessagePack.Tests
+{
+    public class MessagePackReaderWriterSpanTest
+    {
+        [Fact]
+        public void WriterTest()
+        {
+            Span<byte> span = stackalloc byte[100];
+
+            var writer = new MessagePackWriter(span);
+
+            writer.WriteArrayHeader(5);
+            writer.Write(1);
+            writer.Write(10);
+            writer.Write(100);
+            writer.Write(1000);
+            writer.Write(10000);
+
+            span = span.Slice(0, (int)writer.WrittenCount);
+
+            var bin = MessagePackSerializer.Deserialize<int[]>(span.ToArray());
+
+            bin.Is(1, 10, 100, 1000, 1000);
+        }
+
+        [Fact]
+        public void WriterThrow()
+        {
+            Span<byte> span = stackalloc byte[5];
+
+            var writer = new MessagePackWriter(span);
+
+            writer.WriteArrayHeader(5); // +1
+            writer.Write(1); // +1
+            writer.Write(10); // +1
+            writer.Write(100); // +1
+
+            try
+            {
+                writer.Write(1000); // +3, can't grow
+                Assert.Fail("should throw exceptions.");
+            }
+            catch (Exception ex)
+            {
+                if (ex is not InvalidOperationException)
+                {
+                    throw;
+                }
+            }
+        }
+
+        [Fact]
+        public void ReaderTest()
+        {
+            var bin = MessagePackSerializer.Serialize(new int[] { 1, 10, 100, 1000, 10000 });
+            var span = bin.AsSpan();
+
+            var reader = new MessagePackReader(span);
+
+            var len = reader.ReadArrayHeader();
+            var array = new int[len];
+            array[0] = reader.ReadInt32();
+            array[1] = reader.ReadInt32();
+            array[2] = reader.ReadInt32();
+            array[3] = reader.ReadInt32();
+            array[4] = reader.ReadInt32();
+
+            array.Length.Is(5);
+            array.Is(1, 10, 100, 1000, 10000);
+        }
+    }
+}


### PR DESCRIPTION
While the addition of MessagePackPrimitives is proving challenging (ref: https://github.com/MessagePack-CSharp/MessagePack-CSharp/pull/1986),
what's really needed for practical use cases is the ability to Write/Read to/from Span.

For example, in my network framework [MagicOnion](https://github.com/Cysharp/MagicOnion), while we're reading and writing headers in MessagePack binary format, there are cases where we want to read/write directly with Span.

Therefore, I adapted `MessagePackWriter` and `MessagePackReader` to support Span operations.
Since the Writer is expected to auto-expand, I made it throw an `InvalidOperationException` when expansion is needed.
While Try-pattern APIs might be better, this current approach isn't necessarily bad.

I also added a public `long WrittenCount` property since we need to be able to get the amount written.

For the Reader, since some APIs in SequenceReader require a Sequence, I temporarily implemented it to create a Sequence using ToArray.
While this is better than throwing an exception, it's not the optimal solution.

Additionally, since ReadBytes requires generating a ReadOnlySequence, I added TryReadBytes that returns a raw Span.
This should be a required API for symmetry, as TryReadStringSpan already exists.

Making MessagePackReader compatible with ReadOnlySpan enables the addition of `MessagePackSerializer.Deserialize<T>(ReadOnlySpan<byte>)`, though this API isn't included in this PR.
The inability to pass Span to Deserialize is a shortcoming in MessagePack for C#'s API that needs to be addressed.

Note that when both ReadOnlySpan and ReadOnlyMemory overloads exist, passing a `byte[]` causes overload resolution errors, so we need to either add `T[]` overloads or resolve it with OverloadResolutionPriority (though the latter is likely impractical).

More advanced solution proposal:
Remove ReadOnlySequence generation from BufferReader's public API to make everything Span-based. This would eliminate the need for Span copying and allow removing ReadOnlyMemory from overloads (though it might need to be kept for compatibility reasons).