### PR TITLE
Fix bugs in serializing long numbers

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StandardClassLibraryFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StandardClassLibraryFormatter.cs
@@ -143,8 +143,8 @@ namespace MessagePack.Formatters
 
         public void Serialize(ref MessagePackWriter writer, decimal value, MessagePackSerializerOptions options)
         {
-            var dest = writer.GetSpan(MessagePackRange.MaxFixStringLength);
-            if (System.Buffers.Text.Utf8Formatter.TryFormat(value, dest.Slice(1), out var written))
+            var dest = writer.GetSpan(1 + MessagePackRange.MaxFixStringLength);
+            if (System.Buffers.Text.Utf8Formatter.TryFormat(value, dest.Slice(1, MessagePackRange.MaxFixStringLength), out var written))
             {
                 // write header
                 dest[0] = (byte)(MessagePackCode.MinFixStr | written);
@@ -503,7 +503,7 @@ namespace MessagePack.Formatters
             {
                 // try to get bin8 buffer.
                 var span = writer.GetSpan(byte.MaxValue);
-                if (value.TryWriteBytes(span.Slice(2), out var written))
+                if (value.TryWriteBytes(span.Slice(2, byte.MaxValue), out var written))
                 {
                     span[0] = MessagePackCode.Bin8;
                     span[1] = (byte)written;

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
@@ -1054,7 +1054,7 @@ namespace MessagePack
         /// <summary>
         /// Gets memory where raw messagepack data can be written.
         /// </summary>
-        /// <param name="length">The size of the memory block required.</param>
+        /// <param name="length">The minimum length of the returned System.Span`1. If 0, a non-empty buffer is returned.</param>
         /// <returns>The span of memory to write to. This *may* exceed <paramref name="length"/>.</returns>
         /// <remarks>
         /// <para>After initializing the resulting memory, always follow up with a call to <see cref="Advance(int)"/>.</para>


### PR DESCRIPTION
We had some code that assumed `GetSpan` returns exactly the size requested. And even if that were true, it forgets that we need slightly larger than that length in order to prefix it.