### PR TITLE
Fix bugs for Hardware Intrinsics

### DIFF
--- a/src/MessagePack/Internal/UnsafeRefSerializeHelper.cs
+++ b/src/MessagePack/Internal/UnsafeRefSerializeHelper.cs
@@ -1200,19 +1200,19 @@ internal static class UnsafeRefSerializeHelper
                         Unsafe.Add(ref outputIterator, outputOffset) = MessagePackCode.Float32;
                         Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 1), shuffled.GetElement(0));
                         Unsafe.Add(ref outputIterator, outputOffset + 5) = MessagePackCode.Float32;
-                        Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 6), shuffled.GetElement(0));
+                        Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 6), shuffled.GetElement(1));
                         Unsafe.Add(ref outputIterator, outputOffset + 10) = MessagePackCode.Float32;
-                        Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 11), shuffled.GetElement(0));
+                        Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 11), shuffled.GetElement(2));
                         Unsafe.Add(ref outputIterator, outputOffset + 15) = MessagePackCode.Float32;
-                        Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 16), shuffled.GetElement(0));
+                        Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 16), shuffled.GetElement(3));
                         Unsafe.Add(ref outputIterator, outputOffset + 20) = MessagePackCode.Float32;
-                        Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 21), shuffled.GetElement(0));
+                        Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 21), shuffled.GetElement(4));
                         Unsafe.Add(ref outputIterator, outputOffset + 25) = MessagePackCode.Float32;
-                        Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 26), shuffled.GetElement(0));
+                        Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 26), shuffled.GetElement(5));
                         Unsafe.Add(ref outputIterator, outputOffset + 30) = MessagePackCode.Float32;
-                        Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 31), shuffled.GetElement(0));
+                        Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 31), shuffled.GetElement(6));
                         Unsafe.Add(ref outputIterator, outputOffset + 35) = MessagePackCode.Float32;
-                        Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 35), shuffled.GetElement(0));
+                        Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 36), shuffled.GetElement(7));
                     }
 
                     writer.Advance(outputLength);
@@ -1241,11 +1241,11 @@ internal static class UnsafeRefSerializeHelper
                         Unsafe.Add(ref outputIterator, outputOffset) = MessagePackCode.Float32;
                         Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 1), shuffled.GetElement(0));
                         Unsafe.Add(ref outputIterator, outputOffset + 5) = MessagePackCode.Float32;
-                        Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 6), shuffled.GetElement(0));
+                        Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 6), shuffled.GetElement(1));
                         Unsafe.Add(ref outputIterator, outputOffset + 10) = MessagePackCode.Float32;
-                        Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 11), shuffled.GetElement(0));
+                        Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 11), shuffled.GetElement(2));
                         Unsafe.Add(ref outputIterator, outputOffset + 15) = MessagePackCode.Float32;
-                        Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 16), shuffled.GetElement(0));
+                        Unsafe.WriteUnaligned(ref Unsafe.Add(ref outputIterator, outputOffset + 16), shuffled.GetElement(3));
                     }
 
                     writer.Advance(outputLength);

--- a/tests/MessagePack.Tests/PrimitiveCollectionTests.cs
+++ b/tests/MessagePack.Tests/PrimitiveCollectionTests.cs
@@ -82,6 +82,12 @@ public class PrimitiveCollectionTests
         [new ushort[17] { sbyte.MaxValue - 2, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, (ushort)sbyte.MaxValue, sbyte.MaxValue - 1, }], // 1byte
         [new uint[17] { sbyte.MaxValue - 2, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, (uint)sbyte.MaxValue, sbyte.MaxValue - 1, }], // 1byte
         [new ulong[17] { sbyte.MaxValue - 2, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, (ulong)sbyte.MaxValue, sbyte.MaxValue - 1, }], // 1byte
+        [new float[15] { float.MinValue, -2f, -3f, -4f, 0f, 1f, 2f, 3f, 4f, 5.43f, 6f, 7f, 12.10f, 11f, float.MaxValue, }],
+        [new float[16] { float.MinValue, -2f, -3f, -4f, 0f, 1f, 2f, 3f, 4f, 5.43f, 6f, 7f, 12.10f, 11f, 12f, float.MaxValue, }],
+        [new float[17] { float.MinValue, -2f, -3f, -4f, 0f, 1f, 2f, 3f, 4f, 5.43f, 6f, 7f, 12.10f, 11f, 12f, 13f, float.MaxValue, }],
+        [new double[15] { double.MinValue, -2.0, -3.0, -4.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.43, 6.0, 7.0, 12.10, 11.0, double.MaxValue, }],
+        [new double[16] { double.MinValue, -2.0, -3.0, -4.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.43, 6.0, 7.0, 12.10, 11.0, 12.0, double.MaxValue, }],
+        [new double[17] { double.MinValue, -2.0, -3.0, -4.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.43, 6.0, 7.0, 12.10, 11.0, 12.0, 13.0, double.MaxValue, }],
     ];
 
     [Theory]


### PR DESCRIPTION
I don't know well about loop-unrolling in C#.
The code should be rewritten when fixed size `for` loop is unrolled by .NET runtime.