### PR TITLE
ci: put set of GitHub Actions workflows to run build and release

### DIFF
--- a/.github/actions/check-metas/action.yaml
+++ b/.github/actions/check-metas/action.yaml
@@ -1,0 +1,33 @@
+name: Check all .meta is commited
+description: Check all Unity .meta files are committed.
+inputs:
+  directory:
+    description: Working directory to check change
+    required: true
+  exit-on-error:
+    description: Exit on error
+    required: false
+    default: "true"
+outputs:
+  meta-exists:
+    description: If .meta file exists
+    value: ${{ steps.check-meta.outputs.meta-exists }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check .meta exists
+      id: check-meta
+      shell: bash
+      run: |
+        if git ls-files --others --exclude-standard -t | grep --regexp='[.]meta$'; then
+          echo "Detected .meta file generated. Do you forgot commit a .meta file?"
+          echo "meta-exists=true" | tee -a "$GITHUB_OUTPUT"
+          if [[ "${{inputs.exit-on-error }}" == "true" ]]; then
+            exit 1
+          fi
+        else
+          echo "Great, all .meta files are commited."
+          echo "meta-exists=false" | tee -a "$GITHUB_OUTPUT"
+        fi
+      working-directory: ${{ inputs.directory }}

--- a/.github/actions/setup-dotnet/action.yaml
+++ b/.github/actions/setup-dotnet/action.yaml
@@ -1,0 +1,52 @@
+name: Setup .NET SDKs
+description: Setup .NET SDKs and environment variables
+inputs:
+  global-json-file:
+    description: "path to the global.json file."
+    required: false
+    default: "global.json"
+  skip-env:
+    description: "Optional skip environment set."
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    # see: https://github.com/actions/setup-dotnet
+    - uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: ${{ inputs.global-json-file }}
+
+    # see: https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables
+    # GitHub Actions Hosted Runner default environment contains some .NET Environment.
+    # * DOTNET_MUTILEVEL_LOOKUP=0
+    # * DOTNET_NOLOGO=1
+    # * DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+    # Do not set the following environment variables:
+    # * NUGET_XMLDOC_MODE=skip <- pulumi and some other packge restore will fail.
+    - name: "Configure Environment Variables (.NET SDK)"
+      shell: bash
+      run: |
+        echo "::group::Configure .NET Environment Variables."
+          echo "COMPlus_EnableDiagnostics=0" | tee -a "$GITHUB_ENV"
+          echo "DOTNET_CLI_TELEMETRY_OPTOUT=1" | tee -a "$GITHUB_ENV"
+          echo "DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION=1" | tee -a "$GITHUB_ENV"
+          echo "MSBUILDDISABLENODEREUSE=1" | tee -a "$GITHUB_ENV"
+          echo "TERM=xterm" | tee -a "$GITHUB_ENV"
+        echo "::endgroup::"
+      if: ${{ inputs.skip-env == 'false' }}
+
+    - name: dotnet version
+      shell: bash
+      run: |
+        echo "::group::Show dotnet version"
+          dotnet --version
+        echo "::endgroup::"
+
+    - name: List installed .NET SDKs
+      shell: bash
+      run: |
+        echo "::group::List installed .NET SDKs"
+          dotnet --list-sdks
+        echo "::endgroup::"

--- a/.github/workflows/_clean-packagejson-branch.yaml
+++ b/.github/workflows/_clean-packagejson-branch.yaml
@@ -1,0 +1,54 @@
+name: (R) Update package.json
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: "branch name to delete. Only delete branches that are created by github-actions[bot] and are not the default branch."
+        required: true
+        type: string
+    outputs:
+      branch-deleted:
+        description: "Indicate branch is deleted or not by boolean. true = branch deleted, false = branch not deleted."
+        value: ${{ jobs.cleanup.outputs.branch-deleted }}
+
+jobs:
+  cleanup:
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # auto generated token
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      branch-deleted: ${{ steps.check-branch.outputs.deletable }}
+    steps:
+      - name: Check branch is deletable
+        id: check-branch
+        run: |
+          # Check if the branch is the default branch
+          if [[ "$(gh api /repos/${{ github.repository }} | jq -r '.default_branch')" == "${{ inputs.branch }}" ]]; then
+            echo "Branch is default, you cannot delete this branch. branch: ${{ inputs.branch }}"
+            exit 1
+          fi
+
+          # Check if the branch is created by github-actions[bot]
+          if gh api /repos/${{ github.repository }}/branches | jq -r '.[].name' | grep "${{ inputs.branch }}" >/dev/null; then
+            echo "branch exists. branch: ${{ inputs.branch }}"
+
+            # Check info of the branch
+            gh api /repos/${{ github.repository }}/branches/${{ inputs.branch }} | jq
+
+            if [[ "$(gh api /repos/${{ github.repository }}/branches/${{ inputs.branch }} | jq -r '.commit.author.login')" != "github-actions[bot]" ]]; then
+              echo "Branch is not created by github-actions[bot], you cannot delete this branch. branch: ${{ inputs.branch }}"
+              exit 1
+            fi
+
+            branch_deletable=true
+          else
+            echo "branch not exists. branch: ${{ inputs.branch }}"
+            branch_deletable=false
+          fi
+
+          echo "deletable=${branch_deletable}" | tee -a "${GITHUB_OUTPUT}"
+      - name: Delete branch
+        if: ${{ steps.check-branch.outputs.deletable == 'true' }}
+        run: gh api -X DELETE /repos/${{ github.repository }}/git/refs/heads/${{ inputs.branch }}

--- a/.github/workflows/_clean-packagejson-branch.yaml
+++ b/.github/workflows/_clean-packagejson-branch.yaml
@@ -1,4 +1,4 @@
-name: (R) Update package.json
+name: (R) Clean package.json branch
 
 on:
   workflow_call:

--- a/.github/workflows/_create-release.yaml
+++ b/.github/workflows/_create-release.yaml
@@ -109,9 +109,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit-id }}
-      - uses: actions/setup-dotnet@v4
-        with:
-          global-json-file: global.json
+      - uses: ./.github/actions/setup-dotnet
 
       # Download(All) Artifacts to $GITHUB_WORKSPACE
       - name: donload artifacts

--- a/.github/workflows/_create-release.yaml
+++ b/.github/workflows/_create-release.yaml
@@ -11,11 +11,6 @@ on:
         description: "true = no upload. false = dry run changes && delete release after 60s."
         required: true
         type: boolean
-      require-validation:
-        description: "true require validation must pass, false to keep going even validation failed."
-        required: false
-        type: boolean
-        default: true
       tag:
         description: "Git tag to create. (sample 1.0.0)"
         required: true

--- a/.github/workflows/_create-release.yaml
+++ b/.github/workflows/_create-release.yaml
@@ -71,6 +71,20 @@ jobs:
         run: |
           while read -r asset_path; do
             if [[ "${asset_path}" == "" ]]; then continue; fi
+            # is it a wildcard?
+            # shellcheck disable=SC2086
+            if [[ "$asset_path" == *\** || "$asset_path" == *\?* ]]; then
+              # shellcheck disable=SC2086
+              if ! ls -l ${asset_path}; then
+                echo "Specified nuget package not found. path: $asset_path"
+                if [[ "${asset_path}" == *.nupkg ]]; then
+                  echo ".nupkg must be included in the artifact."
+                  exit 1
+                fi
+              fi
+              continue
+            fi
+            # is it a file?
             if [[ ! -f "${asset_path}" ]]; then
               echo "Specified asset not found. path: ${asset_path}"
               exit 1
@@ -113,6 +127,15 @@ jobs:
         run: |
           while read -r asset_path; do
             if [[ "${asset_path}" == "" ]]; then continue; fi
+            # is it a wildcard?
+            # shellcheck disable=SC2086
+            if [[ "$asset_path" == *\** || "$asset_path" == *\?* ]]; then
+              for file in ${asset_path}; do
+                gh release upload ${{ inputs.tag }} "${file}"
+              done
+              continue
+            fi
+            # is it a file?
             gh release upload ${{ inputs.tag }} "${asset_path}"
           done <<< "${{ inputs.release-asset-path }}"
         if: ${{ inputs.release-upload }}
@@ -137,7 +160,7 @@ jobs:
           done <<< "${{ inputs.nuget-path }}"
 
       # Clean up
-      - name: Clean up. Wait 60s and delete releas if dry-run or failure. (dry-run=${{ inputs.dry-run }}})
+      - name: Clean up. Wait 60s and delete release if dry-run or failure. (dry-run=${{ inputs.dry-run }}})
         if: ${{ inputs.dry-run || failure() }}
         run: |
           if gh release list | grep Draft | grep ${{ inputs.tag }}; then

--- a/.github/workflows/_create-release.yaml
+++ b/.github/workflows/_create-release.yaml
@@ -1,0 +1,198 @@
+name: (R) Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit-id:
+        description: "commit-id: CommitId to create release & tag."
+        required: false
+        type: string
+      dry-run:
+        description: "dry-run: true = no upload. false = dry run changes && delete release after 60s."
+        required: true
+        type: boolean
+      require-validation:
+        description: "require-validation: true require validation must pass, false to keep going even validation failed."
+        required: false
+        type: boolean
+        default: true
+      tag:
+        description: "tag: Git tag to create. (sample 1.0.0)"
+        required: true
+        type: string
+      # nuget
+      nuget-push:
+        description: "nuget-push: true = upload nuget package. false = not upload"
+        required: false
+        type: boolean
+        default: false
+      # release
+      release-asset-path:
+        description: "release assets path to upload. This is a list of paths separated by a newline."
+        required: false
+        type: string
+      release-format: # see: https://docs.github.com/en/actions/learn-github-actions/expressions#format
+        description: "release-format: if 'Ver.{0}' is specified, the release title will be 'Ver.1.0.0'. set '{0}' if no prefix is preferred."
+        required: false
+        type: string
+        default: 'Ver.{0}'
+      release-upload:
+        description: "release-upload: true = upload assets. false = not upload"
+        required: false
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      commit-id:
+        description: "CommitId to create release & tag."
+        required: true
+        type: string
+      dry-run:
+        description: "true = no upload. false = dry run changes && delete release after 60s."
+        required: true
+        type: boolean
+      require-validation:
+        description: "true require validation must pass, false to keep going even validation failed."
+        required: false
+        type: boolean
+        default: true
+      tag:
+        description: "Git tag to create. (sample 1.0.0)"
+        required: true
+        type: string
+      # nuget
+      nuget-path:
+        description: "nuget path to upload."
+        required: false
+        type: string
+        default: |
+          ./nuget/*.nupkg
+          ./nuget/*.snupkg
+      nuget-push:
+        description: "true = upload nuget package. false = not upload"
+        required: false
+        type: boolean
+        default: false
+      # release
+      release-asset-path:
+        description: "release assets path to upload. This is a list of paths separated by a newline."
+        required: false
+        type: string
+      release-format: # see: https://docs.github.com/en/actions/learn-github-actions/expressions#format
+        description: "Release format. (if 'Ver.{0}' is specified, the release title will be 'Ver.1.0.0'. set '{0}' if no prefix is preferred.)"
+        required: false
+        type: string
+        default: 'Ver.{0}'
+      release-upload:
+        description: "true = upload assets. false = not upload"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  create-release:
+    name: Create Release
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # auto generated token
+      GH_REPO: ${{ github.repository }}
+      NUGET_KEY: ${{ secrets.NUGET_KEY }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Validate inputs - unitypackage
+        shell: bash
+        if: ${{ inputs.release-upload && inputs.release-asset-path == '' }}
+        run: |
+          echo "Validation error! 'inputs.release-asset-path' cannot be blank when 'inputs.release-upload' is true."
+          exit 1
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit-id }}
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      # Download(All) Artifacts to $GITHUB_WORKSPACE
+      - name: donload artifacts
+        uses: actions/download-artifact@v4 # must sync with actions/upload-artifact@v4 in build-release
+      - name: Show download aritifacts
+        run: ls -lR
+      - name: Validate package exists in artifact - release assets
+        if: ${{ inputs.release-upload }}
+        run: |
+          while read -r asset_path; do
+            if [[ "${asset_path}" == "" ]]; then continue; fi
+            if [[ ! -f "${asset_path}" ]]; then
+              echo "Specified asset not found. path: ${asset_path}"
+              exit 1
+            fi
+          done <<< "${{ inputs.release-asset-path }}"
+      - name: Validate package exists in artifact - NuGet
+        if: ${{ inputs.nuget-push }}
+        run: |
+          while read -r nuget_path; do
+            if [[ "${nuget_path}" == "" ]]; then continue; fi
+            # shellcheck disable=SC2086
+            if ! ls -l ${nuget_path}; then
+              echo "Specified nuget package not found. path: $nuget_path"
+              if [[ "${nuget_path}" == *.nupkg ]]; then
+                echo ".nupkg must be included in the artifact."
+                exit 1
+              fi
+            fi
+          done <<< "${{ inputs.nuget-path }}"
+
+      # Create Releases
+      - name: Create Tag
+        run: |
+          git tag ${{ inputs.tag }}
+          git push origin ${{ inputs.tag }}
+      - name: Create Release
+        run: gh release create ${{ inputs.tag }} --draft --verify-tag --title "${{ format(inputs.release-format, inputs.tag) }}" --generate-notes
+      - name: Wait and Verify Release Name is expected
+        run: |
+          sleep 5s
+          actual=$(gh api --paginate /repos/${{ github.repository }}/releases?per_page=100 --jq '.[] | select(.tag_name == "${{ inputs.tag }}") | .name')
+          expected="${{ format(inputs.release-format, inputs.tag) }}"
+          if [[ "$actual" != "$expected" ]]; then
+            echo "Release name is not as expected. expected: $expected, actual: $actual"
+            exit 1
+          else
+            echo "Release name is expected! expected: $expected, actual: $actual"
+          fi
+      - name: Upload asset files to release
+        run: |
+          while read -r asset_path; do
+            if [[ "${asset_path}" == "" ]]; then continue; fi
+            gh release upload ${{ inputs.tag }} "${asset_path}"
+          done <<< "${{ inputs.release-asset-path }}"
+        if: ${{ inputs.release-upload }}
+
+      # Upload to NuGet
+      - name: Upload to NuGet (DryRun=${{ inputs.dry-run }})
+        if: ${{ inputs.nuget-push }}
+        run: |
+          while read -r nuget_path; do
+            if [[ "$nuget_path" == "" ]]; then continue; fi
+            # shellcheck disable=SC2086
+            if ! ls -l ${nuget_path} >/dev/null 2>&1;then
+              echo "skipping nuget push, $nuget_path not found."
+              continue
+            fi
+
+            if [[ "${{ inputs.dry-run }}" == "true" ]]; then
+              echo "(dry run) dotnet nuget push \"${nuget_path}\" --skip-duplicate -s https://api.nuget.org/v3/index.json -k \"${{ env.NUGET_KEY }}\""
+            else
+              dotnet nuget push "${nuget_path}" --skip-duplicate -s https://api.nuget.org/v3/index.json -k "${{ env.NUGET_KEY }}"
+            fi
+          done <<< "${{ inputs.nuget-path }}"
+
+      # Clean up
+      - name: Clean up. Wait 60s and delete releas if dry-run or failure. (dry-run=${{ inputs.dry-run }}})
+        if: ${{ inputs.dry-run || failure() }}
+        run: |
+          if gh release list | grep Draft | grep ${{ inputs.tag }}; then
+            sleep 60
+            gh release delete ${{ inputs.tag }} --yes --cleanup-tag
+          fi

--- a/.github/workflows/_create-release.yaml
+++ b/.github/workflows/_create-release.yaml
@@ -1,46 +1,6 @@
 name: (R) Create Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      commit-id:
-        description: "commit-id: CommitId to create release & tag."
-        required: false
-        type: string
-      dry-run:
-        description: "dry-run: true = no upload. false = dry run changes && delete release after 60s."
-        required: true
-        type: boolean
-      require-validation:
-        description: "require-validation: true require validation must pass, false to keep going even validation failed."
-        required: false
-        type: boolean
-        default: true
-      tag:
-        description: "tag: Git tag to create. (sample 1.0.0)"
-        required: true
-        type: string
-      # nuget
-      nuget-push:
-        description: "nuget-push: true = upload nuget package. false = not upload"
-        required: false
-        type: boolean
-        default: false
-      # release
-      release-asset-path:
-        description: "release assets path to upload. This is a list of paths separated by a newline."
-        required: false
-        type: string
-      release-format: # see: https://docs.github.com/en/actions/learn-github-actions/expressions#format
-        description: "release-format: if 'Ver.{0}' is specified, the release title will be 'Ver.1.0.0'. set '{0}' if no prefix is preferred."
-        required: false
-        type: string
-        default: 'Ver.{0}'
-      release-upload:
-        description: "release-upload: true = upload assets. false = not upload"
-        required: false
-        type: boolean
-        default: false
   workflow_call:
     inputs:
       commit-id:
@@ -78,11 +38,6 @@ on:
         description: "release assets path to upload. This is a list of paths separated by a newline."
         required: false
         type: string
-      release-format: # see: https://docs.github.com/en/actions/learn-github-actions/expressions#format
-        description: "Release format. (if 'Ver.{0}' is specified, the release title will be 'Ver.1.0.0'. set '{0}' if no prefix is preferred.)"
-        required: false
-        type: string
-        default: 'Ver.{0}'
       release-upload:
         description: "true = upload assets. false = not upload"
         required: false
@@ -147,12 +102,12 @@ jobs:
           git tag ${{ inputs.tag }}
           git push origin ${{ inputs.tag }}
       - name: Create Release
-        run: gh release create ${{ inputs.tag }} --draft --verify-tag --title "${{ format(inputs.release-format, inputs.tag) }}" --generate-notes
+        run: gh release create ${{ inputs.tag }} --draft --verify-tag --title "${{ inputs.tag }}" --generate-notes
       - name: Wait and Verify Release Name is expected
         run: |
           sleep 5s
           actual=$(gh api --paginate /repos/${{ github.repository }}/releases?per_page=100 --jq '.[] | select(.tag_name == "${{ inputs.tag }}") | .name')
-          expected="${{ format(inputs.release-format, inputs.tag) }}"
+          expected="${{ inputs.tag }}"
           if [[ "$actual" != "$expected" ]]; then
             echo "Release name is not as expected. expected: $expected, actual: $actual"
             exit 1

--- a/.github/workflows/_update-packagejson.yaml
+++ b/.github/workflows/_update-packagejson.yaml
@@ -7,11 +7,6 @@ on:
         description: "package.json path to update. You can input multiline paths. Supported files are `package.json`, `plugin.cfg` and `Directory.Build.props`"
         required: true
         type: string
-      require-validation:
-        description: "true require validation must pass, false to keep going even validation failed."
-        required: false
-        type: boolean
-        default: true
       tag:
         description: "git tag you want create. (sample v1.0.0)"
         required: true
@@ -25,11 +20,6 @@ on:
         required: false
         type: boolean
         default: true
-      ref:
-        description: "checkout ref"
-        required: false
-        type: string
-        default: ''
     outputs:
       sha:
         description: "Git commit sha after package.json has changed."
@@ -82,8 +72,6 @@ jobs:
           echo "branch-name=test-release/${{ inputs.tag }}" | tee -a "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
 
       # package.json
       # "version": 1.2.3 -> "version": 2.0.0
@@ -159,9 +147,6 @@ jobs:
             git commit -m "feat: Update package.json to ${{ needs.validate.outputs.normalized_tag }}" -m "Commit by [GitHub Actions](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" -a
             echo "sha=$(git rev-parse HEAD)" | tee -a "$GITHUB_OUTPUT"
             echo "is-branch-created=${{ inputs.dry-run }}" | tee -a "$GITHUB_OUTPUT"
-          elif [[ "${{ inputs.ref }}" != "" ]]; then
-            echo "sha=$(git rev-parse HEAD)" | tee -a "$GITHUB_OUTPUT"
-            echo "is-branch-created=false" | tee -a "$GITHUB_OUTPUT"
           else
             echo "sha=" | tee -a "$GITHUB_OUTPUT"
             echo "is-branch-created=false" | tee -a "$GITHUB_OUTPUT"
@@ -176,7 +161,6 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }} # auto generated token
-          branch: ${{ inputs.ref }}
           tags: ${{ inputs.push-tag }}
 
       - name: Push changes (dry-run)

--- a/.github/workflows/_update-packagejson.yaml
+++ b/.github/workflows/_update-packagejson.yaml
@@ -1,0 +1,186 @@
+name: (R) Update package.json
+
+on:
+  workflow_call:
+    inputs:
+      file-path:
+        description: "package.json path to update. You can input multiline paths. Supported files are `package.json`, `plugin.cfg` and `Directory.Build.props`"
+        required: true
+        type: string
+      require-validation:
+        description: "true require validation must pass, false to keep going even validation failed."
+        required: false
+        type: boolean
+        default: true
+      tag:
+        description: "git tag you want create. (sample v1.0.0)"
+        required: true
+        type: string
+      dry-run:
+        description: "true to simularate commit but not push change."
+        required: true
+        type: boolean
+      push-tag:
+        description: "true = push tag. false = no push tag."
+        required: false
+        type: boolean
+        default: true
+      ref:
+        description: "checkout ref"
+        required: false
+        type: string
+        default: ''
+    outputs:
+      sha:
+        description: "Git commit sha after package.json has changed."
+        value: ${{ jobs.update-packagejson.outputs.sha }}
+      branch-name:
+        description: Git branch name created.
+        value: ${{ jobs.update-packagejson.outputs.branch-name }}
+      is-branch-created:
+        description: Indicate is Git branch created or not.
+        value: ${{ jobs.update-packagejson.outputs.is-branch-created }}
+      normalized_tag:
+        description: Normalized tag with out v prefix.
+        value: ${{ jobs.validate.outputs.normalized_tag }}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      tag: ${{ steps.trim.outputs.tag }}
+      normalized_tag: ${{ steps.trim.outputs.normalized_tag }}
+    steps:
+      - name: Set version without "v" prefix
+        id: trim
+        run: |
+          input_tag="${{ inputs.tag }}"
+          if [[ "$input_tag" == v* ]]; then
+            normalized_tag="${input_tag:1}"
+          else
+            normalized_tag="$input_tag"
+          fi
+          echo "normalized_tag=$normalized_tag" | tee -a "$GITHUB_OUTPUT"
+          echo "tag=${{ inputs.tag }}" | tee -a "$GITHUB_OUTPUT"
+
+  update-packagejson:
+    needs: [validate]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      sha: ${{ steps.commit.outputs.sha }}
+      branch-name: ${{ steps.configure.outputs.branch-name }}
+      is-branch-created: ${{ steps.commit.outputs.is-branch-created }}
+    steps:
+      - name: Configure Output variables
+        id: configure
+        run: |
+          echo "branch-name=test-release/${{ inputs.tag }}" | tee -a "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      # package.json
+      # "version": 1.2.3 -> "version": 2.0.0
+      # plugin.cfg
+      # version="1.2.3" -> version="2.0.0"
+      #
+      # TIPS: `grep -v "^$"` is used to remove empty line.
+      - name: Update files to version ${{ needs.validate.outputs.normalized_tag }}
+        run: |
+          expected="${{ needs.validate.outputs.normalized_tag }}"
+          while read -r file_path; do
+            if [[ "$file_path" == "" ]]; then continue; fi
+
+            echo "Start $file_path"
+            file_name=$(basename "$file_path")
+
+            echo "::group::Before"
+              cat "$file_path"
+            echo "::endgroup::"
+
+            echo "::group::Updating"
+              if [[ "${file_name}" == "package.json" ]]; then
+                # Unity `"version": "VersionString",`
+                sed -i -e "s/\(\"version\":\) \"\(.*\)\",/\1 \"${{ needs.validate.outputs.normalized_tag }}\",/" "${file_path}"
+              elif [[ "${file_name}" == "plugin.cfg" ]]; then
+                # Godot `version="VersionString"`
+                sed -i -e "s/\(version=\)\"\(.*\)\"/\1\"${{ needs.validate.outputs.normalized_tag }}\"/" "${file_path}"
+              elif [[ "${file_name}" == "Directory.Build.props" ]]; then
+                # .NET `<VersionPrefix>VersionString</VersionPrefix>`
+                sed -i -e 's|<VersionPrefix>.*</VersionPrefix>|<VersionPrefix>${{ needs.validate.outputs.normalized_tag }}</VersionPrefix>|g' "${file_path}"
+              else
+                echo "Unknown file name ${file_name} is specified."
+                exit 1
+              fi
+            echo "::endgroup::"
+
+            echo "::group::After"
+              cat "$file_path"
+            echo "::endgroup::"
+
+            echo "::group::Validate Change"
+              if [[ "${file_name}" == "package.json" ]]; then
+                actual=$(grep "version" "$file_path" | cut -d ':' -f 2 | tr -d ',' | tr -d '"' | tr -d ' ')
+              elif [[ "${file_name}" == "plugin.cfg" ]]; then
+                actual=$(grep "version=" "$file_path" | cut -d '=' -f 2 | tr -d '"')
+              elif [[ "${file_name}" == "Directory.Build.props" ]]; then
+                # -P is for perl regex, only available in GNU grep
+                actual=$(grep -oP '<VersionPrefix>\K.*(?=</VersionPrefix>)' "$file_path")
+              else
+                echo "Validation for ${file_name} is not implemented."
+                exit 1
+              fi
+
+              if [[ "$actual" != "$expected" ]]; then
+                echo "Failed. Path: $file_path, Expected: $expected, Actual: $actual"
+                exit 1
+              else
+                echo "Success. Path: $file_path, Expected: $expected, Actual: $actual"
+              fi
+            echo "::endgroup::"
+          done <<< "${{ inputs.file-path }}"
+
+      - name: Check update on git
+        id: check_update
+        run: git diff --exit-code || echo "changed=1" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Commit files (updated? = ${{ steps.check_update.outputs.changed == '1' }})
+        id: commit
+        run: |
+          if [[ "${{ steps.check_update.outputs.changed }}" == "1" ]]; then
+            git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git config --local user.name "github-actions[bot]"
+            git commit -m "feat: Update package.json to ${{ needs.validate.outputs.normalized_tag }}" -m "Commit by [GitHub Actions](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" -a
+            echo "sha=$(git rev-parse HEAD)" | tee -a "$GITHUB_OUTPUT"
+            echo "is-branch-created=${{ inputs.dry-run }}" | tee -a "$GITHUB_OUTPUT"
+          elif [[ "${{ inputs.ref }}" != "" ]]; then
+            echo "sha=$(git rev-parse HEAD)" | tee -a "$GITHUB_OUTPUT"
+            echo "is-branch-created=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "sha=" | tee -a "$GITHUB_OUTPUT"
+            echo "is-branch-created=false" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Tag
+        if: ${{ steps.check_update.outputs.changed == '1' && inputs.push-tag }}
+        run: git tag ${{ inputs.tag }}
+
+      - name: Push changes
+        if: ${{ !inputs.dry-run && steps.check_update.outputs.changed == '1' }}
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }} # auto generated token
+          branch: ${{ inputs.ref }}
+          tags: ${{ inputs.push-tag }}
+
+      - name: Push changes (dry-run)
+        if: ${{ inputs.dry-run && steps.check_update.outputs.changed == '1' }}
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }} # auto generated token
+          branch: "refs/heads/${{ steps.configure.outputs.branch-name }}"
+          tags: false
+          force: true

--- a/.github/workflows/_update-packagejson.yaml
+++ b/.github/workflows/_update-packagejson.yaml
@@ -96,9 +96,6 @@ jobs:
               if [[ "${file_name}" == "package.json" ]]; then
                 # Unity `"version": "VersionString",`
                 sed -i -e "s/\(\"version\":\) \"\(.*\)\",/\1 \"${{ needs.validate.outputs.normalized_tag }}\",/" "${file_path}"
-              elif [[ "${file_name}" == "plugin.cfg" ]]; then
-                # Godot `version="VersionString"`
-                sed -i -e "s/\(version=\)\"\(.*\)\"/\1\"${{ needs.validate.outputs.normalized_tag }}\"/" "${file_path}"
               elif [[ "${file_name}" == "Directory.Build.props" ]]; then
                 # .NET `<VersionPrefix>VersionString</VersionPrefix>`
                 sed -i -e 's|<VersionPrefix>.*</VersionPrefix>|<VersionPrefix>${{ needs.validate.outputs.normalized_tag }}</VersionPrefix>|g' "${file_path}"
@@ -115,8 +112,6 @@ jobs:
             echo "::group::Validate Change"
               if [[ "${file_name}" == "package.json" ]]; then
                 actual=$(grep "version" "$file_path" | cut -d ':' -f 2 | tr -d ',' | tr -d '"' | tr -d ' ')
-              elif [[ "${file_name}" == "plugin.cfg" ]]; then
-                actual=$(grep "version=" "$file_path" | cut -d '=' -f 2 | tr -d '"')
               elif [[ "${file_name}" == "Directory.Build.props" ]]; then
                 # -P is for perl regex, only available in GNU grep
                 actual=$(grep -oP '<VersionPrefix>\K.*(?=</VersionPrefix>)' "$file_path")

--- a/.github/workflows/_update-packagejson.yaml
+++ b/.github/workflows/_update-packagejson.yaml
@@ -52,15 +52,18 @@ jobs:
       tag: ${{ steps.trim.outputs.tag }}
       normalized_tag: ${{ steps.trim.outputs.normalized_tag }}
     steps:
+      - name: tag must begin with v
+        run: |
+          input_tag="${{ inputs.tag }}"
+          if [[ "$input_tag" != v* ]]; then
+            echo "Tag must begin with v. Current tag: $input_tag"
+            exit 1
+          fi
       - name: Set version without "v" prefix
         id: trim
         run: |
           input_tag="${{ inputs.tag }}"
-          if [[ "$input_tag" == v* ]]; then
-            normalized_tag="${input_tag:1}"
-          else
-            normalized_tag="$input_tag"
-          fi
+          normalized_tag="${input_tag:1}"
           echo "normalized_tag=$normalized_tag" | tee -a "$GITHUB_OUTPUT"
           echo "tag=${{ inputs.tag }}" | tee -a "$GITHUB_OUTPUT"
 

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -22,8 +22,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
-    - uses: actions/setup-dotnet@v4
-      with:
-        global-json-file: global.json
+    - uses: ./.github/actions/setup-dotnet
     - run: dotnet build -c ${{ env.BUILD_CONFIG }}
     - run: dotnet test -c ${{ env.BUILD_CONFIG }} --no-build

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,15 +13,17 @@ on:
         type: boolean
 
 jobs:
-  update-packagejson: # for-unity, need to update package.json from tag
-    uses: Cysharp/Actions/.github/workflows/update-packagejson.yaml@main
+  # for unity. need update package.json from tag
+  update-packagejson:
+    uses: ./.github/workflows/_update-packagejson.yaml
     with:
       file-path: |
         ./src/MessagePack.UnityClient/Assets/Scripts/MessagePack/package.json
       tag: ${{ inputs.tag }}
       dry-run: ${{ inputs.dry-run }}
-      push-tag: false
+      push-tag: true
 
+  # for dotnet. Build nuget package
   build-dotnet:
     needs: [update-packagejson]
     runs-on: ubuntu-latest
@@ -31,32 +33,37 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.update-packagejson.outputs.sha }}
-      - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
       # pack nuget
-      - run: dotnet build -c Release -p:Version=${{ inputs.tag }}
+      - run: dotnet build -c Release -p:Version=${{ needs.update-packagejson.outputs.normalized_tag }}
       - run: dotnet test -c Release --no-build
-      - run: dotnet pack -c Release --no-build -p:Version=${{ inputs.tag }} -o ./publish
-      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
+      - run: dotnet pack -c Release --no-build -p:Version=${{ needs.update-packagejson.outputs.normalized_tag }} -o ./publish
+      - name: upload artifacts
+        uses: actions/upload-artifact@v4 # must sync with actions/download-artifact@v4 in create-release
         with:
           name: nuget
           path: ./publish
-          retention-days: 1
+          if-no-files-found: 'error' # default 'warn'
+          retention-days: 1 # expire in 1 day
 
-  # release TODO:Cysharp/create-release needs credential
-  # create-release:
-  #   needs: [update-packagejson, build-dotnet]
-  #   uses: Cysharp/Actions/.github/workflows/create-release.yaml@main
-  #   with:
-  #     dry-run: ${{ inputs.dry-run }}
-  #     commit-id: ${{ needs.update-packagejson.outputs.sha }}
-  #     tag: ${{ inputs.tag }}
-  #     nuget-push: true
-  #     release-upload: true
-  #   secrets: inherit
+  # create release and upload nuget
+  create-release:
+    needs: [update-packagejson, build-dotnet]
+    uses: ./.github/workflows/_create-release.yaml
+    with:
+      commit-id: ${{ needs.update-packagejson.outputs.sha }}
+      dry-run: ${{ inputs.dry-run }}
+      nuget-push: true
+      release-upload: true
+      tag: ${{ inputs.tag }}
+    secrets: inherit
 
+  # delete dry-run created git branch
   cleanup:
     if: ${{ needs.update-packagejson.outputs.is-branch-created == 'true' }}
     needs: [update-packagejson, create-release]
-    uses: Cysharp/Actions/.github/workflows/clean-packagejson-branch.yaml@main
+    uses: ./.github/workflows/_clean-packagejson-branch.yaml
     with:
       branch: ${{ needs.update-packagejson.outputs.branch-name }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -56,14 +56,8 @@ jobs:
       nuget-push: true
       release-upload: true
       release-asset-path: |
-        ./publish/MessagePack.${{ needs.update-packagejson.outputs.normalized_tag }}.nupkg
-        MessagePack.Annotations.${{ needs.update-packagejson.outputs.normalized_tag }}.nupkg
-        MessagePack.AspNetCoreMvcFormatter.${{ needs.update-packagejson.outputs.normalized_tag }}.nupkg
-        MessagePack.Experimental.${{ needs.update-packagejson.outputs.normalized_tag }}.nupkg
-        MessagePack.ImmutableCollection.${{ needs.update-packagejson.outputs.normalized_tag }}.nupkg
-        MessagePack.ReactiveProperty.${{ needs.update-packagejson.outputs.normalized_tag }}.nupkg
-        MessagePack.UnityShims.${{ needs.update-packagejson.outputs.normalized_tag }}.nupkg
-        MessagePackAnalyzer.${{ needs.update-packagejson.outputs.normalized_tag }}.nupkg
+        ./nuget/*.nupkg
+        ./nuget/*.snupkg
       tag: ${{ inputs.tag }}
     secrets: inherit
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/upload-artifact@v4 # must sync with actions/download-artifact@v4 in create-release
         with:
           name: nuget
-          path: ./publish
+          path: ./nuget/
           if-no-files-found: 'error' # default 'warn'
           retention-days: 1 # expire in 1 day
 
@@ -55,6 +55,15 @@ jobs:
       dry-run: ${{ inputs.dry-run }}
       nuget-push: true
       release-upload: true
+      release-asset-path: |
+        ./publish/MessagePack.${{ needs.update-packagejson.outputs.normalized_tag }}.nupkg
+        MessagePack.Annotations.${{ needs.update-packagejson.outputs.normalized_tag }}.nupkg
+        MessagePack.AspNetCoreMvcFormatter.${{ needs.update-packagejson.outputs.normalized_tag }}.nupkg
+        MessagePack.Experimental.${{ needs.update-packagejson.outputs.normalized_tag }}.nupkg
+        MessagePack.ImmutableCollection.${{ needs.update-packagejson.outputs.normalized_tag }}.nupkg
+        MessagePack.ReactiveProperty.${{ needs.update-packagejson.outputs.normalized_tag }}.nupkg
+        MessagePack.UnityShims.${{ needs.update-packagejson.outputs.normalized_tag }}.nupkg
+        MessagePackAnalyzer.${{ needs.update-packagejson.outputs.normalized_tag }}.nupkg
       tag: ${{ inputs.tag }}
     secrets: inherit
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -33,9 +33,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.update-packagejson.outputs.sha }}
-      - uses: actions/setup-dotnet@v4
-        with:
-          global-json-file: global.json
+      - uses: ./.github/actions/setup-dotnet
       # pack nuget
       - run: dotnet build -c Release -p:Version=${{ needs.update-packagejson.outputs.normalized_tag }}
       - run: dotnet test -c Release --no-build

--- a/.github/workflows/unity.yml
+++ b/.github/workflows/unity.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         global-json-file: global.json
     - run: dotnet build -c ${{ env.BUILD_CONFIG }} # require dotnet build (Debug) before Unity build.
-    
+
     - name: restore and run local tool for NuGetForUnity
       working-directory: ./src/MessagePack.UnityClient
       run: |
@@ -59,6 +59,7 @@ jobs:
     - name: Execute UnitTest
       run: ./src/MessagePack.UnityClient/bin/UnitTest/StandaloneLinux64_IL2CPP/test
 
-    - uses: Cysharp/Actions/.github/actions/check-metas@main # check meta files
+    # check meta files
+    - uses: ./.github/actions/check-metas
       with:
         directory: src/MessagePack.UnityClient

--- a/.github/workflows/unity.yml
+++ b/.github/workflows/unity.yml
@@ -22,9 +22,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
-    - uses: actions/setup-dotnet@v4
-      with:
-        global-json-file: global.json
+    - uses: ./.github/actions/setup-dotnet
     - run: dotnet build -c ${{ env.BUILD_CONFIG }} # require dotnet build (Debug) before Unity build.
 
     - name: restore and run local tool for NuGetForUnity


### PR DESCRIPTION
## tl;dr;

This pull request includes several updates to GitHub Actions workflows to improve automation and streamline the setup process. The changes primarily involve the creation of new composite actions and the modification of existing workflows to use these actions.

## Description of concerns

Release flow should cover following concerns. 

**Release Tag naming**

You should input `v1.0.0` as release version, NOT `1.0.0`.

| type | current naming style | with `v` or not |
| --- | --- | --- |
| [git tag](https://github.com/MessagePack-CSharp/MessagePack-CSharp/tags) | v1.0.0 | need v prefix|
| [GitHubRelease](https://github.com/MessagePack-CSharp/MessagePack-CSharp/releases/tag/v2.5.192) | v1.0.0 | need v prefix |
| [NuGet package](https://www.nuget.org/packages/messagepack) | 1.0.0 | w/o v prefix |

**GITHUB SECRET handling**

Please add `NUGET_KEY` to your Org or Repo secret.

## GitHub Actions updates

### New Composite Actions:
* [`.github/actions/check-metas/action.yaml`](diffhunk://#diff-d8914262a611f2715aef77b7a866380b768bd40e9b34c61e3918f1d2f1466279R1-R33): Added a new action to check if all Unity `.meta` files are committed.
* [`.github/actions/setup-dotnet/action.yaml`](diffhunk://#diff-f7ca64a553355397e0dd61d06eaaf9d768929186b7c725788550650e7895356fR1-R52): Added a new action to set up .NET SDKs and configure environment variables.

### New Reusable Workflows:

* [`.github/workflows/_clean-packagejson-branch.yaml`](diffhunk://#diff-b52b677b518942785185d27c9012ed70732d85bd8937c62d8f975d628946f137R1-R54): Created a new workflow to clean up branches created by GitHub Actions bots that are not the default branch.
* [`.github/workflows/_create-release.yaml`](diffhunk://#diff-c01978695ee114e80c57097a01f451aaba3e4559254d18f5b0951fe70306bad7R1-R156): Created a new workflow to automate the release creation process, including validation, tagging, and uploading assets.
* [`.github/workflows/_update-packagejson.yaml`](diffhunk://#diff-50b4516c1937df0e30c632db87f48723ee1f63d23c250dfad9dff3aca1dd8fefR1-R186): Created a new workflow to update `package.json` and other configuration files with a new version tag.

### Workflow Updates:

* [`.github/workflows/build-debug.yml`](diffhunk://#diff-a47402ba595f68a087ff1c5748f9d2fa43986244367edaaaea5db0501466af99L25-R25): Updated to use the new `.github/actions/setup-dotnet` action.
* [`.github/workflows/build-release.yml`](diffhunk://#diff-4d14704b6b88fb06db888f96c03a8e9b3a5e07a4ee566d97d4111b2c05210e84L16-R26): Updated to use the new `_update-packagejson`, `_create-release`, and `_clean-packagejson-branch` workflows. [[1]](diffhunk://#diff-4d14704b6b88fb06db888f96c03a8e9b3a5e07a4ee566d97d4111b2c05210e84L16-R26) [[2]](diffhunk://#diff-4d14704b6b88fb06db888f96c03a8e9b3a5e07a4ee566d97d4111b2c05210e84L34-R65)
* [`.github/workflows/unity.yml`](diffhunk://#diff-3b739592ec0b95d14f953ef27c16fa130d2a7aa4cdb5b410c64357ac161d926cL25-R25): Updated to use the new `.github/actions/setup-dotnet` and `.github/actions/check-metas` actions. [[1]](diffhunk://#diff-3b739592ec0b95d14f953ef27c16fa130d2a7aa4cdb5b410c64357ac161d926cL25-R25) [[2]](diffhunk://#diff-3b739592ec0b95d14f953ef27c16fa130d2a7aa4cdb5b410c64357ac161d926cL62-R61)

