### PR TITLE
Touch-ups to master

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "nbgv": {
-      "version": "3.6.143",
+      "version": "3.6.146",
       "commands": [
         "nbgv"
       ]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -74,7 +74,7 @@
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" />
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.143" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.146" />
     <GlobalPackageReference Include="Nullable" Version="1.3.1" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
   </ItemGroup>

--- a/src/MessagePack.Experimental/MessagePack.Experimental.csproj
+++ b/src/MessagePack.Experimental/MessagePack.Experimental.csproj
@@ -7,8 +7,6 @@
     <Title>MessagePack for C#, Experimental Plugins</Title>
     <Description>Extremely Fast MessagePack Serializer for C#(.NET, .NET Core, Unity, Xamarin). Experimental implementations.</Description>
     <PackageTags>MsgPack;MessagePack;Serialization;Formatter;Serializer</PackageTags>
-    <!-- TODO:v3.0.3 upload issue so disable temporary -->
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.0.300",
+  "version": "3.0",
+  "versionHeightOffset": 300,
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/v1\\.x$",


### PR DESCRIPTION
- [Re-enable packing of MessagePack.Experimental](https://github.com/MessagePack-CSharp/MessagePack-CSharp/commit/e01602ff364bb990d95b128ab467754aa49c0aeb)
- Fix version.json to resume counting with the 3rd version integer.

I plan to add to this PR to re-activate NB.GV as the determiner of version numbers.