### PR TITLE
Fix Source Generator doesnt work in Unity

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -61,7 +61,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition=" ('$(TargetFramework)' == 'netstandard2.0' and '$(IsAnalyzerProject)' != 'true') or '$(TargetFramework)' == 'net472'">
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />


### PR DESCRIPTION
The System.Collections.Immutable version updates Source Generators reference in Directory.Package.props.
This will cause Source Generators to stop working in Unity projects.
Therefore, we stopped updating all packages in IsAnalyzerProject.
Fix #2086 