### PR TITLE
Check IsGenericType before call ConstructUnboundGenericType()

### DIFF
--- a/src/MessagePack.SourceGenerator/Analyzers/MsgPack00xMessagePackAnalyzer.cs
+++ b/src/MessagePack.SourceGenerator/Analyzers/MsgPack00xMessagePackAnalyzer.cs
@@ -369,11 +369,12 @@ public class MsgPack00xMessagePackAnalyzer : DiagnosticAnalyzer
         if (options.KnownFormattersByName.TryGetValue(typeName, out FormatterDescriptor? formatter))
         {
             // Call out any formattable reference types that are not nullable.
-            INamedTypeSymbol[] missing = (
-                from iface in declaredSymbol.Interfaces
-                where SymbolEqualityComparer.Default.Equals(iface.ConstructUnboundGenericType(), typeReferences.MessagePackFormatterOfT) &&
-                    iface.TypeArguments is [INamedTypeSymbol { IsReferenceType: true, NullableAnnotation: NullableAnnotation.NotAnnotated } a]
-                select (INamedTypeSymbol)iface.TypeArguments[0]).ToArray();
+            INamedTypeSymbol[] missing = declaredSymbol.Interfaces
+                .Where(iface => iface.IsGenericType)
+                .Where(iface => SymbolEqualityComparer.Default.Equals(iface.ConstructUnboundGenericType(), typeReferences.MessagePackFormatterOfT)
+                             && iface.TypeArguments is [INamedTypeSymbol { IsReferenceType: true, NullableAnnotation: NullableAnnotation.NotAnnotated } a])
+                .Select(iface => (INamedTypeSymbol)iface.TypeArguments[0])
+                .ToArray();
 
             if (missing.Length > 0)
             {

--- a/src/MessagePack.SourceGenerator/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.SourceGenerator/CodeAnalysis/TypeCollector.cs
@@ -610,7 +610,7 @@ public class TypeCollector
             return;
         }
 
-        if (type.AllInterfaces.FirstOrDefault(x => !x.IsUnboundGenericType && x.ConstructUnboundGenericType() is { Name: nameof(ICollection<int>) }) is INamedTypeSymbol collectionIface
+        if (type.AllInterfaces.FirstOrDefault(x => x.IsGenericType && !x.IsUnboundGenericType && x.ConstructUnboundGenericType() is { Name: nameof(ICollection<int>) }) is INamedTypeSymbol collectionIface
             && type.InstanceConstructors.Any(ctor => ctor.Parameters.Length == 0))
         {
             this.CollectCore(collectionIface.TypeArguments[0], callerSymbol);

--- a/src/MessagePack.SourceGenerator/MessagePack.SourceGenerator.csproj
+++ b/src/MessagePack.SourceGenerator/MessagePack.SourceGenerator.csproj
@@ -8,6 +8,7 @@
     <AnalyzerLanguage>cs</AnalyzerLanguage>
     <DebugType>embedded</DebugType>
     <IsPackable>false</IsPackable>
+    <IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
fixed #2092 
and add `<IsRoslynComponent>true</IsRoslynComponent>` for debugging.