### PR TITLE
allow DynamicGenericResolver to StandardResolver in DynamicAssembly.AvoidDynamicCode

### DIFF
--- a/src/MessagePack/Resolvers/StandardResolver.cs
+++ b/src/MessagePack/Resolvers/StandardResolver.cs
@@ -259,7 +259,7 @@ namespace MessagePack.Internal
     internal static class StandardResolverHelper
     {
         public static readonly IFormatterResolver[] DefaultResolvers = DynamicAssembly.AvoidDynamicCode
-            ? [BuiltinResolver.Instance, AttributeFormatterResolver.Instance, SourceGeneratedFormatterResolver.Instance, ImmutableCollection.ImmutableCollectionResolver.Instance, CompositeResolver.Create(ExpandoObjectFormatter.Instance)]
+            ? [BuiltinResolver.Instance, AttributeFormatterResolver.Instance, SourceGeneratedFormatterResolver.Instance, ImmutableCollection.ImmutableCollectionResolver.Instance, CompositeResolver.Create(ExpandoObjectFormatter.Instance), DynamicGenericResolver.Instance]
             : [BuiltinResolver.Instance, AttributeFormatterResolver.Instance, SourceGeneratedFormatterResolver.Instance, ImmutableCollection.ImmutableCollectionResolver.Instance, CompositeResolver.Create(ExpandoObjectFormatter.Instance), DynamicGenericResolver.Instance, DynamicUnionResolver.Instance];
     }
 }


### PR DESCRIPTION
With the current Unity's IL2CPP Full Generic Sharing, MakeGenericType works in many cases.
Therefore, it can likely be enabled even with AvoidDynamicCode.
https://unity.com/blog/engine-platform/il2cpp-full-generic-sharing-in-unity-2022-1-beta

Regarding NativeAOT, we should fundamentally reconsider the strategy.
In any case, since this Resolver becomes the endpoint when AvoidDynamicCode is used, enabling it wouldn't make a difference (either way it will throw an exception - whether it's because the Formatter wasn't found or because of an invalid MakeGenericType call).