### PR TITLE
Consolidation of AssemblyBuilderAccess when generating dynamic assemblies

### DIFF
--- a/src/MessagePack/Internal/DynamicAssembly.cs
+++ b/src/MessagePack/Internal/DynamicAssembly.cs
@@ -33,12 +33,10 @@ namespace MessagePack.Internal
         /// <param name="skipVisibilityChecksTo">The names of assemblies that should be fully accessible to this dynamic one, bypassing visibility checks.</param>
         public DynamicAssembly(string moduleName, ImmutableHashSet<AssemblyName> skipVisibilityChecksTo)
         {
-#if NETFRAMEWORK // We don't ship a net472 target, but we might add one for debugging purposes
-            AssemblyBuilderAccess builderAccess = AssemblyBuilderAccess.RunAndSave;
+#if NETFRAMEWORK
             this.moduleName = moduleName;
-#else
-            AssemblyBuilderAccess builderAccess = AssemblyBuilderAccess.RunAndCollect;
 #endif
+            AssemblyBuilderAccess builderAccess = AssemblyBuilderAccess.RunAndCollect;
             this.assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(moduleName), builderAccess);
             this.moduleBuilder = this.assemblyBuilder.DefineDynamicModule(moduleName + ".dll");
 


### PR DESCRIPTION
Hi.

I was recently upgrading `MassTransit`'s referenced version of `MessagePack` to the latest major version, when I discovered some tests were failing for **ONLY for** `.NET Framework 4.7.2`, due to the following exception:
> System.NotSupportedException: A non-collectible assembly may not reference a collectible assembly.

Upon some research I found the cause, which appeared to be a `MassTransit` generating dynamic assemblies that are collectible, while `MessagePack`'s dynamic assemblies are non-collectible.

Please see my discussion for my `MassTransit` PR: https://github.com/MassTransit/MassTransit/pull/5726
Additionally, I found an earlier issue for `MessagePack` involving the same issue for `.NET 5`, rather than `.NET Framework 4.7.2`: https://github.com/MessagePack-CSharp/MessagePack-CSharp/issues/1150.

The PR that resolved the mentioned issue only affects non-framework builds, so I am curious if there is a specific reason why the `.NET Framework` builds do not share the same `AssemblyBuilderAccess` flag. 

With these changes, both `MessagePack` & `MassTransit` pass their respective tests, so I would love to hear your thoughts and concerns. 