### PR TITLE
Remove FluentAssertions, Use Shouldly

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
     <PackageVersion Include="Ceras" Version="4.1.7" />
     <PackageVersion Include="ConsoleAppFramework" Version="4.2.4" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="FsPickler" Version="5.3.2" />
     <PackageVersion Include="Hyperion" Version="0.12.2" />
     <PackageVersion Include="IsExternalInit" Version="1.0.3" />

--- a/tests/MessagePack.SourceGenerator.Tests/MessagePack.SourceGenerator.Tests.csproj
+++ b/tests/MessagePack.SourceGenerator.Tests/MessagePack.SourceGenerator.Tests.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Shouldly" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />

--- a/tests/MessagePack.Tests/MessagePack.Tests.csproj
+++ b/tests/MessagePack.Tests/MessagePack.Tests.csproj
@@ -38,12 +38,12 @@
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Xunit.SkippableFact" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />
     <Using Include="Xunit.Abstractions" />
-    <Using Include="FluentAssertions" />
+    <Using Include="Shouldly" />
     <Using Include="MessagePack" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/MessagePack.Tests/NewCollectionTypesTest.cs
+++ b/tests/MessagePack.Tests/NewCollectionTypesTest.cs
@@ -31,7 +31,7 @@ public class NewCollectionTypesTest
 
         var v2 = Convert(v);
 
-        v.AsEnumerable().Should().Equal(v2.AsEnumerable());
+        v.AsEnumerable().ShouldBe(v2.AsEnumerable());
     }
 
     [Fact]
@@ -39,7 +39,7 @@ public class NewCollectionTypesTest
     {
         var v = new ReadOnlySet<int>(new HashSet<int>() { 1, 2, 5, 3, 9, 7 });
         var v2 = Convert(v);
-        v2.Should().Equal(v);
+        v2.ShouldBe(v);
     }
 }
 

--- a/tests/MessagePack.Tests/NewStandardClassTypesTest.cs
+++ b/tests/MessagePack.Tests/NewStandardClassTypesTest.cs
@@ -20,7 +20,7 @@ public class NewStandardClassTypesTest
         Rune v = Rune.GetRuneAt("あ", 0);
         var bin = MessagePackSerializer.Serialize(v);
         var v2 = MessagePackSerializer.Deserialize<Rune>(bin);
-        v2.Should().Be(v);
+        v2.ShouldBe(v);
     }
 
     // NET7
@@ -36,7 +36,7 @@ public class NewStandardClassTypesTest
         var i = new Int128(upper, lower);
         var bin = MessagePackSerializer.Serialize(i);
         var i2 = MessagePackSerializer.Deserialize<Int128>(bin);
-        i.Should().Be(i2);
+        i.ShouldBe(i2);
     }
 
     [Theory]
@@ -50,7 +50,7 @@ public class NewStandardClassTypesTest
         var i = new UInt128(upper, lower);
         var bin = MessagePackSerializer.Serialize(i);
         var i2 = MessagePackSerializer.Deserialize<UInt128>(bin);
-        i.Should().Be(i2);
+        i.ShouldBe(i2);
     }
 }
 #endif


### PR DESCRIPTION
`FluentAssertions` has been acquired and changed to a commercial license.
https://github.com/fluentassertions/fluentassertions/pull/2943
Such an abrupt license change from OSS is unacceptable.
I removed `FluentAssertions` and switched to [Shouldly](https://github.com/shouldly/shouldly), which provides equivalent functionality.

This repository has been using `ChainingAssertion`, a library I created 10 years ago, and some parts of it still remain.
I had planned to eventually replace all of it with FluentAssertions, but that plan is now on hold.