### PR TITLE
Protects the generated resolver type metadata from trimmer

### DIFF
--- a/src/MessagePack/Internal/GeneratedAssemblyMessagePackResolverAttribute.cs
+++ b/src/MessagePack/Internal/GeneratedAssemblyMessagePackResolverAttribute.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MessagePack.Internal
 {
@@ -23,7 +24,7 @@ namespace MessagePack.Internal
         /// The <see cref="Version.Minor"/> component of the version of the generator that produced the resolver and formatters.
         /// This may be used to determine whether the resolver and formatters are compatible with the current version of MessagePack.
         /// </param>
-        public GeneratedAssemblyMessagePackResolverAttribute(Type resolverType, int majorVersion, int minorVersion)
+        public GeneratedAssemblyMessagePackResolverAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type resolverType, int majorVersion, int minorVersion)
         {
             ResolverType = resolverType;
             MajorVersion = majorVersion;

--- a/src/MessagePack/Internal/PolyfillAttributes.cs
+++ b/src/MessagePack/Internal/PolyfillAttributes.cs
@@ -1,0 +1,302 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1649 // File name should match first type name
+#pragma warning disable SA1402 // File may only contain a single type
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+namespace System.Diagnostics.CodeAnalysis
+{
+#if !NET8_0_OR_GREATER
+    /// <summary>
+    /// Indicates that the specified method requires the ability to generate new code at runtime,
+    /// for example through <see cref="Reflection"/>.
+    /// </summary>
+    /// <remarks>
+    /// This allows tools to understand which methods are unsafe to call when compiling ahead of time.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class, Inherited = false)]
+    [Conditional("NEVERDEFINED")] // We don't need these attributes preserved in the compilation if the runtime doesn't support it.
+    internal sealed class RequiresDynamicCodeAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequiresDynamicCodeAttribute"/> class
+        /// with the specified message.
+        /// </summary>
+        /// <param name="message">
+        /// A message that contains information about the usage of dynamic code.
+        /// </param>
+        public RequiresDynamicCodeAttribute(string message)
+        {
+            Message = message;
+        }
+
+        /// <summary>
+        /// Gets a message that contains information about the usage of dynamic code.
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// Gets or sets an optional URL that contains more information about the method,
+        /// why it requires dynamic code, and what options a consumer has to deal with it.
+        /// </summary>
+        public string? Url { get; set; }
+    }
+#endif
+
+#if !NET6_0_OR_GREATER
+    /// <summary>
+    /// Suppresses reporting of a specific rule violation, allowing multiple suppressions on a
+    /// single code artifact.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="UnconditionalSuppressMessageAttribute"/> is different than
+    /// <see cref="SuppressMessageAttribute"/> in that it doesn't have a
+    /// <see cref="ConditionalAttribute"/>. So it is always preserved in the compiled assembly.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+    [Conditional("NEVERDEFINED")] // We don't need these attributes preserved in the compilation if the runtime doesn't support it.
+    internal sealed class UnconditionalSuppressMessageAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnconditionalSuppressMessageAttribute"/>
+        /// class, specifying the category of the tool and the identifier for an analysis rule.
+        /// </summary>
+        /// <param name="category">The category for the attribute.</param>
+        /// <param name="checkId">The identifier of the analysis rule the attribute applies to.</param>
+        public UnconditionalSuppressMessageAttribute(string category, string checkId)
+        {
+            Category = category;
+            CheckId = checkId;
+        }
+
+        /// <summary>
+        /// Gets the category identifying the classification of the attribute.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Category"/> property describes the tool or tool analysis category
+        /// for which a message suppression attribute applies.
+        /// </remarks>
+        public string Category { get; }
+
+        /// <summary>
+        /// Gets the identifier of the analysis tool rule to be suppressed.
+        /// </summary>
+        /// <remarks>
+        /// Concatenated together, the <see cref="Category"/> and <see cref="CheckId"/>
+        /// properties form a unique check identifier.
+        /// </remarks>
+        public string CheckId { get; }
+
+        /// <summary>
+        /// Gets or sets the scope of the code that is relevant for the attribute.
+        /// </summary>
+        /// <remarks>
+        /// The Scope property is an optional argument that specifies the metadata scope for which
+        /// the attribute is relevant.
+        /// </remarks>
+        public string? Scope { get; set; }
+
+        /// <summary>
+        /// Gets or sets a fully qualified path that represents the target of the attribute.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Target"/> property is an optional argument identifying the analysis target
+        /// of the attribute. An example value is "System.IO.Stream.ctor():System.Void".
+        /// Because it is fully qualified, it can be long, particularly for targets such as parameters.
+        /// The analysis tool user interface should be capable of automatically formatting the parameter.
+        /// </remarks>
+        public string? Target { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional argument expanding on exclusion criteria.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="MessageId "/> property is an optional argument that specifies additional
+        /// exclusion where the literal metadata target is not sufficiently precise. For example,
+        /// the <see cref="UnconditionalSuppressMessageAttribute"/> cannot be applied within a method,
+        /// and it may be desirable to suppress a violation against a statement in the method that will
+        /// give a rule violation, but not against all statements in the method.
+        /// </remarks>
+        public string? MessageId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the justification for suppressing the code analysis message.
+        /// </summary>
+        public string? Justification { get; set; }
+    }
+
+    /// <summary>
+    /// Indicates that the specified method requires dynamic access to code that is not referenced
+    /// statically, for example through <see cref="Reflection"/>.
+    /// </summary>
+    /// <remarks>
+    /// This allows tools to understand which methods are unsafe to call when removing unreferenced
+    /// code from an application.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class, Inherited = false)]
+    [Conditional("NEVERDEFINED")] // We don't need these attributes preserved in the compilation if the runtime doesn't support it.
+    internal sealed class RequiresUnreferencedCodeAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequiresUnreferencedCodeAttribute"/> class
+        /// with the specified message.
+        /// </summary>
+        /// <param name="message">
+        /// A message that contains information about the usage of unreferenced code.
+        /// </param>
+        public RequiresUnreferencedCodeAttribute(string message)
+        {
+            Message = message;
+        }
+
+        /// <summary>
+        /// Gets a message that contains information about the usage of unreferenced code.
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// Gets or sets an optional URL that contains more information about the method,
+        /// why it requires unreferenced code, and what options a consumer has to deal with it.
+        /// </summary>
+        public string? Url { get; set; }
+    }
+
+    /// <summary>
+    /// Indicates that certain members on a specified <see cref="Type"/> are accessed dynamically,
+    /// for example through <see cref="Reflection"/>.
+    /// </summary>
+    /// <remarks>
+    /// This allows tools to understand which members are being accessed during the execution
+    /// of a program.
+    ///
+    /// This attribute is valid on members whose type is <see cref="Type"/> or <see cref="string"/>.
+    ///
+    /// When this attribute is applied to a location of type <see cref="string"/>, the assumption is
+    /// that the string represents a fully qualified type name.
+    ///
+    /// When this attribute is applied to a class, interface, or struct, the members specified
+    /// can be accessed dynamically on <see cref="Type"/> instances returned from calling
+    /// <see cref="object.GetType"/> on instances of that class, interface, or struct.
+    ///
+    /// If the attribute is applied to a method it's treated as a special case and it implies
+    /// the attribute should be applied to the "this" parameter of the method. As such the attribute
+    /// should only be used on instance methods of types assignable to System.Type (or string, but no methods
+    /// will use it there).
+    /// </remarks>
+    [AttributeUsage(
+        AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |
+        AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Method |
+        AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct,
+        Inherited = false)]
+    [Conditional("NEVERDEFINED")] // We don't need these attributes preserved in the compilation if the runtime doesn't support it.
+    internal sealed class DynamicallyAccessedMembersAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicallyAccessedMembersAttribute"/> class
+        /// with the specified member types.
+        /// </summary>
+        /// <param name="memberTypes">The types of members dynamically accessed.</param>
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+        {
+            MemberTypes = memberTypes;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="DynamicallyAccessedMemberTypes"/> which specifies the type
+        /// of members dynamically accessed.
+        /// </summary>
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+    }
+
+    /// <summary>
+    /// Specifies the types of members that are dynamically accessed. This enumeration
+    /// has a System.FlagsAttribute attribute that allows a bitwise combination of its
+    /// member values.
+    /// </summary>
+    [Flags]
+    internal enum DynamicallyAccessedMemberTypes
+    {
+        /// <summary>
+        /// Specifies all members.
+        /// </summary>
+        All = -1,
+
+        /// <summary>
+        /// Specifies no members.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Specifies the default, parameterless public constructor.
+        /// </summary>
+        PublicParameterlessConstructor = 1,
+
+        /// <summary>
+        /// Specifies all public constructors.
+        /// </summary>
+        PublicConstructors = 3,
+
+        /// <summary>
+        /// Specifies all non-public constructors.
+        /// </summary>
+        NonPublicConstructors = 4,
+
+        /// <summary>
+        /// Specifies all public methods.
+        /// </summary>
+        PublicMethods = 8,
+
+        /// <summary>
+        /// Specifies all non-public methods.
+        /// </summary>
+        NonPublicMethods = 16,
+
+        /// <summary>
+        /// Specifies all public fields.
+        /// </summary>
+        PublicFields = 32,
+
+        /// <summary>
+        /// Specifies all non-public fields.
+        /// </summary>
+        NonPublicFields = 64,
+
+        /// <summary>
+        /// Specifies all public nested types.
+        /// </summary>
+        PublicNestedTypes = 128,
+
+        /// <summary>
+        /// Specifies all non-public nested types.
+        /// </summary>
+        NonPublicNestedTypes = 256,
+
+        /// <summary>
+        /// Specifies all public properties.
+        /// </summary>
+        PublicProperties = 512,
+
+        /// <summary>
+        /// Specifies all non-public properties.
+        /// </summary>
+        NonPublicProperties = 1024,
+
+        /// <summary>
+        /// Specifies all public events.
+        /// </summary>
+        PublicEvents = 2048,
+
+        /// <summary>
+        /// Specifies all non-public events.
+        /// </summary>
+        NonPublicEvents = 4096,
+
+        /// <summary>
+        /// Specifies all interfaces implemented by the type.
+        /// </summary>
+        Interfaces = 8192,
+    }
+#endif
+}


### PR DESCRIPTION
This PR adds attribute for trimmer to `GeneratedAssemblyMessagePackResolverAttribute`.

The metadata about the type of the generated Resolver (`resolverType`) specified in `GeneratedAssemblyMessagePackResolverAttribute` is not referenced anywhere, so it will be removed by the trimmer. As a result, the generated Resolver cannot be found and does not work as expected on Native AOT.

Work on Native AOT support was previously in progress in #1998, but it was not merged, so this PR is a workaround to make it minimally workable.