### PR TITLE
Fix issues about Double.MaxValue

### DIFF
--- a/src/MessagePack/MessagePackSerializer.Json.cs
+++ b/src/MessagePack/MessagePackSerializer.Json.cs
@@ -291,11 +291,11 @@ namespace MessagePack
                 case MessagePackType.Float:
                     if (reader.NextCode == MessagePackCode.Float32)
                     {
-                        writer.Write(reader.ReadSingle().ToString(CultureInfo.InvariantCulture));
+                        writer.Write(reader.ReadSingle().ToString("R", CultureInfo.InvariantCulture));
                     }
                     else
                     {
-                        writer.Write(reader.ReadDouble().ToString(CultureInfo.InvariantCulture));
+                        writer.Write(reader.ReadDouble().ToString("R", CultureInfo.InvariantCulture));
                     }
 
                     break;


### PR DESCRIPTION
Double.MaxValue default to stirng is 1.79769313486232E+308, then using Newtonsoft to parse will throw OverflowException.