### PR TITLE
Add PreserveAttribute to generic formatters for Unity IL2CPP

### DIFF
--- a/sandbox/DynamicCodeDumper/Program.cs
+++ b/sandbox/DynamicCodeDumper/Program.cs
@@ -467,3 +467,13 @@ namespace DynamicCodeDumper
     ////    }
     ////}
 }
+
+
+#pragma warning disable
+
+namespace MessagePack.Internal
+{
+    internal sealed class PreserveAttribute : System.Attribute
+    {
+    }
+}

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/IL2CPPTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/IL2CPPTest.cs
@@ -4,6 +4,8 @@
 #nullable enable
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using MessagePack;
 using NUnit.Framework;
@@ -72,6 +74,33 @@ namespace Assets.Scripts.Tests
 
             var ys = MessagePackSerializer.Deserialize<MyClass[]>(bin, lz4Option);
             CollectionAssert.AreEqual(xs, ys);
+        }
+
+        [Test]
+        public void EnumSerialize()
+        {
+            var bin = MessagePackSerializer.Serialize(MessagePackCompression.Lz4BlockArray);
+            var v2 = MessagePackSerializer.Deserialize<MessagePackCompression>(bin);
+
+            Assert.AreEqual(MessagePackCompression.Lz4BlockArray, v2);
+        }
+
+        [Test]
+        public void ListSerialize()
+        {
+            var bin = MessagePackSerializer.Serialize(new List<ulong> { 10UL });
+            var v2 = MessagePackSerializer.Deserialize<List<ulong>>(bin);
+
+            CollectionAssert.AreEqual(new List<ulong> { 10UL }, v2);
+        }
+
+        [Test]
+        public void ConcurrentBagSerialize()
+        {
+            var bin = MessagePackSerializer.Serialize(new ConcurrentBag<ulong> { 10UL });
+            var v2 = MessagePackSerializer.Deserialize<ConcurrentBag<ulong>>(bin);
+
+            CollectionAssert.AreEqual(new ConcurrentBag<ulong> { 10UL }, v2);
         }
     }
 

--- a/src/MessagePack/Formatters/CollectionFormatter.cs
+++ b/src/MessagePack/Formatters/CollectionFormatter.cs
@@ -10,12 +10,14 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
+using MessagePack.Internal;
 
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1649 // File name should match first type name
 
 namespace MessagePack.Formatters
 {
+    [Preserve]
     public sealed class ArrayFormatter<T> : IMessagePackFormatter<T[]?>
     {
         public void Serialize(ref MessagePackWriter writer, T[]? value, MessagePackSerializerOptions options)
@@ -158,6 +160,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class MemoryFormatter<T> : IMessagePackFormatter<Memory<T>>
     {
         public void Serialize(ref MessagePackWriter writer, Memory<T> value, MessagePackSerializerOptions options)
@@ -172,6 +175,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class ReadOnlyMemoryFormatter<T> : IMessagePackFormatter<ReadOnlyMemory<T>>
     {
         public void Serialize(ref MessagePackWriter writer, ReadOnlyMemory<T> value, MessagePackSerializerOptions options)
@@ -194,6 +198,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class ReadOnlySequenceFormatter<T> : IMessagePackFormatter<ReadOnlySequence<T>>
     {
         public void Serialize(ref MessagePackWriter writer, ReadOnlySequence<T> value, MessagePackSerializerOptions options)
@@ -218,6 +223,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class ArraySegmentFormatter<T> : IMessagePackFormatter<ArraySegment<T>>
     {
         public void Serialize(ref MessagePackWriter writer, ArraySegment<T> value, MessagePackSerializerOptions options)
@@ -248,6 +254,7 @@ namespace MessagePack.Formatters
     }
 
     // List<T> is popular format, should avoid abstraction.
+    [Preserve]
     public sealed class ListFormatter<T> : IMessagePackFormatter<List<T>?>
     {
         public void Serialize(ref MessagePackWriter writer, List<T>? value, MessagePackSerializerOptions options)
@@ -464,6 +471,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class GenericCollectionFormatter<TElement, TCollection> : CollectionFormatterBase<TElement, TCollection>
          where TCollection : ICollection<TElement>, new()
     {
@@ -478,6 +486,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class GenericEnumerableFormatter<TElement, TCollection> : CollectionFormatterBase<TElement, TElement[], TCollection>
         where TCollection : IEnumerable<TElement>
     {
@@ -497,6 +506,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class LinkedListFormatter<T> : CollectionFormatterBase<T, LinkedList<T>, LinkedList<T>.Enumerator, LinkedList<T>>
     {
         protected override void Add(LinkedList<T> collection, int index, T value, MessagePackSerializerOptions options)
@@ -520,6 +530,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class QueueFormatter<T> : CollectionFormatterBase<T, Queue<T>, Queue<T>.Enumerator, Queue<T>>
     {
         protected override int? GetCount(Queue<T> sequence)
@@ -640,6 +651,7 @@ namespace MessagePack.Formatters
 #endif
 
     // should deserialize reverse order.
+    [Preserve]
     public sealed class StackFormatter<T> : CollectionFormatterBase<T, T[], Stack<T>.Enumerator, Stack<T>>
     {
         protected override int? GetCount(Stack<T> sequence)
@@ -669,6 +681,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class HashSetFormatter<T> : CollectionFormatterBase<T, HashSet<T>, HashSet<T>.Enumerator, HashSet<T>>
     {
         protected override int? GetCount(HashSet<T> sequence)
@@ -697,6 +710,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class ReadOnlyCollectionFormatter<T> : CollectionFormatterBase<T, T[], ReadOnlyCollection<T>>
     {
         protected override void Add(T[] collection, int index, T value, MessagePackSerializerOptions options)
@@ -753,6 +767,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class InterfaceListFormatter2<T> : CollectionFormatterBase<T, List<T>, IList<T>>
     {
         protected override void Add(List<T> collection, int index, T value, MessagePackSerializerOptions options)
@@ -771,6 +786,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class InterfaceCollectionFormatter2<T> : CollectionFormatterBase<T, List<T>, ICollection<T>>
     {
         protected override void Add(List<T> collection, int index, T value, MessagePackSerializerOptions options)
@@ -789,6 +805,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class InterfaceEnumerableFormatter<T> : CollectionFormatterBase<T, T[], IEnumerable<T>>
     {
         protected override void Add(T[] collection, int index, T value, MessagePackSerializerOptions options)
@@ -808,6 +825,7 @@ namespace MessagePack.Formatters
     }
 
     // [Key, [Array]]
+    [Preserve]
     public sealed class InterfaceGroupingFormatter<TKey, TElement> : IMessagePackFormatter<IGrouping<TKey, TElement>?>
     {
         public void Serialize(ref MessagePackWriter writer, IGrouping<TKey, TElement>? value, MessagePackSerializerOptions options)
@@ -854,6 +872,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class InterfaceLookupFormatter<TKey, TElement> : CollectionFormatterBase<IGrouping<TKey, TElement>, Dictionary<TKey, IGrouping<TKey, TElement>>, ILookup<TKey, TElement>>
         where TKey : notnull
     {
@@ -947,6 +966,7 @@ namespace MessagePack.Formatters
 
     /* NonGenerics */
 
+    [Preserve]
     public sealed class NonGenericListFormatter<T> : IMessagePackFormatter<T?>
         where T : class, IList, new()
     {
@@ -998,6 +1018,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class NonGenericInterfaceCollectionFormatter : IMessagePackFormatter<ICollection?>
     {
         public static readonly IMessagePackFormatter<ICollection?> Instance = new NonGenericInterfaceCollectionFormatter();
@@ -1058,6 +1079,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class NonGenericInterfaceEnumerableFormatter : IMessagePackFormatter<IEnumerable?>
     {
         public static readonly IMessagePackFormatter<IEnumerable?> Instance = new NonGenericInterfaceEnumerableFormatter();
@@ -1199,6 +1221,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class NonGenericDictionaryFormatter<T> : IMessagePackFormatter<T?>
         where T : class, IDictionary, new()
     {
@@ -1312,6 +1335,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class ObservableCollectionFormatter<T> : CollectionFormatterBase<T, ObservableCollection<T>>
     {
         protected override void Add(ObservableCollection<T> collection, int index, T value, MessagePackSerializerOptions options)
@@ -1325,6 +1349,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class ReadOnlyObservableCollectionFormatter<T> : CollectionFormatterBase<T, ObservableCollection<T>, ReadOnlyObservableCollection<T>>
     {
         protected override void Add(ObservableCollection<T> collection, int index, T value, MessagePackSerializerOptions options)
@@ -1343,6 +1368,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class InterfaceReadOnlyListFormatter<T> : CollectionFormatterBase<T, T[], IReadOnlyList<T>>
     {
         protected override void Add(T[] collection, int index, T value, MessagePackSerializerOptions options)
@@ -1361,6 +1387,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class InterfaceReadOnlyCollectionFormatter<T> : CollectionFormatterBase<T, T[], IReadOnlyCollection<T>>
     {
         protected override void Add(T[] collection, int index, T value, MessagePackSerializerOptions options)
@@ -1379,6 +1406,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class InterfaceSetFormatter<T> : CollectionFormatterBase<T, HashSet<T>, ISet<T>>
     {
         protected override void Add(HashSet<T> collection, int index, T value, MessagePackSerializerOptions options)
@@ -1441,6 +1469,7 @@ namespace MessagePack.Formatters
 
 #endif
 
+    [Preserve]
     public sealed class ConcurrentBagFormatter<T> : CollectionFormatterBase<T, System.Collections.Concurrent.ConcurrentBag<T>>
     {
         protected override int? GetCount(ConcurrentBag<T> sequence)
@@ -1459,6 +1488,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class ConcurrentQueueFormatter<T> : CollectionFormatterBase<T, System.Collections.Concurrent.ConcurrentQueue<T>>
     {
         protected override int? GetCount(ConcurrentQueue<T> sequence)
@@ -1477,6 +1507,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class ConcurrentStackFormatter<T> : CollectionFormatterBase<T, T[], ConcurrentStack<T>>
     {
         protected override int? GetCount(ConcurrentStack<T> sequence)

--- a/src/MessagePack/Formatters/DictionaryFormatter.cs
+++ b/src/MessagePack/Formatters/DictionaryFormatter.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Reflection;
+using MessagePack.Internal;
 
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1649 // File name should match first type name
@@ -141,6 +142,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class DictionaryFormatter<TKey, TValue> : DictionaryFormatterBase<TKey, TValue, Dictionary<TKey, TValue>, Dictionary<TKey, TValue>.Enumerator, Dictionary<TKey, TValue>>
         where TKey : notnull
     {
@@ -165,6 +167,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class GenericDictionaryFormatter<TKey, TValue, TDictionary> : DictionaryFormatterBase<TKey, TValue, TDictionary>
         where TDictionary : class?, IDictionary<TKey, TValue>, new()
         where TKey : notnull
@@ -180,6 +183,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class GenericReadOnlyDictionaryFormatter<TKey, TValue, TDictionary> : DictionaryFormatterBase<TKey, TValue, Dictionary<TKey, TValue>, TDictionary>
         where TDictionary : class?, IReadOnlyDictionary<TKey, TValue>
         where TKey : notnull
@@ -200,6 +204,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class InterfaceDictionaryFormatter<TKey, TValue> : DictionaryFormatterBase<TKey, TValue, Dictionary<TKey, TValue>, IDictionary<TKey, TValue>>
         where TKey : notnull
     {
@@ -219,6 +224,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class SortedListFormatter<TKey, TValue> : DictionaryFormatterBase<TKey, TValue, SortedList<TKey, TValue>>
         where TKey : notnull
     {
@@ -233,6 +239,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class SortedDictionaryFormatter<TKey, TValue> : DictionaryFormatterBase<TKey, TValue, SortedDictionary<TKey, TValue>, SortedDictionary<TKey, TValue>.Enumerator, SortedDictionary<TKey, TValue>>
         where TKey : notnull
     {
@@ -257,6 +264,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class ReadOnlyDictionaryFormatter<TKey, TValue> : DictionaryFormatterBase<TKey, TValue, Dictionary<TKey, TValue>, ReadOnlyDictionary<TKey, TValue>>
         where TKey : notnull
     {
@@ -276,6 +284,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class InterfaceReadOnlyDictionaryFormatter<TKey, TValue> : DictionaryFormatterBase<TKey, TValue, Dictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>>
         where TKey : notnull
     {
@@ -295,6 +304,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class ConcurrentDictionaryFormatter<TKey, TValue> : DictionaryFormatterBase<TKey, TValue, System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue>>
         where TKey : notnull
     {

--- a/src/MessagePack/Formatters/EnumAsStringFormatter`1.cs
+++ b/src/MessagePack/Formatters/EnumAsStringFormatter`1.cs
@@ -10,6 +10,7 @@ using MessagePack.Internal;
 namespace MessagePack.Formatters
 {
     // Note:This implementation is 'not' fastest, should more improve.
+    [Preserve]
     public sealed class EnumAsStringFormatter<T> : IMessagePackFormatter<T>
         where T : struct, Enum
     {

--- a/src/MessagePack/Formatters/GenericEnumFormatter`1.cs
+++ b/src/MessagePack/Formatters/GenericEnumFormatter`1.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using MessagePack.Internal;
 
 namespace MessagePack.Formatters
 {
+    [Preserve]
     public sealed class GenericEnumFormatter<T> : IMessagePackFormatter<T>
         where T : struct, Enum
     {

--- a/src/MessagePack/Formatters/ImmutableCollectionFormatters.cs
+++ b/src/MessagePack/Formatters/ImmutableCollectionFormatters.cs
@@ -70,7 +70,12 @@ namespace MessagePack.ImmutableCollection
                     reader.Depth--;
                 }
 
+                // Unity IL2CPP sometimes failes on ImmutableCollectionsMarshal.AsImmutableArray(array) so netstandard version degrade it.
+#if NETSTANDARD2_0 || NETSTANDARD2_1
+                return ImmutableArray.Create(array);
+#else
                 return ImmutableCollectionsMarshal.AsImmutableArray(array);
+#endif
             }
         }
     }

--- a/src/MessagePack/Formatters/MultiDimensionalArrayFormatter.cs
+++ b/src/MessagePack/Formatters/MultiDimensionalArrayFormatter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Text;
+using MessagePack.Internal;
 
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1649 // File name should match first type name
@@ -13,6 +14,7 @@ namespace MessagePack.Formatters
 {
     /* multi dimensional array serialize to [i, j, [seq]] */
 
+    [Preserve]
     public sealed class TwoDimensionalArrayFormatter<T> : IMessagePackFormatter<T[,]?>
     {
         private const int ArrayLength = 3;
@@ -96,6 +98,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class ThreeDimensionalArrayFormatter<T> : IMessagePackFormatter<T[,,]?>
     {
         private const int ArrayLength = 4;
@@ -189,6 +192,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class FourDimensionalArrayFormatter<T> : IMessagePackFormatter<T[,,,]?>
     {
         private const int ArrayLength = 5;

--- a/src/MessagePack/Formatters/NullableFormatter.cs
+++ b/src/MessagePack/Formatters/NullableFormatter.cs
@@ -2,12 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
+using MessagePack.Internal;
 
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1649 // File name should match first type name
 
 namespace MessagePack.Formatters
 {
+    [Preserve]
     public sealed class NullableFormatter<T> : IMessagePackFormatter<T?>
         where T : struct
     {
@@ -37,6 +39,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class StaticNullableFormatter<T> : IMessagePackFormatter<T?>
         where T : struct
     {

--- a/src/MessagePack/Formatters/StandardClassLibraryFormatter.cs
+++ b/src/MessagePack/Formatters/StandardClassLibraryFormatter.cs
@@ -375,6 +375,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class KeyValuePairFormatter<TKey, TValue> : IMessagePackFormatter<KeyValuePair<TKey, TValue>>
     {
         public void Serialize(ref MessagePackWriter writer, KeyValuePair<TKey, TValue> value, MessagePackSerializerOptions options)
@@ -765,6 +766,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class LazyFormatter<T> : IMessagePackFormatter<Lazy<T>?>
     {
         public void Serialize(ref MessagePackWriter writer, Lazy<T>? value, MessagePackSerializerOptions options)
@@ -808,6 +810,7 @@ namespace MessagePack.Formatters
     /// Serializes any instance of <see cref="Type"/> by its <see cref="Type.AssemblyQualifiedName"/> value.
     /// </summary>
     /// <typeparam name="T">The <see cref="Type"/> class itself or a derived type.</typeparam>
+    [Preserve]
     public sealed class TypeFormatter<T> : IMessagePackFormatter<T?>
         where T : Type
     {

--- a/src/MessagePack/Formatters/TupleFormatter.cs
+++ b/src/MessagePack/Formatters/TupleFormatter.cs
@@ -6,12 +6,14 @@
 
 using System;
 using System.Buffers;
+using MessagePack.Internal;
 
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1649 // File name should match first type name
 
 namespace MessagePack.Formatters
 {
+    [Preserve]
     public sealed class TupleFormatter<T1> : IMessagePackFormatter<Tuple<T1>?>
     {
         public void Serialize(ref MessagePackWriter writer, Tuple<T1>? value, MessagePackSerializerOptions options)
@@ -59,6 +61,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class TupleFormatter<T1, T2> : IMessagePackFormatter<Tuple<T1, T2>?>
     {
         public void Serialize(ref MessagePackWriter writer, Tuple<T1, T2>? value, MessagePackSerializerOptions options)
@@ -108,6 +111,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class TupleFormatter<T1, T2, T3> : IMessagePackFormatter<Tuple<T1, T2, T3>?>
     {
         public void Serialize(ref MessagePackWriter writer, Tuple<T1, T2, T3>? value, MessagePackSerializerOptions options)
@@ -159,6 +163,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class TupleFormatter<T1, T2, T3, T4> : IMessagePackFormatter<Tuple<T1, T2, T3, T4>?>
     {
         public void Serialize(ref MessagePackWriter writer, Tuple<T1, T2, T3, T4>? value, MessagePackSerializerOptions options)
@@ -212,6 +217,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class TupleFormatter<T1, T2, T3, T4, T5> : IMessagePackFormatter<Tuple<T1, T2, T3, T4, T5>?>
     {
         public void Serialize(ref MessagePackWriter writer, Tuple<T1, T2, T3, T4, T5>? value, MessagePackSerializerOptions options)
@@ -267,6 +273,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class TupleFormatter<T1, T2, T3, T4, T5, T6> : IMessagePackFormatter<Tuple<T1, T2, T3, T4, T5, T6>?>
     {
         public void Serialize(ref MessagePackWriter writer, Tuple<T1, T2, T3, T4, T5, T6>? value, MessagePackSerializerOptions options)
@@ -324,6 +331,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class TupleFormatter<T1, T2, T3, T4, T5, T6, T7> : IMessagePackFormatter<Tuple<T1, T2, T3, T4, T5, T6, T7>?>
     {
         public void Serialize(ref MessagePackWriter writer, Tuple<T1, T2, T3, T4, T5, T6, T7>? value, MessagePackSerializerOptions options)
@@ -383,6 +391,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class TupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest> : IMessagePackFormatter<Tuple<T1, T2, T3, T4, T5, T6, T7, TRest>?>
         where TRest : notnull
     {

--- a/src/MessagePack/Formatters/TupleFormatter.tt
+++ b/src/MessagePack/Formatters/TupleFormatter.tt
@@ -12,6 +12,7 @@
 
 using System;
 using System.Buffers;
+using MessagePack.Internal;
 
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1649 // File name should match first type name
@@ -24,6 +25,7 @@ namespace MessagePack.Formatters
     var t = "Tuple<" + ts + ">";
 #>
 
+    [Preserve]
     public sealed class TupleFormatter<<#= ts #>> : IMessagePackFormatter<<#= t #>?>
 <# if (i == 8) { #>
         where TRest : notnull

--- a/src/MessagePack/Formatters/ValueTupleFormatter.cs
+++ b/src/MessagePack/Formatters/ValueTupleFormatter.cs
@@ -6,12 +6,14 @@
 
 using System;
 using System.Buffers;
+using MessagePack.Internal;
 
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1649 // File name should match first type name
 
 namespace MessagePack.Formatters
 {
+    [Preserve]
     public sealed class ValueTupleFormatter<T1> : IMessagePackFormatter<ValueTuple<T1>>
     {
         public void Serialize(ref MessagePackWriter writer, ValueTuple<T1> value, MessagePackSerializerOptions options)
@@ -52,6 +54,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class ValueTupleFormatter<T1, T2> : IMessagePackFormatter<ValueTuple<T1, T2>>
     {
         public void Serialize(ref MessagePackWriter writer, ValueTuple<T1, T2> value, MessagePackSerializerOptions options)
@@ -94,6 +97,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class ValueTupleFormatter<T1, T2, T3> : IMessagePackFormatter<ValueTuple<T1, T2, T3>>
     {
         public void Serialize(ref MessagePackWriter writer, ValueTuple<T1, T2, T3> value, MessagePackSerializerOptions options)
@@ -138,6 +142,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class ValueTupleFormatter<T1, T2, T3, T4> : IMessagePackFormatter<ValueTuple<T1, T2, T3, T4>>
     {
         public void Serialize(ref MessagePackWriter writer, ValueTuple<T1, T2, T3, T4> value, MessagePackSerializerOptions options)
@@ -184,6 +189,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class ValueTupleFormatter<T1, T2, T3, T4, T5> : IMessagePackFormatter<ValueTuple<T1, T2, T3, T4, T5>>
     {
         public void Serialize(ref MessagePackWriter writer, ValueTuple<T1, T2, T3, T4, T5> value, MessagePackSerializerOptions options)
@@ -232,6 +238,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class ValueTupleFormatter<T1, T2, T3, T4, T5, T6> : IMessagePackFormatter<ValueTuple<T1, T2, T3, T4, T5, T6>>
     {
         public void Serialize(ref MessagePackWriter writer, ValueTuple<T1, T2, T3, T4, T5, T6> value, MessagePackSerializerOptions options)
@@ -282,6 +289,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7> : IMessagePackFormatter<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>
     {
         public void Serialize(ref MessagePackWriter writer, ValueTuple<T1, T2, T3, T4, T5, T6, T7> value, MessagePackSerializerOptions options)
@@ -334,6 +342,7 @@ namespace MessagePack.Formatters
         }
     }
 
+    [Preserve]
     public sealed class ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest> : IMessagePackFormatter<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>
         where TRest : struct
     {

--- a/src/MessagePack/Formatters/ValueTupleFormatter.tt
+++ b/src/MessagePack/Formatters/ValueTupleFormatter.tt
@@ -12,6 +12,7 @@
 
 using System;
 using System.Buffers;
+using MessagePack.Internal;
 
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1649 // File name should match first type name
@@ -24,6 +25,7 @@ namespace MessagePack.Formatters
     var t = "ValueTuple<" + ts + ">";
 #>
 
+    [Preserve]
     public sealed class ValueTupleFormatter<<#= ts #>> : IMessagePackFormatter<<#= t #>><#= (t.Contains("TRest") ? @"
         where TRest : struct" : "") #>
     {

--- a/src/MessagePack/Internal/PreserveAttribute.cs
+++ b/src/MessagePack/Internal/PreserveAttribute.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace MessagePack.Internal;
+
+// In Unity's AOT environment, MakeGenericType often works for Full Generic Sharing.
+// https://unity.com/blog/engine-platform/il2cpp-full-generic-sharing-in-unity-2022-1-beta
+
+// Therefore, even with AvoidDynamicCode, we include DynamicGenericResolver in StandardResolver.
+// However, if the Formatter itself is stripped, it naturally won't function.
+// While this behavior changes depending on Unity's build settings' StrippingLevel,
+// we want MessagePack for C# to operate as naturally as possible even at the highest stripping level.
+
+// To achieve this, we'll make Generic Formatters preserve.
+// Since PreserveAttribute can be application-specific, we'll implement it as an internal type.
+// https://docs.unity3d.com/6000.0/Documentation/Manual/managed-code-stripping-preserving.html
+
+// Additionally, when supporting the generation of Generic-compatible Formatters,
+// it might be worth considering making it a public type and applying it to generated types.
+
+internal sealed class PreserveAttribute : System.Attribute
+{
+}


### PR DESCRIPTION
In Unity's AOT environment, MakeGenericType often works for Full Generic Sharing.
https://unity.com/blog/engine-platform/il2cpp-full-generic-sharing-in-unity-2022-1-beta

Therefore, even with AvoidDynamicCode, we include DynamicGenericResolver in StandardResolver.
However, if the Formatter itself is stripped, it naturally won't function.
While this behavior changes depending on Unity's build settings' StrippingLevel,
we want MessagePack for C# to operate as naturally as possible even at the highest stripping level.

To achieve this, we'll make Generic Formatters preserve.
Since PreserveAttribute can be application-specific, we'll implement it as an internal type.
https://docs.unity3d.com/6000.0/Documentation/Manual/managed-code-stripping-preserving.html

Additionally, when supporting the generation of Generic-compatible Formatters,
it might be worth considering making it a public type and applying it to generated types.

#2134 is also related, Having looked into Native AOT related matters recently, I'm starting to think it's better to settle for an approach where things work - even if they might result in runtime errors in some cases - with workarounds available, rather than obsessing over 100% compatibility.