### PR TITLE
Change ByteListFormatter behaviour to keep binary compatibility for List<byte>

### DIFF
--- a/src/MessagePack/Formatters/PrimitiveFormatter.cs
+++ b/src/MessagePack/Formatters/PrimitiveFormatter.cs
@@ -173,6 +173,7 @@ namespace MessagePack.Formatters
             return list;
         }
     }
+
 #endif
 
     public sealed class Int32Formatter : IMessagePackFormatter<Int32>
@@ -329,6 +330,7 @@ namespace MessagePack.Formatters
             return list;
         }
     }
+
 #endif
 
     public sealed class Int64Formatter : IMessagePackFormatter<Int64>
@@ -485,6 +487,7 @@ namespace MessagePack.Formatters
             return list;
         }
     }
+
 #endif
 
     public sealed class UInt16Formatter : IMessagePackFormatter<UInt16>
@@ -641,6 +644,7 @@ namespace MessagePack.Formatters
             return list;
         }
     }
+
 #endif
 
     public sealed class UInt32Formatter : IMessagePackFormatter<UInt32>
@@ -797,6 +801,7 @@ namespace MessagePack.Formatters
             return list;
         }
     }
+
 #endif
 
     public sealed class UInt64Formatter : IMessagePackFormatter<UInt64>
@@ -953,6 +958,7 @@ namespace MessagePack.Formatters
             return list;
         }
     }
+
 #endif
 
     public sealed class SingleFormatter : IMessagePackFormatter<Single>
@@ -1109,6 +1115,7 @@ namespace MessagePack.Formatters
             return list;
         }
     }
+
 #endif
 
     public sealed class DoubleFormatter : IMessagePackFormatter<Double>
@@ -1265,6 +1272,7 @@ namespace MessagePack.Formatters
             return list;
         }
     }
+
 #endif
 
     public sealed class BooleanFormatter : IMessagePackFormatter<Boolean>
@@ -1513,76 +1521,6 @@ namespace MessagePack.Formatters
         }
     }
 
-#if NET8_0_OR_GREATER
-    public sealed class ByteListFormatter : IMessagePackFormatter<List<Byte>?>
-    {
-        public static readonly ByteListFormatter Instance = new ByteListFormatter();
-
-        private ByteListFormatter()
-        {
-        }
-
-        public void Serialize(ref MessagePackWriter writer, List<Byte>? value, MessagePackSerializerOptions options)
-        {
-            if (value == null)
-            {
-                writer.WriteNil();
-            }
-            else
-            {
-                writer.Write(CollectionsMarshal.AsSpan(value));
-            }
-        }
-
-        public List<Byte>? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
-        {
-            if (reader.NextMessagePackType == MessagePackType.Array)
-            {
-                int len = reader.ReadArrayHeader();
-                if (len == 0)
-                {
-                    return [];
-                }
-
-                var list = new List<byte>(len);
-                options.Security.DepthStep(ref reader);
-                try
-                {
-                    CollectionsMarshal.SetCount(list, len);
-                    var span = CollectionsMarshal.AsSpan(list);
-                    for (int i = 0; i < len; i++)
-                    {
-                        reader.CancellationToken.ThrowIfCancellationRequested();
-                        span[i] = reader.ReadByte();
-                    }
-                }
-                finally
-                {
-                    reader.Depth--;
-                }
-
-                return list;
-            }
-            else
-            {
-                var sequence = reader.ReadBytes();
-                if (sequence == null)
-                {
-                    return null;
-                }
-
-                int len = checked((int)sequence.Value.Length);
-                var list = new List<byte>(len);
-                CollectionsMarshal.SetCount(list, len);
-                var span = CollectionsMarshal.AsSpan(list);
-                sequence.Value.CopyTo(span);
-                return list;
-            }
-        }
-    }
-
-#endif
-
     public sealed class SByteFormatter : IMessagePackFormatter<SByte>
     {
         public static readonly SByteFormatter Instance = new SByteFormatter();
@@ -1737,6 +1675,7 @@ namespace MessagePack.Formatters
             return list;
         }
     }
+
 #endif
 
     public sealed class CharFormatter : IMessagePackFormatter<Char>
@@ -1893,6 +1832,7 @@ namespace MessagePack.Formatters
             return list;
         }
     }
+
 #endif
 
     public sealed class DateTimeFormatter : IMessagePackFormatter<DateTime>

--- a/src/MessagePack/Formatters/PrimitiveFormatter.tt
+++ b/src/MessagePack/Formatters/PrimitiveFormatter.tt
@@ -95,79 +95,7 @@ namespace MessagePack.Formatters
             }
         }
     }
-<# if(t.Name == "Byte") { #>
-
-#if NET8_0_OR_GREATER
-    public sealed class <#= t.Name #>ListFormatter : IMessagePackFormatter<List<<#= t.Name #>>?>
-    {
-        public static readonly <#= t.Name #>ListFormatter Instance = new <#= t.Name #>ListFormatter();
-
-        private <#= t.Name #>ListFormatter()
-        {
-        }
-
-        public void Serialize(ref MessagePackWriter writer, List<<#= t.Name #>>? value, MessagePackSerializerOptions options)
-        {
-            if (value == null)
-            {
-                writer.WriteNil();
-            }
-            else
-            {
-                writer.Write(CollectionsMarshal.AsSpan(value));
-            }
-        }
-
-        public List<<#= t.Name #>>? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
-        {
-            if (reader.NextMessagePackType == MessagePackType.Array)
-            {
-                int len = reader.ReadArrayHeader();
-                if (len == 0)
-                {
-                    return [];
-                }
-
-                var list = new List<byte>(len);
-                options.Security.DepthStep(ref reader);
-                try
-                {
-                    CollectionsMarshal.SetCount(list, len);
-                    var span = CollectionsMarshal.AsSpan(list);
-                    for (int i = 0; i < len; i++)
-                    {
-                        reader.CancellationToken.ThrowIfCancellationRequested();
-                        span[i] = reader.ReadByte();
-                    }
-                }
-                finally
-                {
-                    reader.Depth--;
-                }
-
-                return list;
-            }
-            else
-            {
-                var sequence = reader.ReadBytes();
-                if (sequence == null)
-                {
-                    return null;
-                }
-
-                int len = checked((int)sequence.Value.Length);
-                var list = new List<byte>(len);
-                CollectionsMarshal.SetCount(list, len);
-                var span = CollectionsMarshal.AsSpan(list);
-                sequence.Value.CopyTo(span);
-                return list;
-            }
-        }
-    }
-
-#endif
-<# } #>
-<# else if(t.Name == "DateTime") { #>
+<# if(t.Name == "DateTime") { #>
 
     public sealed class <#= t.Name #>ArrayFormatter : IMessagePackFormatter<<#= t.Name #>[]?>
     {
@@ -360,7 +288,7 @@ namespace MessagePack.Formatters
     }
 #endif
 <# } #>
-<# else { #>
+<# else if(t.Name != "Byte") { #>
 
     public sealed class <#= t.Name #>ArrayFormatter : IMessagePackFormatter<<#= t.Name #>[]?>
     {
@@ -464,6 +392,7 @@ namespace MessagePack.Formatters
             return list;
         }
     }
+
 #endif
 <# } #>
 <# } #>

--- a/src/MessagePack/Resolvers/BuiltinResolver.cs
+++ b/src/MessagePack/Resolvers/BuiltinResolver.cs
@@ -131,7 +131,6 @@ namespace MessagePack.Internal
             { typeof(List<Single>), SingleListFormatter.Instance },
             { typeof(List<Double>), DoubleListFormatter.Instance },
             { typeof(List<Boolean>), BooleanListFormatter.Instance },
-            { typeof(List<byte>), ByteListFormatter.Instance },
             { typeof(List<SByte>), SByteListFormatter.Instance },
             { typeof(List<Char>), CharListFormatter.Instance },
 #else

--- a/src/MessagePack/Resolvers/BuiltinResolver.cs
+++ b/src/MessagePack/Resolvers/BuiltinResolver.cs
@@ -143,7 +143,6 @@ namespace MessagePack.Internal
             { typeof(List<Single>), new ListFormatter<Single>() },
             { typeof(List<Double>), new ListFormatter<Double>() },
             { typeof(List<Boolean>), new ListFormatter<Boolean>() },
-            { typeof(List<byte>), new ListFormatter<byte>() },
             { typeof(List<SByte>), new ListFormatter<SByte>() },
             { typeof(List<Char>), new ListFormatter<Char>() },
 #endif

--- a/src/MessagePack/Resolvers/BuiltinResolver.cs
+++ b/src/MessagePack/Resolvers/BuiltinResolver.cs
@@ -149,6 +149,7 @@ namespace MessagePack.Internal
 #endif
             { typeof(List<DateTime>), new ListFormatter<DateTime>() },
             { typeof(List<string>), new ListFormatter<string>() },
+            { typeof(List<Byte>), ByteListFormatter.Instance }, // special formatter to maintain compatibility due to bugs
 
             { typeof(object[]), new ArrayFormatter<object>() },
             { typeof(List<object>), new ListFormatter<object>() },


### PR DESCRIPTION
about: https://github.com/MessagePack-CSharp/MessagePack-CSharp/issues/2099#issuecomment-2611324420

@AArnott @pCYSl5EDgo 
Last year, due to optimization code that was introduced, the serialization results for `List<byte>` became different between .NET 8 and other versions.
The correct behavior should be returning identical serialization results across all platforms.
Therefore, we reverted the behavior of `List<byte>` to its original state.

This is a breaking change that requires careful consideration.
To protect serialized `List<byte>` data that already exists in .NET 8 environments,
we decided to support both array and binary deserialization.
We believe this will allow for updates without practical issues.