### PR TITLE
Fix stackoverflow on analyzer

### DIFF
--- a/sandbox/Sandbox/Program.cs
+++ b/sandbox/Sandbox/Program.cs
@@ -26,14 +26,9 @@ Console.WriteLine("foo");
 //}
 
 
-[MessagePackObject(true)]
-public class Tako
+public class ClassA<T> where T : ClassA<T>.ClassB
 {
-    public IReadOnlySet<int> MyProperty1 { get; set; }
-
-    public PriorityQueue<int, int> MyProperty2 { get; set; }
-
-    public OrderedDictionary<int, int> MyProperty3 { get; set; }
-
-    public ReadOnlySet<int> MyProperty4 { get; set; }
+    public class ClassB
+    {
+    }
 }

--- a/src/MessagePack.SourceGenerator/Analyzers/MsgPack00xMessagePackAnalyzer.cs
+++ b/src/MessagePack.SourceGenerator/Analyzers/MsgPack00xMessagePackAnalyzer.cs
@@ -363,7 +363,7 @@ public class MsgPack00xMessagePackAnalyzer : DiagnosticAnalyzer
     private static void SymbolStartAction(SymbolStartAnalysisContext context, ReferenceSymbols typeReferences, AnalyzerOptions options)
     {
         INamedTypeSymbol declaredSymbol = (INamedTypeSymbol)context.Symbol;
-        QualifiedNamedTypeName typeName = new(declaredSymbol);
+        QualifiedNamedTypeName typeName = new(declaredSymbol, ImmutableStack<GenericTypeParameterInfo>.Empty);
 
         // If this is a formatter, confirm that it meets requirements.
         if (options.KnownFormattersByName.TryGetValue(typeName, out FormatterDescriptor? formatter))
@@ -407,7 +407,7 @@ public class MsgPack00xMessagePackAnalyzer : DiagnosticAnalyzer
     private void AnalyzeSymbol(SymbolAnalysisContext context, ReferenceSymbols typeReferences, AnalyzerOptions options)
     {
         INamedTypeSymbol declaredSymbol = (INamedTypeSymbol)context.Symbol;
-        QualifiedNamedTypeName typeName = new(declaredSymbol);
+        QualifiedNamedTypeName typeName = new(declaredSymbol, ImmutableStack<GenericTypeParameterInfo>.Empty);
 
         // If this is a formatter, confirm that it meets requirements.
         if (options.KnownFormattersByName.TryGetValue(typeName, out FormatterDescriptor? formatter))

--- a/src/MessagePack.SourceGenerator/CodeAnalysis/QualifiedNamedTypeName.cs
+++ b/src/MessagePack.SourceGenerator/CodeAnalysis/QualifiedNamedTypeName.cs
@@ -42,7 +42,7 @@ public record QualifiedNamedTypeName : QualifiedTypeName, IComparable<QualifiedN
         this.Name = symbol.Name;
         this.Kind = symbol.TypeKind;
         this.isRecord |= symbol.IsRecord;
-        this.Container = symbol.ContainingType is { } nesting ? new NestingTypeContainer(new(nesting)) :
+        this.Container = symbol.ContainingType is { } nesting ? new NestingTypeContainer(new(nesting, recursionGuard)) :
             symbol.ContainingNamespace?.GetFullNamespaceName() is string ns ? new NamespaceTypeContainer(ns) :
             null;
         this.TypeParameters = CodeAnalysisUtilities.GetTypeParameters(symbol, recursionGuard);

--- a/src/MessagePack.SourceGenerator/Utils/AnalyzerUtilities.cs
+++ b/src/MessagePack.SourceGenerator/Utils/AnalyzerUtilities.cs
@@ -66,7 +66,7 @@ public static class AnalyzerUtilities
 
         ResolverOptions resolverOptions = new()
         {
-            Name = new QualifiedNamedTypeName((INamedTypeSymbol)targetSymbol),
+            Name = new QualifiedNamedTypeName((INamedTypeSymbol)targetSymbol, ImmutableStack<GenericTypeParameterInfo>.Empty),
         };
 
         GeneratorOptions generatorOptions = new()


### PR DESCRIPTION
Fix #2149

`SymbolStartAction` of `MsgPack00xMessagePackAnalyzer` calls `new QualifiedNamedTypeName()`.
The constructor of `QualifiedNamedTypeName` can surprisingly cause Stackoverflow.
The problem was fixed by setting recursionGuard.

I don't know why recursionGuard is made optional.
There are already several bug reports about this, and it seems to be dangerous code.
Also, generating a `QualifiedNamedTypeName` for every symbol seems like a high cost.