### PR TITLE
Support deserializing a 16 byte binary guid/uuid

### DIFF
--- a/src/MessagePack/Formatters/StandardClassLibraryFormatter.cs
+++ b/src/MessagePack/Formatters/StandardClassLibraryFormatter.cs
@@ -304,7 +304,7 @@ namespace MessagePack.Formatters
 
             if (bytes.Length == 16) // Its binary
             {
-                return new Guid(bytes);
+                return new Guid(bytes, bigEndian: true); // GUID must always be stored big-endian
             }
 
             if (segment.Length != 36)

--- a/src/MessagePack/Formatters/StandardClassLibraryFormatter.cs
+++ b/src/MessagePack/Formatters/StandardClassLibraryFormatter.cs
@@ -298,6 +298,15 @@ namespace MessagePack.Formatters
         public Guid Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
             ReadOnlySequence<byte> segment = reader.ReadStringSequence() ?? throw MessagePackSerializationException.ThrowUnexpectedNilWhileDeserializing<Guid>();
+
+            var bytes = reader.ReadBytes()?.ToArray()
+            ?? throw MessagePackSerializationException.ThrowUnexpectedNilWhileDeserializing<Guid>();
+
+            if (bytes.Length == 16) // Its binary
+            {
+                return new Guid(bytes);
+            }
+
             if (segment.Length != 36)
             {
                 throw new MessagePackSerializationException("Unexpected length of string.");

--- a/src/MessagePack/Formatters/StandardClassLibraryFormatter.cs
+++ b/src/MessagePack/Formatters/StandardClassLibraryFormatter.cs
@@ -289,10 +289,19 @@ namespace MessagePack.Formatters
 
         public unsafe void Serialize(ref MessagePackWriter writer, Guid value, MessagePackSerializerOptions options)
         {
-            byte* pBytes = stackalloc byte[36];
-            Span<byte> bytes = new Span<byte>(pBytes, 36);
-            new GuidBits(ref value).Write(bytes);
-            writer.WriteString(bytes);
+            if (options.BigEndianUuid) // TODO: This doesn't exist yet
+            {
+                byte* pBytes = stackalloc byte[16];
+                Span<byte> bytes = new Span<byte>(pBytes, 16);
+                value.TryWriteBytes(bytes, bigEndian: true, out _);
+            }
+            else
+            {
+                byte* pBytes = stackalloc byte[36];
+                Span<byte> bytes = new Span<byte>(pBytes, 36);
+                new GuidBits(ref value).Write(bytes);
+                writer.WriteString(bytes);
+            }
         }
 
         public Guid Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)


### PR DESCRIPTION
When sending a uuid with javascript its a string. I tried sending a `Uint8Array` but that failed to deserialize. Turns out in only supports text formatted uuid. This adds support for deserializing a 16 byte guid.