### PR TITLE
Promote analyzers to AnalyzerReleases.Shipped.md

### DIFF
--- a/src/MessagePack.SourceGenerator/AnalyzerReleases.Shipped.md
+++ b/src/MessagePack.SourceGenerator/AnalyzerReleases.Shipped.md
@@ -1,3 +1,60 @@
 ﻿; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
 
+## Release v2.1.80
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+MsgPack001 | Reliability | Disabled | MsgPack001SpecifyOptionsAnalyzer
+MsgPack002 | Reliability | Disabled | MsgPack002UseConstantOptionsAnalyzer
+MsgPack003 | Usage | Error | MsgPack00xMessagePackAnalyzer
+MsgPack004 | Usage | Error | Member needs Key or IgnoreMember attribute
+MsgPack005 | Usage | Error | MsgPack00xMessagePackAnalyzer
+
+## Release v2.3.73-alpha
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+MsgPack006 | Usage | Error | MsgPack00xMessagePackAnalyzer
+
+## Release v2.6.95-alpha
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+MsgPack007 | Usage | Error | MsgPack00xMessagePackAnalyzer
+MsgPack008 | Usage | Error | MsgPack00xMessagePackAnalyzer
+
+## Release v3.0.54-alpha
+
+### New Rules
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+MsgPack009 | Usage | Error | MsgPack00xMessagePackAnalyzer
+MsgPack010 | Usage | Warning | Formatter is not accessible to the source generated resolver
+MsgPack011 | Usage | Error | MsgPack00xMessagePackAnalyzer
+MsgPack012 | Usage | Error | MsgPack00xMessagePackAnalyzer
+
+## Release v3.0.129-beta
+
+### New Rules
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+MsgPack013 | Usage | Warning | Formatter has no accessible instance for the source generated resolver
+
+## Release v3.0.208-rc.1
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+MsgPack014 | Usage | Warning | Formatters of reference types should implement `IMessagePackFormatter<T?>`
+MsgPack015 | Usage | Warning | MessagePackObjectAttribute.AllowPrivate should be set
+MsgPack016 | Usage | Error | KeyAttribute-derived attributes are not supported by AOT formatters
+MsgPack017 | Usage | Warning | Property with init accessor and initializer
+MsgPack018 | Usage | Error | Unique names required in force map mode

--- a/src/MessagePack.SourceGenerator/AnalyzerReleases.Shipped.md
+++ b/src/MessagePack.SourceGenerator/AnalyzerReleases.Shipped.md
@@ -1,7 +1,7 @@
 ﻿; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
 
-## Release v2.1.80
+## Release 2.1.80
 
 ### New Rules
 
@@ -13,7 +13,7 @@ MsgPack003 | Usage | Error | MsgPack00xMessagePackAnalyzer
 MsgPack004 | Usage | Error | Member needs Key or IgnoreMember attribute
 MsgPack005 | Usage | Error | MsgPack00xMessagePackAnalyzer
 
-## Release v2.3.73-alpha
+## Release 2.3.73-alpha
 
 ### New Rules
 
@@ -21,7 +21,7 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 MsgPack006 | Usage | Error | MsgPack00xMessagePackAnalyzer
 
-## Release v2.6.95-alpha
+## Release 2.6.95-alpha
 
 ### New Rules
 
@@ -30,7 +30,7 @@ Rule ID | Category | Severity | Notes
 MsgPack007 | Usage | Error | MsgPack00xMessagePackAnalyzer
 MsgPack008 | Usage | Error | MsgPack00xMessagePackAnalyzer
 
-## Release v3.0.54-alpha
+## Release 3.0.54-alpha
 
 ### New Rules
 Rule ID | Category | Severity | Notes
@@ -40,14 +40,14 @@ MsgPack010 | Usage | Warning | Formatter is not accessible to the source generat
 MsgPack011 | Usage | Error | MsgPack00xMessagePackAnalyzer
 MsgPack012 | Usage | Error | MsgPack00xMessagePackAnalyzer
 
-## Release v3.0.129-beta
+## Release 3.0.129-beta
 
 ### New Rules
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 MsgPack013 | Usage | Warning | Formatter has no accessible instance for the source generated resolver
 
-## Release v3.0.208-rc.1
+## Release 3.0.208-rc.1
 
 ### New Rules
 

--- a/src/MessagePack.SourceGenerator/AnalyzerReleases.Unshipped.md
+++ b/src/MessagePack.SourceGenerator/AnalyzerReleases.Unshipped.md
@@ -1,25 +1,3 @@
 ﻿; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
 
-### New Rules
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
-MsgPack001 | Reliability | Disabled | MsgPack001SpecifyOptionsAnalyzer
-MsgPack002 | Reliability | Disabled | MsgPack002UseConstantOptionsAnalyzer
-MsgPack003 | Usage | Error | MsgPack00xMessagePackAnalyzer
-MsgPack004 | Usage | Error | Member needs Key or IgnoreMember attribute
-MsgPack005 | Usage | Error | MsgPack00xMessagePackAnalyzer
-MsgPack006 | Usage | Error | MsgPack00xMessagePackAnalyzer
-MsgPack007 | Usage | Error | MsgPack00xMessagePackAnalyzer
-MsgPack008 | Usage | Error | MsgPack00xMessagePackAnalyzer
-MsgPack009 | Usage | Error | MsgPack00xMessagePackAnalyzer
-MsgPack010 | Usage | Warning | Formatter is not accessible to the source generated resolver
-MsgPack011 | Usage | Error | MsgPack00xMessagePackAnalyzer
-MsgPack012 | Usage | Error | MsgPack00xMessagePackAnalyzer
-MsgPack013 | Usage | Warning | Formatter has no accessible instance for the source generated resolver
-MsgPack014 | Usage | Warning | Formatters of reference types should implement `IMessagePackFormatter<T?>`
-MsgPack015 | Usage | Warning | MessagePackObjectAttribute.AllowPrivate should be set
-MsgPack016 | Usage | Error | KeyAttribute-derived attributes are not supported by AOT formatters
-MsgPack017 | Usage | Warning | Property with init accessor and initializer
-MsgPack018 | Usage | Error | Unique names required in force map mode


### PR DESCRIPTION
I moved the rules from AnalyzerReleases.Unshipped.md to AnalyzerReleases.Shipped.md.

Follow the approach described below.
https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md#release-tracking-analyzer

I have looked at which versions MsgPack was added and concluded that. No mention is made of the deletion of the Rule named MessagePackAnalyzer_XXX.
```
[v2.1.80]
PR : #769 (rename from MessagePackAnalyzer_XXX)
MsgPack001 (#7340534c698bffe3347d16c238f9e75c7233a0dd)
MsgPack002  (#7340534c698bffe3347d16c238f9e75c7233a0dd)
MsgPack003 (#d218434d5e4cb3376dd7bd00b4054b4933caeb6c)
MsgPack004  (#d218434d5e4cb3376dd7bd00b4054b4933caeb6c)
MsgPack005  (#d218434d5e4cb3376dd7bd00b4054b4933caeb6c)

[v2.3.73-alpha]
PR : #1259
MsgPack006 (#fb3277d980f5a0aa38721ca4e049c370e48c03bc)

[v2.6.95-alpha]
PR : #1605
MsgPack007 (#d3208d90b90266627213fd4dfd47914faea4a3ea)
MsgPack008 (#d3208d90b90266627213fd4dfd47914faea4a3ea)

[vv3.0.54-alpha]
PR : #1796
MsgPack009 (#7c62679cb692ed46f3652c821da9e46f1ed3dfed)
MsgPack010 (#79f5323f35392d78d25c26c3f6851f6c40a4378e)

PR : #1802
MsgPack011 (#01d63889b9f703a714132cb26d74af194d5fb829)
MsgPack012 (#01d63889b9f703a714132cb26d74af194d5fb829)

[v3.0.129-beta]
PR : #1893
MsgPack0013 (#052f2da37fd381efd180e06cb6c7837dd224f702)

[v3.0.208-rc.1]
# PR : 1969
MsgPack014 (#2f67c65714e623cd588ee417049f001ed18bb934)

# PR : #1990
MsgPack15 (#03c254657c6fa16c1df806ee4368f32092af3aa8)

# PR : #2003
MsgPack016 (#41b9a4adaf3fd266d9aa21681788a28cef1d686d)
MsgPack017. (#9929d2143d1eee98f1d893a31d66d7f828c3f9bf)

# PR : 2006
MsgPack0018 (#0d3ef095d18ceaeb853e7ff4eee1572035162de9)
```