### PR TITLE
Perf: Use `Span.CopyTo<Byte>()` on .NET 7 and above.

### DIFF
--- a/src/MessagePack/Internal/UnsafeMemory.cs
+++ b/src/MessagePack/Internal/UnsafeMemory.cs
@@ -7,9 +7,7 @@
 #pragma warning disable SA1402 // File may only contain a single type
 
 using System;
-using System.Buffers;
 using System.Runtime.CompilerServices;
-using MessagePack.Formatters;
 
 namespace MessagePack.Internal
 {
@@ -19,16 +17,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw4(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 4).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -36,17 +25,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw5(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 5).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 1) = *(int*)(pSrc + 1);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -54,17 +33,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw6(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 6).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 2) = *(int*)(pSrc + 2);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -72,17 +41,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw7(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 7).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 3) = *(int*)(pSrc + 3);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -90,17 +49,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw8(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 8).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -108,18 +57,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw9(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 9).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 5) = *(int*)(pSrc + 5);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -127,18 +65,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw10(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 10).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 6) = *(int*)(pSrc + 6);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -146,18 +73,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw11(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 11).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 7) = *(int*)(pSrc + 7);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -165,18 +81,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw12(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 12).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 8) = *(int*)(pSrc + 8);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -184,19 +89,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw13(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 13).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 8) = *(int*)(pSrc + 8);
-                *(int*)(pDst + 9) = *(int*)(pSrc + 9);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -204,19 +97,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw14(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 14).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 8) = *(int*)(pSrc + 8);
-                *(int*)(pDst + 10) = *(int*)(pSrc + 10);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -224,19 +105,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw15(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 15).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 8) = *(int*)(pSrc + 8);
-                *(int*)(pDst + 11) = *(int*)(pSrc + 11);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -244,19 +113,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw16(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 16).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 8) = *(int*)(pSrc + 8);
-                *(int*)(pDst + 12) = *(int*)(pSrc + 12);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -264,20 +121,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw17(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 17).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 8) = *(int*)(pSrc + 8);
-                *(int*)(pDst + 12) = *(int*)(pSrc + 12);
-                *(int*)(pDst + 13) = *(int*)(pSrc + 13);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -285,20 +129,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw18(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 18).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 8) = *(int*)(pSrc + 8);
-                *(int*)(pDst + 12) = *(int*)(pSrc + 12);
-                *(int*)(pDst + 14) = *(int*)(pSrc + 14);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -306,20 +137,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw19(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 19).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 8) = *(int*)(pSrc + 8);
-                *(int*)(pDst + 12) = *(int*)(pSrc + 12);
-                *(int*)(pDst + 15) = *(int*)(pSrc + 15);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -327,20 +145,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw20(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 20).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 8) = *(int*)(pSrc + 8);
-                *(int*)(pDst + 12) = *(int*)(pSrc + 12);
-                *(int*)(pDst + 16) = *(int*)(pSrc + 16);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -348,21 +153,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw21(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 21).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 8) = *(int*)(pSrc + 8);
-                *(int*)(pDst + 12) = *(int*)(pSrc + 12);
-                *(int*)(pDst + 16) = *(int*)(pSrc + 16);
-                *(int*)(pDst + 17) = *(int*)(pSrc + 17);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -370,21 +161,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw22(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 22).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 8) = *(int*)(pSrc + 8);
-                *(int*)(pDst + 12) = *(int*)(pSrc + 12);
-                *(int*)(pDst + 16) = *(int*)(pSrc + 16);
-                *(int*)(pDst + 18) = *(int*)(pSrc + 18);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -392,21 +169,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw23(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 23).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 8) = *(int*)(pSrc + 8);
-                *(int*)(pDst + 12) = *(int*)(pSrc + 12);
-                *(int*)(pDst + 16) = *(int*)(pSrc + 16);
-                *(int*)(pDst + 19) = *(int*)(pSrc + 19);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -414,21 +177,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw24(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 24).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 8) = *(int*)(pSrc + 8);
-                *(int*)(pDst + 12) = *(int*)(pSrc + 12);
-                *(int*)(pDst + 16) = *(int*)(pSrc + 16);
-                *(int*)(pDst + 20) = *(int*)(pSrc + 20);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -436,22 +185,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw25(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 25).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 8) = *(int*)(pSrc + 8);
-                *(int*)(pDst + 12) = *(int*)(pSrc + 12);
-                *(int*)(pDst + 16) = *(int*)(pSrc + 16);
-                *(int*)(pDst + 20) = *(int*)(pSrc + 20);
-                *(int*)(pDst + 21) = *(int*)(pSrc + 21);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -459,22 +193,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw26(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 26).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 8) = *(int*)(pSrc + 8);
-                *(int*)(pDst + 12) = *(int*)(pSrc + 12);
-                *(int*)(pDst + 16) = *(int*)(pSrc + 16);
-                *(int*)(pDst + 20) = *(int*)(pSrc + 20);
-                *(int*)(pDst + 22) = *(int*)(pSrc + 22);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -482,22 +201,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw27(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 27).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 8) = *(int*)(pSrc + 8);
-                *(int*)(pDst + 12) = *(int*)(pSrc + 12);
-                *(int*)(pDst + 16) = *(int*)(pSrc + 16);
-                *(int*)(pDst + 20) = *(int*)(pSrc + 20);
-                *(int*)(pDst + 23) = *(int*)(pSrc + 23);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -505,22 +209,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw28(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 28).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 8) = *(int*)(pSrc + 8);
-                *(int*)(pDst + 12) = *(int*)(pSrc + 12);
-                *(int*)(pDst + 16) = *(int*)(pSrc + 16);
-                *(int*)(pDst + 20) = *(int*)(pSrc + 20);
-                *(int*)(pDst + 24) = *(int*)(pSrc + 24);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -528,23 +217,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw29(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 29).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 8) = *(int*)(pSrc + 8);
-                *(int*)(pDst + 12) = *(int*)(pSrc + 12);
-                *(int*)(pDst + 16) = *(int*)(pSrc + 16);
-                *(int*)(pDst + 20) = *(int*)(pSrc + 20);
-                *(int*)(pDst + 24) = *(int*)(pSrc + 24);
-                *(int*)(pDst + 25) = *(int*)(pSrc + 25);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -552,23 +225,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw30(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 30).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 8) = *(int*)(pSrc + 8);
-                *(int*)(pDst + 12) = *(int*)(pSrc + 12);
-                *(int*)(pDst + 16) = *(int*)(pSrc + 16);
-                *(int*)(pDst + 20) = *(int*)(pSrc + 20);
-                *(int*)(pDst + 24) = *(int*)(pSrc + 24);
-                *(int*)(pDst + 26) = *(int*)(pSrc + 26);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -576,23 +233,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw31(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 31).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(int*)(pDst + 0) = *(int*)(pSrc + 0);
-                *(int*)(pDst + 4) = *(int*)(pSrc + 4);
-                *(int*)(pDst + 8) = *(int*)(pSrc + 8);
-                *(int*)(pDst + 12) = *(int*)(pSrc + 12);
-                *(int*)(pDst + 16) = *(int*)(pSrc + 16);
-                *(int*)(pDst + 20) = *(int*)(pSrc + 20);
-                *(int*)(pDst + 24) = *(int*)(pSrc + 24);
-                *(int*)(pDst + 27) = *(int*)(pSrc + 27);
-            }
-#endif
             writer.Advance(src.Length);
         }
     }
@@ -603,16 +244,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw8(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 8).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -620,17 +252,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw9(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 9).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 1) = *(long*)(pSrc + 1);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -638,17 +260,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw10(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 10).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 2) = *(long*)(pSrc + 2);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -656,17 +268,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw11(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 11).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 3) = *(long*)(pSrc + 3);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -674,17 +276,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw12(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 12).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 4) = *(long*)(pSrc + 4);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -692,17 +284,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw13(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 13).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 5) = *(long*)(pSrc + 5);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -710,17 +292,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw14(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 14).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 6) = *(long*)(pSrc + 6);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -728,17 +300,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw15(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 15).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 7) = *(long*)(pSrc + 7);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -746,17 +308,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw16(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 16).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 8) = *(long*)(pSrc + 8);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -764,18 +316,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw17(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 17).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 8) = *(long*)(pSrc + 8);
-                *(long*)(pDst + 9) = *(long*)(pSrc + 9);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -783,18 +324,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw18(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 18).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 8) = *(long*)(pSrc + 8);
-                *(long*)(pDst + 10) = *(long*)(pSrc + 10);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -802,18 +332,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw19(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 19).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 8) = *(long*)(pSrc + 8);
-                *(long*)(pDst + 11) = *(long*)(pSrc + 11);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -821,18 +340,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw20(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 20).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 8) = *(long*)(pSrc + 8);
-                *(long*)(pDst + 12) = *(long*)(pSrc + 12);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -840,18 +348,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw21(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 21).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 8) = *(long*)(pSrc + 8);
-                *(long*)(pDst + 13) = *(long*)(pSrc + 13);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -859,18 +356,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw22(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 22).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 8) = *(long*)(pSrc + 8);
-                *(long*)(pDst + 14) = *(long*)(pSrc + 14);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -878,18 +364,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw23(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 23).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 8) = *(long*)(pSrc + 8);
-                *(long*)(pDst + 15) = *(long*)(pSrc + 15);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -897,18 +372,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw24(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 24).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 8) = *(long*)(pSrc + 8);
-                *(long*)(pDst + 16) = *(long*)(pSrc + 16);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -916,19 +380,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw25(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 25).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 8) = *(long*)(pSrc + 8);
-                *(long*)(pDst + 16) = *(long*)(pSrc + 16);
-                *(long*)(pDst + 17) = *(long*)(pSrc + 17);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -936,19 +388,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw26(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 26).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 8) = *(long*)(pSrc + 8);
-                *(long*)(pDst + 16) = *(long*)(pSrc + 16);
-                *(long*)(pDst + 18) = *(long*)(pSrc + 18);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -956,19 +396,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw27(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 27).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 8) = *(long*)(pSrc + 8);
-                *(long*)(pDst + 16) = *(long*)(pSrc + 16);
-                *(long*)(pDst + 19) = *(long*)(pSrc + 19);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -976,19 +404,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw28(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 28).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 8) = *(long*)(pSrc + 8);
-                *(long*)(pDst + 16) = *(long*)(pSrc + 16);
-                *(long*)(pDst + 20) = *(long*)(pSrc + 20);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -996,19 +412,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw29(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 29).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 8) = *(long*)(pSrc + 8);
-                *(long*)(pDst + 16) = *(long*)(pSrc + 16);
-                *(long*)(pDst + 21) = *(long*)(pSrc + 21);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -1016,19 +420,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw30(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 30).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 8) = *(long*)(pSrc + 8);
-                *(long*)(pDst + 16) = *(long*)(pSrc + 16);
-                *(long*)(pDst + 22) = *(long*)(pSrc + 22);
-            }
-#endif
             writer.Advance(src.Length);
         }
 
@@ -1036,19 +428,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw31(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, 31).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-                *(long*)(pDst + 0) = *(long*)(pSrc + 0);
-                *(long*)(pDst + 8) = *(long*)(pSrc + 8);
-                *(long*)(pDst + 16) = *(long*)(pSrc + 16);
-                *(long*)(pDst + 23) = *(long*)(pSrc + 23);
-            }
-#endif
             writer.Advance(src.Length);
         }
     }

--- a/src/MessagePack/Internal/UnsafeMemory.cs
+++ b/src/MessagePack/Internal/UnsafeMemory.cs
@@ -20,12 +20,15 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 4).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
                 *(int*)(pDst + 0) = *(int*)(pSrc + 0);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -34,13 +37,16 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 5).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
                 *(int*)(pDst + 0) = *(int*)(pSrc + 0);
                 *(int*)(pDst + 1) = *(int*)(pSrc + 1);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -49,13 +55,16 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 6).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
                 *(int*)(pDst + 0) = *(int*)(pSrc + 0);
                 *(int*)(pDst + 2) = *(int*)(pSrc + 2);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -64,13 +73,16 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 7).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
                 *(int*)(pDst + 0) = *(int*)(pSrc + 0);
                 *(int*)(pDst + 3) = *(int*)(pSrc + 3);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -79,13 +91,16 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 8).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
                 *(int*)(pDst + 0) = *(int*)(pSrc + 0);
                 *(int*)(pDst + 4) = *(int*)(pSrc + 4);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -94,6 +109,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 9).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -101,7 +119,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 4) = *(int*)(pSrc + 4);
                 *(int*)(pDst + 5) = *(int*)(pSrc + 5);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -110,6 +128,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 10).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -117,7 +138,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 4) = *(int*)(pSrc + 4);
                 *(int*)(pDst + 6) = *(int*)(pSrc + 6);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -126,6 +147,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 11).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -133,7 +157,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 4) = *(int*)(pSrc + 4);
                 *(int*)(pDst + 7) = *(int*)(pSrc + 7);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -142,6 +166,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 12).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -149,7 +176,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 4) = *(int*)(pSrc + 4);
                 *(int*)(pDst + 8) = *(int*)(pSrc + 8);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -158,6 +185,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 13).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -166,7 +196,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 8) = *(int*)(pSrc + 8);
                 *(int*)(pDst + 9) = *(int*)(pSrc + 9);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -175,6 +205,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 14).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -183,7 +216,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 8) = *(int*)(pSrc + 8);
                 *(int*)(pDst + 10) = *(int*)(pSrc + 10);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -192,6 +225,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 15).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -200,7 +236,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 8) = *(int*)(pSrc + 8);
                 *(int*)(pDst + 11) = *(int*)(pSrc + 11);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -209,6 +245,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 16).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -217,7 +256,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 8) = *(int*)(pSrc + 8);
                 *(int*)(pDst + 12) = *(int*)(pSrc + 12);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -226,6 +265,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 17).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -235,7 +277,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 12) = *(int*)(pSrc + 12);
                 *(int*)(pDst + 13) = *(int*)(pSrc + 13);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -244,6 +286,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 18).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -253,7 +298,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 12) = *(int*)(pSrc + 12);
                 *(int*)(pDst + 14) = *(int*)(pSrc + 14);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -262,6 +307,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 19).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -271,7 +319,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 12) = *(int*)(pSrc + 12);
                 *(int*)(pDst + 15) = *(int*)(pSrc + 15);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -280,6 +328,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 20).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -289,7 +340,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 12) = *(int*)(pSrc + 12);
                 *(int*)(pDst + 16) = *(int*)(pSrc + 16);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -298,6 +349,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 21).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -308,7 +362,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 16) = *(int*)(pSrc + 16);
                 *(int*)(pDst + 17) = *(int*)(pSrc + 17);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -317,6 +371,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 22).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -327,7 +384,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 16) = *(int*)(pSrc + 16);
                 *(int*)(pDst + 18) = *(int*)(pSrc + 18);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -336,6 +393,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 23).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -346,7 +406,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 16) = *(int*)(pSrc + 16);
                 *(int*)(pDst + 19) = *(int*)(pSrc + 19);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -355,6 +415,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 24).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -365,7 +428,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 16) = *(int*)(pSrc + 16);
                 *(int*)(pDst + 20) = *(int*)(pSrc + 20);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -374,6 +437,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 25).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -385,7 +451,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 20) = *(int*)(pSrc + 20);
                 *(int*)(pDst + 21) = *(int*)(pSrc + 21);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -394,6 +460,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 26).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -405,7 +474,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 20) = *(int*)(pSrc + 20);
                 *(int*)(pDst + 22) = *(int*)(pSrc + 22);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -414,6 +483,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 27).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -425,7 +497,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 20) = *(int*)(pSrc + 20);
                 *(int*)(pDst + 23) = *(int*)(pSrc + 23);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -434,6 +506,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 28).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -445,7 +520,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 20) = *(int*)(pSrc + 20);
                 *(int*)(pDst + 24) = *(int*)(pSrc + 24);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -454,6 +529,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 29).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -466,7 +544,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 24) = *(int*)(pSrc + 24);
                 *(int*)(pDst + 25) = *(int*)(pSrc + 25);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -475,6 +553,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 30).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -487,7 +568,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 24) = *(int*)(pSrc + 24);
                 *(int*)(pDst + 26) = *(int*)(pSrc + 26);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -496,6 +577,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 31).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -508,7 +592,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 24) = *(int*)(pSrc + 24);
                 *(int*)(pDst + 27) = *(int*)(pSrc + 27);
             }
-
+#endif
             writer.Advance(src.Length);
         }
     }
@@ -520,12 +604,15 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 8).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
                 *(long*)(pDst + 0) = *(long*)(pSrc + 0);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -534,13 +621,16 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 9).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
                 *(long*)(pDst + 0) = *(long*)(pSrc + 0);
                 *(long*)(pDst + 1) = *(long*)(pSrc + 1);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -549,13 +639,16 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 10).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
                 *(long*)(pDst + 0) = *(long*)(pSrc + 0);
                 *(long*)(pDst + 2) = *(long*)(pSrc + 2);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -564,13 +657,16 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 11).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
                 *(long*)(pDst + 0) = *(long*)(pSrc + 0);
                 *(long*)(pDst + 3) = *(long*)(pSrc + 3);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -579,13 +675,16 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 12).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
                 *(long*)(pDst + 0) = *(long*)(pSrc + 0);
                 *(long*)(pDst + 4) = *(long*)(pSrc + 4);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -594,13 +693,16 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 13).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
                 *(long*)(pDst + 0) = *(long*)(pSrc + 0);
                 *(long*)(pDst + 5) = *(long*)(pSrc + 5);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -609,13 +711,16 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 14).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
                 *(long*)(pDst + 0) = *(long*)(pSrc + 0);
                 *(long*)(pDst + 6) = *(long*)(pSrc + 6);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -624,13 +729,16 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 15).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
                 *(long*)(pDst + 0) = *(long*)(pSrc + 0);
                 *(long*)(pDst + 7) = *(long*)(pSrc + 7);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -639,13 +747,16 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 16).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
                 *(long*)(pDst + 0) = *(long*)(pSrc + 0);
                 *(long*)(pDst + 8) = *(long*)(pSrc + 8);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -654,6 +765,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 17).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -661,7 +775,7 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 8) = *(long*)(pSrc + 8);
                 *(long*)(pDst + 9) = *(long*)(pSrc + 9);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -670,6 +784,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 18).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -677,7 +794,7 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 8) = *(long*)(pSrc + 8);
                 *(long*)(pDst + 10) = *(long*)(pSrc + 10);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -686,6 +803,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 19).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -693,7 +813,7 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 8) = *(long*)(pSrc + 8);
                 *(long*)(pDst + 11) = *(long*)(pSrc + 11);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -702,6 +822,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 20).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -709,7 +832,7 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 8) = *(long*)(pSrc + 8);
                 *(long*)(pDst + 12) = *(long*)(pSrc + 12);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -718,6 +841,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 21).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -725,7 +851,7 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 8) = *(long*)(pSrc + 8);
                 *(long*)(pDst + 13) = *(long*)(pSrc + 13);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -734,6 +860,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 22).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -741,7 +870,7 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 8) = *(long*)(pSrc + 8);
                 *(long*)(pDst + 14) = *(long*)(pSrc + 14);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -750,6 +879,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 23).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -757,7 +889,7 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 8) = *(long*)(pSrc + 8);
                 *(long*)(pDst + 15) = *(long*)(pSrc + 15);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -766,6 +898,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 24).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -773,7 +908,7 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 8) = *(long*)(pSrc + 8);
                 *(long*)(pDst + 16) = *(long*)(pSrc + 16);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -782,6 +917,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 25).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -790,7 +928,7 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 16) = *(long*)(pSrc + 16);
                 *(long*)(pDst + 17) = *(long*)(pSrc + 17);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -799,6 +937,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 26).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -807,7 +948,7 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 16) = *(long*)(pSrc + 16);
                 *(long*)(pDst + 18) = *(long*)(pSrc + 18);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -816,6 +957,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 27).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -824,7 +968,7 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 16) = *(long*)(pSrc + 16);
                 *(long*)(pDst + 19) = *(long*)(pSrc + 19);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -833,6 +977,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 28).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -841,7 +988,7 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 16) = *(long*)(pSrc + 16);
                 *(long*)(pDst + 20) = *(long*)(pSrc + 20);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -850,6 +997,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 29).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -858,7 +1008,7 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 16) = *(long*)(pSrc + 16);
                 *(long*)(pDst + 21) = *(long*)(pSrc + 21);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -867,6 +1017,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 30).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -875,7 +1028,7 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 16) = *(long*)(pSrc + 16);
                 *(long*)(pDst + 22) = *(long*)(pSrc + 22);
             }
-
+#endif
             writer.Advance(src.Length);
         }
 
@@ -884,6 +1037,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, 31).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -892,7 +1048,7 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 16) = *(long*)(pSrc + 16);
                 *(long*)(pDst + 23) = *(long*)(pSrc + 23);
             }
-
+#endif
             writer.Advance(src.Length);
         }
     }

--- a/src/MessagePack/Internal/UnsafeMemory.tt
+++ b/src/MessagePack/Internal/UnsafeMemory.tt
@@ -16,9 +16,7 @@
 #pragma warning disable SA1402 // File may only contain a single type
 
 using System;
-using System.Buffers;
 using System.Runtime.CompilerServices;
-using MessagePack.Formatters;
 
 namespace MessagePack.Internal
 {
@@ -29,21 +27,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw<#= i #>(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, <#= i #>).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-<# for(var j = 0; j < (i / 4); j++) { #>
-                *(int*)(pDst + <#= (4 * j) #>) = *(int*)(pSrc + <#= (4 * j) #>);
-<# } #>
-<# if(i % 4 != 0) { #>
-                *(int*)(pDst + <#= i - 4 #>) = *(int*)(pSrc + <#= (i - 4) #>);
-<# } #>
-            }
-#endif
             writer.Advance(src.Length);
         }
 <# } #>
@@ -56,21 +40,7 @@ namespace MessagePack.Internal
         public static unsafe void WriteRaw<#= i #>(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
             Span<byte> dst = writer.GetSpan(src.Length);
-
-#if NET7_0_OR_GREATER
             src.Slice(0, <#= i #>).CopyTo(dst);
-#else
-            fixed (byte* pSrc = &src[0])
-            fixed (byte* pDst = &dst[0])
-            {
-<# for(var j = 0; j < (i / 8); j++) { #>
-                *(long*)(pDst + <#= (8 * j) #>) = *(long*)(pSrc + <#= (8 * j) #>);
-<# } #>
-<# if(i % 8 != 0) { #>
-                *(long*)(pDst + <#= i - 8 #>) = *(long*)(pSrc + <#= (i - 8) #>);
-<# } #>
-            }
-#endif
             writer.Advance(src.Length);
         }
 <# } #>

--- a/src/MessagePack/Internal/UnsafeMemory.tt
+++ b/src/MessagePack/Internal/UnsafeMemory.tt
@@ -30,6 +30,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, <#= i #>).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -40,7 +43,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + <#= i - 4 #>) = *(int*)(pSrc + <#= (i - 4) #>);
 <# } #>
             }
-
+#endif
             writer.Advance(src.Length);
         }
 <# } #>
@@ -54,6 +57,9 @@ namespace MessagePack.Internal
         {
             Span<byte> dst = writer.GetSpan(src.Length);
 
+#if NET7_0_OR_GREATER
+            src.Slice(0, <#= i #>).CopyTo(dst);
+#else
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
@@ -64,7 +70,7 @@ namespace MessagePack.Internal
                 *(long*)(pDst + <#= i - 8 #>) = *(long*)(pSrc + <#= (i - 8) #>);
 <# } #>
             }
-
+#endif
             writer.Advance(src.Length);
         }
 <# } #>


### PR DESCRIPTION
This changes `UnsafeMemory` to use the safe equivalents in .NET 7 and above as they are more performant than the equivalent code and can take advantage of vectorization on hardware that supports it

This optimization exists on at least .NET 7.