### PR TITLE
Update DynamicAssembly usage to honor different AssemblyLoadContext's

### DIFF
--- a/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
+++ b/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
@@ -46,6 +46,9 @@
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\Internal\DynamicAssembly.cs">
       <Link>Code\DynamicAssembly.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\MessagePack\Internal\DynamicAssemblyFactory.cs">
+      <Link>Code\DynamicAssemblyFactory.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\Internal\ExpressionUtility.cs">
       <Link>Code\ExpressionUtility.cs</Link>
     </Compile>

--- a/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
+++ b/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
@@ -46,7 +46,7 @@
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\Internal\DynamicAssembly.cs">
       <Link>Code\DynamicAssembly.cs</Link>
     </Compile>
-    <Compile Include="..\..\src\MessagePack\Internal\DynamicAssemblyFactory.cs">
+    <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\Internal\DynamicAssemblyFactory.cs">
       <Link>Code\DynamicAssemblyFactory.cs</Link>
     </Compile>
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\Internal\ExpressionUtility.cs">

--- a/sandbox/Sandbox/Generated.cs
+++ b/sandbox/Sandbox/Generated.cs
@@ -3093,6 +3093,53 @@ namespace MessagePack.Formatters.SharedData
         }
     }
 
+    public sealed class SimpleGenericDataFormatter<T> : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.SimpleGenericData<T>>
+    {
+
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.SimpleGenericData<T> value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (value == null)
+            {
+                writer.WriteNil();
+                return;
+            }
+
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
+            writer.WriteArrayHeader(1);
+            global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<T>(formatterResolver).Serialize(ref writer, value.Value, options);
+        }
+
+        public global::SharedData.SimpleGenericData<T> Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                return null;
+            }
+
+            options.Security.DepthStep(ref reader);
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
+            var length = reader.ReadArrayHeader();
+            var __Value__ = default(T);
+
+            for (int i = 0; i < length; i++)
+            {
+                switch (i)
+                {
+                    case 0:
+                        __Value__ = global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<T>(formatterResolver).Deserialize(ref reader, options);
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
+                }
+            }
+
+            var ____result = new global::SharedData.SimpleGenericData<T>(__Value__);
+            reader.Depth--;
+            return ____result;
+        }
+    }
+
     public sealed class SimpleIntKeyDataFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.SimpleIntKeyData>
     {
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/DynamicAssembly.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/DynamicAssembly.cs
@@ -20,6 +20,11 @@ namespace MessagePack.Internal
         // don't expose ModuleBuilder
         //// public ModuleBuilder ModuleBuilder { get { return moduleBuilder; } }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicAssembly"/> class.
+        /// Please use <see cref="DynamicAssemblyFactory"/> instead in order to work across different AssemblyLoadContext that may have duplicate modules.
+        /// </summary>
+        /// <param name="moduleName">Name of the module to be generated.</param>
         public DynamicAssembly(string moduleName)
         {
 #if NETFRAMEWORK // We don't ship a net472 target, but we might add one for debugging purposes

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/DynamicAssemblyFactory.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/DynamicAssemblyFactory.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+#if NET
+using System.Runtime.Loader;
+#endif
+
+namespace MessagePack.Internal
+{
+    /// <summary>
+    /// This class is responsible for managing DynamicAssembly instance creation taking into account
+    /// AssemblyLoadContext when running under .NET.
+    /// </summary>
+    internal class DynamicAssemblyFactory
+    {
+        private readonly string moduleName;
+
+        private readonly Lazy<DynamicAssembly> singletonAssembly;
+
+#if NET
+        private readonly Dictionary<AssemblyLoadContext, DynamicAssembly> alcCache = new();
+#endif
+
+        public DynamicAssemblyFactory(string moduleName)
+        {
+            this.moduleName = moduleName;
+            this.singletonAssembly = new Lazy<DynamicAssembly>(() => new DynamicAssembly(this.moduleName));
+        }
+
+#if NET
+        public DynamicAssembly GetDynamicAssembly(Type? type)
+        {
+            if (type is null || AssemblyLoadContext.GetLoadContext(type.Assembly) is not AssemblyLoadContext loadContext)
+            {
+                return this.singletonAssembly.Value;
+            }
+            else
+            {
+                DynamicAssembly? assembly = null;
+                lock (this.alcCache)
+                {
+                    if (!this.alcCache.TryGetValue(loadContext, out assembly))
+                    {
+                        assembly = new DynamicAssembly(this.moduleName);
+                        this.alcCache[loadContext] = assembly;
+                    }
+
+                    return assembly;
+                }
+            }
+        }
+#else
+        public DynamicAssembly GetDynamicAssembly(Type? type)
+        {
+            return this.singletonAssembly.Value;
+        }
+#endif
+    }
+}

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicEnumResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicEnumResolver.cs
@@ -25,7 +25,7 @@ namespace MessagePack.Resolvers
 
         private const string ModuleName = "MessagePack.Resolvers.DynamicEnumResolver";
 
-        private static readonly Lazy<DynamicAssembly> DynamicAssembly;
+        private static readonly DynamicAssemblyFactory DynamicAssemblyFactory;
 
         private static int nameSequence = 0;
 
@@ -35,13 +35,13 @@ namespace MessagePack.Resolvers
 
         static DynamicEnumResolver()
         {
-            DynamicAssembly = new Lazy<DynamicAssembly>(() => new DynamicAssembly(ModuleName));
+            DynamicAssemblyFactory = new DynamicAssemblyFactory(ModuleName);
         }
 
 #if NETFRAMEWORK
         internal AssemblyBuilder Save()
         {
-            return DynamicAssembly.Value.Save();
+            return DynamicAssemblyFactory.GetDynamicAssembly(type: null).Save();
         }
 #endif
 
@@ -95,7 +95,7 @@ namespace MessagePack.Resolvers
             {
                 using (MonoProtection.EnterRefEmitLock())
                 {
-                    TypeBuilder typeBuilder = DynamicAssembly.Value.DefineType("MessagePack.Formatters." + enumType.FullName!.Replace(".", "_") + "Formatter" + Interlocked.Increment(ref nameSequence), TypeAttributes.Public | TypeAttributes.Sealed, null, new[] { formatterType });
+                    TypeBuilder typeBuilder = DynamicAssemblyFactory.GetDynamicAssembly(enumType).DefineType("MessagePack.Formatters." + enumType.FullName!.Replace(".", "_") + "Formatter" + Interlocked.Increment(ref nameSequence), TypeAttributes.Public | TypeAttributes.Sealed, null, new[] { formatterType });
 
                     // void Serialize(ref MessagePackWriter writer, T value, MessagePackSerializerOptions options);
                     {

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -38,13 +38,13 @@ namespace MessagePack.Resolvers
         /// </summary>
         public static readonly MessagePackSerializerOptions Options;
 
-        internal static readonly Lazy<DynamicAssembly> DynamicAssembly;
+        internal static readonly DynamicAssemblyFactory DynamicAssemblyFactory;
 
         static DynamicObjectResolver()
         {
             Instance = new DynamicObjectResolver();
             Options = new MessagePackSerializerOptions(Instance);
-            DynamicAssembly = new Lazy<DynamicAssembly>(() => new DynamicAssembly(ModuleName));
+            DynamicAssemblyFactory = new DynamicAssemblyFactory(ModuleName);
         }
 
         private DynamicObjectResolver()
@@ -54,7 +54,7 @@ namespace MessagePack.Resolvers
 #if NETFRAMEWORK
         internal AssemblyBuilder Save()
         {
-            return DynamicAssembly.Value.Save();
+            return DynamicAssemblyFactory.GetDynamicAssembly(type: null).Save();
         }
 #endif
 
@@ -99,7 +99,7 @@ namespace MessagePack.Resolvers
                 TypeInfo? formatterTypeInfo;
                 try
                 {
-                    formatterTypeInfo = DynamicObjectTypeBuilder.BuildType(DynamicAssembly.Value, typeof(T), false, false);
+                    formatterTypeInfo = DynamicObjectTypeBuilder.BuildType(DynamicAssemblyFactory.GetDynamicAssembly(typeof(T)), typeof(T), false, false);
                 }
                 catch (InitAccessorInGenericClassNotSupportedException)
                 {
@@ -181,7 +181,7 @@ namespace MessagePack.Resolvers
 
         private const string ModuleName = "MessagePack.Resolvers.DynamicContractlessObjectResolver";
 
-        private static readonly Lazy<DynamicAssembly> DynamicAssembly;
+        private static readonly DynamicAssemblyFactory DynamicAssemblyFactory;
 
         private DynamicContractlessObjectResolver()
         {
@@ -189,13 +189,13 @@ namespace MessagePack.Resolvers
 
         static DynamicContractlessObjectResolver()
         {
-            DynamicAssembly = new Lazy<DynamicAssembly>(() => new DynamicAssembly(ModuleName));
+            DynamicAssemblyFactory = new DynamicAssemblyFactory(ModuleName);
         }
 
 #if NETFRAMEWORK
         internal AssemblyBuilder Save()
         {
-            return DynamicAssembly.Value.Save();
+            return DynamicAssemblyFactory.GetDynamicAssembly(type: null).Save();
         }
 #endif
 
@@ -242,7 +242,7 @@ namespace MessagePack.Resolvers
                     return;
                 }
 
-                TypeInfo? formatterTypeInfo = DynamicObjectTypeBuilder.BuildType(DynamicAssembly.Value, typeof(T), true, true);
+                TypeInfo? formatterTypeInfo = DynamicObjectTypeBuilder.BuildType(DynamicAssemblyFactory.GetDynamicAssembly(typeof(T)), typeof(T), true, true);
                 if (formatterTypeInfo == null)
                 {
                     return;

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Class1.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Class1.cs
@@ -87,6 +87,18 @@ namespace SharedData
         ////public int Prop7 { get; set; }
     }
 
+    [MessagePackObject]
+    public class SimpleGenericData<T>
+    {
+        [Key(0)]
+        public T Value { get; set; }
+
+        public SimpleGenericData(T value)
+        {
+            this.Value = value;
+        }
+    }
+
     public class OreOreFormatter : IMessagePackFormatter<int>
     {
         public int Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)

--- a/tests/MessagePack.Tests/AssemblyLoadContextTests.cs
+++ b/tests/MessagePack.Tests/AssemblyLoadContextTests.cs
@@ -1,0 +1,174 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NET
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Text;
+using System.Threading.Tasks;
+using ComplexdUnion;
+using MessagePack;
+using MessagePack.Formatters;
+using MessagePack.Resolvers;
+using SharedData;
+using Xunit;
+
+#pragma warning disable SA1302 // Interface names should begin with I
+#pragma warning disable SA1403 // File may only contain a single namespace
+
+public class AssemblyLoadContextTests : IDisposable
+{
+    private static readonly string SharedDataAssemblyName = typeof(RootUnionType).Assembly.Location;
+    private readonly AssemblyLoadContext loadContext = new AssemblyLoadContext("TestContext", isCollectible: true);
+
+    public void Dispose()
+    {
+        this.loadContext.Unload();
+    }
+
+    [Fact]
+    public void DynamicUnionResolverWorksAcrossAssemblyLoadContexts()
+    {
+        RootUnionType unionTypeInMainLoadContext = new SubUnionType1();
+        var options = this.CreateSerializerOptions();
+
+        var buffer1 = MessagePackSerializer.Serialize(unionTypeInMainLoadContext, options: options);
+        var o1 = MessagePackSerializer.Deserialize<RootUnionType>(buffer1, options: options);
+
+        Assert.True(o1 is SubUnionType1);
+
+        var assembly = this.loadContext.LoadFromAssemblyPath(SharedDataAssemblyName);
+        object unionTypeInOtherContext = assembly.CreateInstance(typeof(SubUnionType1).FullName);
+        Type rootUnionType = assembly.GetType(typeof(RootUnionType).FullName);
+
+        var buffer2 = MessagePackSerializer.Serialize(rootUnionType, unionTypeInOtherContext, options: options);
+        var o2 = MessagePackSerializer.Deserialize(rootUnionType, buffer2, options: options);
+
+        Assert.True(o2.GetType().IsAssignableTo(rootUnionType));
+    }
+
+    [Fact]
+    public void DynamicEnumResolverWorksAcrossAssemblyLoadContexts()
+    {
+        ByteEnum e1 = ByteEnum.A;
+        var options = this.CreateSerializerOptions();
+
+        var b1 = MessagePackSerializer.Serialize(e1, options: options);
+        var o1 = MessagePackSerializer.Deserialize<ByteEnum>(b1, options: options);
+
+        Assert.Equal(typeof(ByteEnum), o1.GetType());
+
+        var assembly = this.loadContext.LoadFromAssemblyPath(SharedDataAssemblyName);
+        Type enumType = assembly.GetType(typeof(ByteEnum).FullName);
+        object e2 = Enum.GetValues(enumType).GetValue(1);
+
+        var b2 = MessagePackSerializer.Serialize(enumType, e2, options: options);
+        var o2 = MessagePackSerializer.Deserialize(enumType, b2, options: options);
+
+        Assert.Equal(o2.GetType(), e2.GetType());
+    }
+
+    [Fact]
+    public void DynamicObjectResolverWorksAcrossAssemblyLoadContexts()
+    {
+        FirstSimpleData e1 = new FirstSimpleData();
+        var options = this.CreateSerializerOptions();
+
+        var b1 = MessagePackSerializer.Serialize(e1, options: options);
+        var o1 = MessagePackSerializer.Deserialize<FirstSimpleData>(b1, options: options);
+
+        Assert.Equal(typeof(FirstSimpleData), o1.GetType());
+
+        var assembly = this.loadContext.LoadFromAssemblyPath(SharedDataAssemblyName);
+        Type objectType = assembly.GetType(typeof(FirstSimpleData).FullName);
+        object e2 = assembly.CreateInstance(typeof(FirstSimpleData).FullName);
+
+        var b2 = MessagePackSerializer.Serialize(objectType, e2, options: options);
+        var o2 = MessagePackSerializer.Deserialize(objectType, b2, options: options);
+
+        Assert.Equal(o2.GetType(), e2.GetType());
+    }
+
+    [Fact]
+    public void DynamiObjectResolverWorksWithGenericsAcrossAssemblyLoadContexts()
+    {
+        IList<FirstSimpleData> e1 = new List<FirstSimpleData> { new FirstSimpleData(), new FirstSimpleData() };
+        var options = this.CreateSerializerOptions();
+
+        var b1 = MessagePackSerializer.Serialize(e1, options: options);
+        var o1 = MessagePackSerializer.Deserialize<List<FirstSimpleData>>(b1, options: options);
+
+        Assert.Equal(typeof(List<FirstSimpleData>), o1.GetType());
+        Assert.Equal(2, o1.Count);
+        Assert.All(o1, item => Assert.IsType<FirstSimpleData>(item));
+
+        var assembly = this.loadContext.LoadFromAssemblyPath(SharedDataAssemblyName);
+        Type objectType = assembly.GetType(typeof(FirstSimpleData).FullName);
+        Type listType = typeof(List<>).MakeGenericType(objectType);
+        object list = Activator.CreateInstance(listType);
+
+        // Add two instances to the list
+        var addMethod = listType.GetMethod("Add");
+        addMethod.Invoke(list, new[] { assembly.CreateInstance(typeof(FirstSimpleData).FullName) });
+        addMethod.Invoke(list, new[] { assembly.CreateInstance(typeof(FirstSimpleData).FullName) });
+
+        Assert.Equal(objectType, (list as System.Collections.IList)[0].GetType());
+
+        var b2 = MessagePackSerializer.Serialize(listType, list, options: options);
+        var o2 = MessagePackSerializer.Deserialize(listType, b2, options: options);
+
+        // Verify the element type directly from the generic type arguments
+        Type elementType = o2.GetType().GetGenericArguments()[0];
+        Assert.Equal(objectType, elementType);
+
+        // Get the first item to verify its actual runtime type
+        var enumerable = o2 as System.Collections.IList;
+        Assert.Equal(objectType, enumerable[0].GetType());
+    }
+
+    [Fact]
+    public void DynamicContractlessObjectResolverWorksAcrossAssemblyLoadContexts()
+    {
+        FirstSimpleData e1 = new FirstSimpleData();
+        var options = new MessagePackSerializerOptions(
+            CompositeResolver.Create(
+                BuiltinResolver.Instance,
+                PrimitiveObjectResolver.Instance,
+                DynamicContractlessObjectResolver.Instance));
+
+        var b1 = MessagePackSerializer.Serialize(e1, options: options);
+        var o1 = MessagePackSerializer.Deserialize<FirstSimpleData>(b1, options: options);
+
+        Assert.Equal(typeof(FirstSimpleData), o1.GetType());
+
+        var assembly = this.loadContext.LoadFromAssemblyPath(SharedDataAssemblyName);
+        Type objectType = assembly.GetType(typeof(FirstSimpleData).FullName);
+        object e2 = assembly.CreateInstance(typeof(FirstSimpleData).FullName);
+
+        var b2 = MessagePackSerializer.Serialize(objectType, e2, options: options);
+        var o2 = MessagePackSerializer.Deserialize(objectType, b2, options: options);
+
+        Assert.Equal(o2.GetType(), e2.GetType());
+    }
+
+    private MessagePackSerializerOptions CreateSerializerOptions()
+    {
+        // Avoid default options as it will use source generated formatter which works in this scenario.
+        return new MessagePackSerializerOptions(
+            CompositeResolver.Create(
+                BuiltinResolver.Instance,
+                AttributeFormatterResolver.Instance,
+                DynamicEnumResolver.Instance,
+                DynamicGenericResolver.Instance,
+                DynamicUnionResolver.Instance,
+                DynamicObjectResolver.Instance,
+                PrimitiveObjectResolver.Instance));
+    }
+}
+
+#endif


### PR DESCRIPTION
Cherry picking #1978 to v2.x branch with additional tests around generic handling.

This change resolves issue https://github.com/MessagePack-CSharp/MessagePack-CSharp/issues/1952 where dynamic resolvers did not work where same assembly in different locations was loaded in different AssemblyLoadContext's.

DynamicAssembly creation now happens per unique AssemblyLoadContext so that types are recognized correctly.