### PR TITLE
fix: Use ArrayPool instead of ThreadStatic field for serialization

### DIFF
--- a/tests/MessagePack.Tests/NestedSerializationTest.cs
+++ b/tests/MessagePack.Tests/NestedSerializationTest.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !(MESSAGEPACK_FORCE_AOT || ENABLE_IL2CPP)
+#define DYNAMIC_GENERATION
+#endif
+
+#if DYNAMIC_GENERATION
+
+namespace MessagePack.Tests
+{
+    public class NestedSerializationTest
+    {
+        [MessagePackObject]
+        public class SerializeOnSerializeClass
+        {
+            [IgnoreMember] private string key;
+
+            [Key(0)]
+            public byte[] SerializedKey
+            {
+                get { return MessagePackSerializer.Serialize(key); }
+                set { key = MessagePackSerializer.Deserialize<string>(value); }
+            }
+
+            public SerializeOnSerializeClass()
+            {
+            }
+
+            public SerializeOnSerializeClass(string key)
+            {
+                this.key = key;
+            }
+        }
+
+        [Fact]
+        public void SerializeAndDeserialize()
+        {
+            var testData = new SerializeOnSerializeClass("teststring");
+
+            var data = MessagePackSerializer.Serialize(testData);
+            var restored = MessagePackSerializer.Deserialize<SerializeOnSerializeClass>(data);
+
+            restored.SerializedKey.Is(testData.SerializedKey);
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
There are situations where performing serialization or deserialization in property getter can be useful. However, since `MessagePackSerializer` uses thread-local `byte[]` array, invoking another serialization during serialization can lead to serialization bugs. This PR fixes bug by replacing thread-local field to rented `byte[]` array from `ArrayPool`. This change should not have any significant impact on other behaviours or any performances.

The following tables show the results of the `SerializeBenchmark` benchmark. `AnswerDeserialize` benchmarks are omitted, and only benchmarks using current version of `MessagePack` (extern aliased as `newmsgpack`) are included, and iteration count and warmup count modified to 10 and 5. The first table presents results before the replacement, and the second table shows results after the change, and table shows performance difference is negligible.


```
// * Summary *

BenchmarkDotNet v0.14.0, Windows 10 (10.0.19045.5965/22H2/2022Update)
Intel Core i7-14700, 1 CPU, 28 logical and 20 physical cores
.NET SDK 9.0.103
  [Host]   : .NET 8.0.17 (8.0.1725.26602), X64 RyuJIT AVX2
  ShortRun : .NET 8.0.17 (8.0.1725.26602), X64 RyuJIT AVX2

Job=ShortRun  EnvironmentVariables=DOTNET_TieredPGO=0  Jit=RyuJit
Platform=X64  Runtime=.NET 8.0  IterationCount=10
LaunchCount=1  WarmupCount=5

| Method            | Serializer         | Mean     | Error     | StdDev    | DataSize | Gen0   | Allocated |
|------------------ |------------------- |---------:|----------:|----------:|---------:|-------:|----------:|
| AnswerSerialize   | MessagePack_v2     | 1.430 us | 0.1087 us | 0.0719 us |     469B | 0.0286 |     496 B |
| AnswerSerialize   | MessagePackLz4_v2  | 1.963 us | 0.0748 us | 0.0495 us |     451B | 0.0267 |     480 B |
| AnswerSerialize   | MsgPack_v2_opt     | 1.304 us | 0.0270 us | 0.0161 us |     433B | 0.0267 |     464 B |
| AnswerSerialize   | MsgPack_v2_str_lz4 | 2.952 us | 0.1566 us | 0.1036 us |     868B | 0.0496 |     896 B |
| AnswerSerialize   | MsgPack_v2_string  | 1.680 us | 0.0651 us | 0.0431 us |    1264B | 0.0744 |    1288 B |

```

```
| Method            | Serializer         | Mean     | Error     | StdDev    | DataSize | Gen0   | Allocated |
|------------------ |------------------- |---------:|----------:|----------:|---------:|-------:|----------:|
| AnswerSerialize   | MessagePack_v2     | 1.441 us | 0.0273 us | 0.0180 us |     471B | 0.0286 |     496 B |
| AnswerSerialize   | MessagePackLz4_v2  | 1.979 us | 0.0458 us | 0.0273 us |     453B | 0.0267 |     480 B |
| AnswerSerialize   | MsgPack_v2_opt     | 1.381 us | 0.0735 us | 0.0437 us |     435B | 0.0267 |     464 B |
| AnswerSerialize   | MsgPack_v2_str_lz4 | 2.935 us | 0.0678 us | 0.0448 us |     862B | 0.0496 |     896 B |
| AnswerSerialize   | MsgPack_v2_string  | 1.664 us | 0.0229 us | 0.0120 us |    1262B | 0.0744 |    1288 B |
```