### PR TITLE
Request for being able to configure Contractless Resolver to use Keyless setting

### DIFF
--- a/src/MessagePack/MessagePackSerializerOptions.cs
+++ b/src/MessagePack/MessagePackSerializerOptions.cs
@@ -130,6 +130,15 @@ namespace MessagePack
         public bool AllowAssemblyVersionMismatch { get; private set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether serialization of DataContract Attributes should
+        /// foce the use of string keys instead of numeric keys.
+        /// </summary>
+        /// <value>The default value is <see langword="false"/>.</value>
+        /// <remarks>This is a static for testing purposes because
+        /// where we use this we dont have an Instance of the options.</remarks>
+        public static bool ForceStringKeyForDataContract { get; set; }
+
+        /// <summary>
         /// Gets the security-related options for deserializing messagepack sequences.
         /// </summary>
         /// <value>

--- a/src/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1463,6 +1463,11 @@ namespace MessagePack.Internal
                 return null;
             }
 
+            if (dataContractAttr != null && MessagePackSerializerOptions.ForceStringKeyForDataContract)
+            {
+                forceStringKey = true;
+            }
+
             var isIntKey = true;
             var intMembers = new Dictionary<int, EmittableMember>();
             var stringMembers = new Dictionary<string, EmittableMember>();


### PR DESCRIPTION
Im trying to serialize objects from the microsoft crm (XRM SDK) [Discussion](https://github.com/microsoft/vs-streamjsonrpc/discussions/1231)

This would be very easy possible with the Dynamic Object Resolver, if there wouldnt be [the weird incompatibility of the library of interpreting DataContract attributes into fake MessagePack attributes leading to errors](https://github.com/MessagePack-CSharp/MessagePack-CSharp/issues/2217).

I would be very happy if there would be an option to forceStringKey = true; in the DynamicObjectResolver

Since this faking keys happen in the ObjectSerializationInfo I would be curious what would be the preferred way to control such an option. Right now I made a static property in MessagePackSerializerOptions wich obviously is not the way to go