### PR TITLE
DynamicObjectResolverDataContractKeyless that forces keyless serialization with DataContractAttributes

### DIFF
--- a/src/MessagePack/Resolvers/DynamicObjectResolverDataContractKeyless.cs
+++ b/src/MessagePack/Resolvers/DynamicObjectResolverDataContractKeyless.cs
@@ -1,0 +1,142 @@
+// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
+using System.Threading;
+using MessagePack.Formatters;
+using MessagePack.Internal;
+
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1403 // File may only contain a single namespace
+
+namespace MessagePack.Resolvers
+{
+    /// <summary>
+    /// ObjectResolver by dynamic code generation configured to force keyless serialization when the type is decorated with
+    /// <see cref="DataContractAttribute"/> and does not have a <see cref="MessagePackObjectAttribute"/>.
+    /// </summary>
+    public sealed class DynamicObjectResolverDataContractKeyless : IFormatterResolver
+    {
+        private const string ModuleName = "MessagePack.Resolvers.DynamicObjectResolverDataContractKeyless";
+
+        /// <summary>
+        /// The singleton instance that can be used.
+        /// </summary>
+        public static readonly DynamicObjectResolverDataContractKeyless Instance = new();
+
+        /// <summary>
+        /// A <see cref="MessagePackSerializerOptions"/> instance with this formatter pre-configured.
+        /// </summary>
+        public static readonly MessagePackSerializerOptions Options;
+
+        internal static readonly DynamicAssemblyFactory DynamicAssemblyFactory = new(ModuleName);
+
+        static DynamicObjectResolverDataContractKeyless()
+        {
+            Options = new MessagePackSerializerOptions(Instance);
+        }
+
+        private DynamicObjectResolverDataContractKeyless()
+        {
+        }
+
+#if NETFRAMEWORK
+        internal AssemblyBuilder? Save()
+        {
+            return DynamicAssemblyFactory.GetDynamicAssembly(type: null, allowPrivate: false)?.Save();
+        }
+#endif
+
+        public IMessagePackFormatter<T>? GetFormatter<T>()
+        {
+            return FormatterCache<T>.Formatter;
+        }
+
+        internal static IMessagePackFormatter<T>? BuildFormatterHelper<T>(IFormatterResolver self, DynamicAssemblyFactory dynamicAssemblyFactory, bool forceStringKey, bool contractless, bool allowPrivate)
+        {
+            TypeInfo ti = typeof(T).GetTypeInfo();
+
+            if (ti.IsInterface || ti.IsAbstract)
+            {
+                return null;
+            }
+
+            DynamicAssembly? dynamicAssembly = null;
+            if (ti.IsAnonymous())
+            {
+                forceStringKey = true;
+                contractless = true;
+
+                // For anonymous types, it's important to be able to access the internal type itself,
+                // but *not* look at non-public members to avoid double-serialization of the properties
+                // as well as their backing fields.
+                allowPrivate = false;
+                dynamicAssembly = DynamicAssemblyFactory.GetDynamicAssembly(typeof(T), true);
+            }
+            else if (ti.IsNullable())
+            {
+                ti = ti.GenericTypeArguments[0].GetTypeInfo();
+
+                var innerFormatter = self.GetFormatterDynamic(ti.AsType());
+                if (innerFormatter == null)
+                {
+                    return null;
+                }
+
+                return (IMessagePackFormatter<T>?)Activator.CreateInstance(typeof(StaticNullableFormatter<>).MakeGenericType(ti.AsType()), [innerFormatter]);
+            }
+
+            if (!forceStringKey
+                && ti.GetCustomAttribute<DataContractAttribute>() is not null
+                && ti.GetCustomAttribute<MessagePackObjectAttribute>() is null)
+            {
+                forceStringKey = true;
+            }
+
+            allowPrivate |= !contractless && typeof(T).GetCustomAttributes<MessagePackObjectAttribute>().Any(a => a.AllowPrivate);
+            dynamicAssembly ??= DynamicAssemblyFactory.GetDynamicAssembly(typeof(T), allowPrivate);
+            TypeInfo? formatterTypeInfo = DynamicObjectTypeBuilder.BuildType(dynamicAssembly, typeof(T), forceStringKey, contractless, allowPrivate);
+            return formatterTypeInfo is null ? null : (IMessagePackFormatter<T>)ResolverUtilities.ActivateFormatter(formatterTypeInfo.AsType());
+        }
+
+        private static class FormatterCache<T>
+        {
+            public static readonly IMessagePackFormatter<T>? Formatter = BuildFormatterHelper<T>(Instance, DynamicAssemblyFactory, false, false, false);
+        }
+    }
+
+    /// <summary>
+    /// ObjectResolver by dynamic code generation for <see cref="DataContractAttribute"/>, allow private member.
+    /// </summary>
+    public sealed class DynamicObjectResolverDataContractKeylessAllowPrivate : IFormatterResolver
+    {
+        private const string ModuleName = "MessagePack.Resolvers.DynamicObjectResolverDataContractKeylessAllowPrivate";
+
+        public static readonly DynamicObjectResolverDataContractKeylessAllowPrivate Instance = new DynamicObjectResolverDataContractKeylessAllowPrivate();
+
+        internal static readonly DynamicAssemblyFactory DynamicAssemblyFactory = new(ModuleName);
+
+        private DynamicObjectResolverDataContractKeylessAllowPrivate()
+        {
+        }
+
+        public IMessagePackFormatter<T>? GetFormatter<T>()
+        {
+            return FormatterCache<T>.Formatter;
+        }
+
+        private static class FormatterCache<T>
+        {
+            internal static readonly IMessagePackFormatter<T>? Formatter = DynamicObjectResolverDataContractKeyless.BuildFormatterHelper<T>(Instance, DynamicAssemblyFactory, false, false, true);
+        }
+    }
+}

--- a/tests/MessagePack.Tests/DataContractTest.cs
+++ b/tests/MessagePack.Tests/DataContractTest.cs
@@ -288,6 +288,99 @@ namespace MessagePack.Tests
             var after = (ClassWithPrivateReadonlyDictionary)dcs.ReadObject(ms);
             Assert.Equal("my name", after.GetBody()["name"]);
         }
+
+        #region DataContractBehavior
+
+        // This is a test for the behavior of DataContract serialization with mixing
+        // attributes [DataMember] and [DataMember(int Order)]
+        // and also setting Order to the same value for multiple properties.
+        // wich usually is valid and commonly used
+
+        [DataContract]
+        public class MixAttrDataContractBase
+        {
+            [DataMember(Order = 5)]
+            public string ID { get; set; }
+
+            [DataMember]
+            public int ZZNumber2 { get; set; }
+
+            [DataMember]
+            public int ANumber { get; set; }
+
+            [DataMember(Order = 5)]
+            public int HNumber { get; set; }
+
+            [DataMember(Order = 0)]
+            public DateTime ZDate { get; set; }
+        }
+
+        [DataContract]
+        public class MixAttrDataContractUser : MixAttrDataContractBase
+        {
+            [DataMember]
+            public string Name { get; set; }
+
+            [DataMember]
+            public int Age { get; set; }
+
+            public static MixAttrDataContractUser GetModelWithTestData()
+            {
+                return new MixAttrDataContractUser()
+                {
+                    ID = "12345",
+                    Age = 30,
+                    Name = "Test User",
+                    ZDate = DateTime.Now.ToUniversalTime(),
+                    ANumber = 1000,
+                    HNumber = 50,
+                    ZZNumber2 = 99,
+                };
+            }
+        }
+
+        [Fact]
+        public void SerializeDeserialize_DataContractWithMixedKeys()
+        {
+            var model = MixAttrDataContractUser.GetModelWithTestData();
+
+            var opts = MessagePackSerializerOptions.Standard.WithResolver(CompositeResolver.Create(
+                DynamicObjectResolverDataContractKeyless.Instance,
+                StandardResolver.Instance));
+
+            var serialized = MessagePackSerializer.Serialize(model, opts);
+            var modelRoundtrip = MessagePackSerializer.Deserialize<MixAttrDataContractUser>(serialized, opts);
+
+            Assert.Equivalent(model, modelRoundtrip);
+        }
+
+        [Fact]
+        public void ShowcaseDataContractSerializerMixedAttributes()
+        {
+            var model = MixAttrDataContractUser.GetModelWithTestData();
+
+            MixAttrDataContractUser modelRoundtrip;
+            string serializedSE = null;
+
+            var ser = new DataContractSerializer(typeof(MixAttrDataContractUser));
+
+            using (var tw = new StringWriter())
+            using (var xw = new System.Xml.XmlTextWriter(tw))
+            {
+                ser.WriteObject(xw, model);
+                serializedSE = tw.ToString();
+            }
+
+            using (TextReader tr = new StringReader(serializedSE))
+            using (var xmlreader = System.Xml.XmlReader.Create(tr))
+            {
+                modelRoundtrip = ser.ReadObject(xmlreader) as MixAttrDataContractUser;
+            }
+
+            Assert.Equivalent(model, modelRoundtrip);
+        }
+
+        #endregion
     }
 
 #endif


### PR DESCRIPTION
Im trying to serialize objects from the microsoft crm (XRM SDK) [Discussion](https://github.com/microsoft/vs-streamjsonrpc/discussions/1231)

This would be very easy possible with the Dynamic Object Resolver, if there wouldnt be [the weird incompatibility of the library of interpreting DataContract attributes into fake MessagePack attributes leading to errors](https://github.com/MessagePack-CSharp/MessagePack-CSharp/issues/2217).

I would be very happy if there would be an option to forceStringKey = true; in the DynamicObjectResolver

I have created a IFormatterResolver implementation for this now with just that change when building the formatter:

```
            if (!forceStringKey
                && ti.GetCustomAttribute<DataContractAttribute>() is not null
                && ti.GetCustomAttribute<MessagePackObjectAttribute>() is null)
            {
                forceStringKey = true;
            }
```

Easy to use, and configure, without any interference:

```
CompositeResolver.Create(
                DynamicObjectResolverDataContractKeyless.Instance,
                StandardResolver.Instance)
```
