### PR TITLE
Add Unity Pose formatter

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters.cs
@@ -1140,4 +1140,47 @@ namespace MessagePack.Unity
             return ____result;
         }
     }
+
+    public sealed class PoseFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::UnityEngine.Pose>
+    {
+        public void Serialize(ref MessagePackWriter writer, Pose value, MessagePackSerializerOptions options)
+        {
+            IFormatterResolver resolver = options.Resolver;
+            writer.WriteArrayHeader(2);
+            resolver.GetFormatterWithVerify<global::UnityEngine.Vector3>().Serialize(ref writer, value.position, options);
+            resolver.GetFormatterWithVerify<global::UnityEngine.Quaternion>().Serialize(ref writer, value.rotation, options);
+        }
+
+        public Pose Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        {
+            if (reader.IsNil)
+            {
+                throw new InvalidOperationException("typecode is null, struct not supported");
+            }
+
+            IFormatterResolver resolver = options.Resolver;
+            var length = reader.ReadArrayHeader();
+            var position = default(global::UnityEngine.Vector3);
+            var rotation = default(global::UnityEngine.Quaternion);
+            for (int i = 0; i < length; i++)
+            {
+                var key = i;
+                switch (key)
+                {
+                    case 0:
+                        position = resolver.GetFormatterWithVerify<global::UnityEngine.Vector3>().Deserialize(ref reader, options);
+                        break;
+                    case 1:
+                        rotation = resolver.GetFormatterWithVerify<global::UnityEngine.Quaternion>().Deserialize(ref reader, options);
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
+                }
+            }
+
+            var result = new global::UnityEngine.Pose(position, rotation);
+            return result;
+        }
+    }
 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters.cs
@@ -1143,7 +1143,7 @@ namespace MessagePack.Unity
 
     public sealed class PoseFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::UnityEngine.Pose>
     {
-        public void Serialize(ref MessagePackWriter writer, Pose value, MessagePackSerializerOptions options)
+        public void Serialize(ref MessagePackWriter writer, global::UnityEngine.Pose value, MessagePackSerializerOptions options)
         {
             IFormatterResolver resolver = options.Resolver;
             writer.WriteArrayHeader(2);
@@ -1151,7 +1151,7 @@ namespace MessagePack.Unity
             resolver.GetFormatterWithVerify<global::UnityEngine.Quaternion>().Serialize(ref writer, value.rotation, options);
         }
 
-        public Pose Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        public global::UnityEngine.Pose Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
             if (reader.IsNil)
             {

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/UnityResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/UnityResolver.cs
@@ -184,11 +184,13 @@ namespace MessagePack.Unity
             { typeof(RangeInt),           new RangeIntFormatter() },
             { typeof(RectInt),            new RectIntFormatter() },
             { typeof(BoundsInt),          new BoundsIntFormatter() },
+            { typeof(Pose),               new PoseFormatter() },
             { typeof(Vector2Int?),        new StaticNullableFormatter<Vector2Int>(new Vector2IntFormatter()) },
             { typeof(Vector3Int?),        new StaticNullableFormatter<Vector3Int>(new Vector3IntFormatter()) },
             { typeof(RangeInt?),          new StaticNullableFormatter<RangeInt>(new RangeIntFormatter()) },
             { typeof(RectInt?),           new StaticNullableFormatter<RectInt>(new RectIntFormatter()) },
             { typeof(BoundsInt?),         new StaticNullableFormatter<BoundsInt>(new BoundsIntFormatter()) },
+            { typeof(Pose?),              new StaticNullableFormatter<Pose>(new PoseFormatter()) },
 
             // unity 2017.2 + array
             { typeof(Vector2Int[]),       new ArrayFormatter<Vector2Int>() },
@@ -196,11 +198,13 @@ namespace MessagePack.Unity
             { typeof(RangeInt[]),         new ArrayFormatter<RangeInt>() },
             { typeof(RectInt[]),          new ArrayFormatter<RectInt>() },
             { typeof(BoundsInt[]),        new ArrayFormatter<BoundsInt>() },
+            { typeof(Pose[]),             new ArrayFormatter<Pose>() },
             { typeof(Vector2Int?[]),      new ArrayFormatter<Vector2Int?>() },
             { typeof(Vector3Int?[]),      new ArrayFormatter<Vector3Int?>() },
             { typeof(RangeInt?[]),        new ArrayFormatter<RangeInt?>() },
             { typeof(RectInt?[]),         new ArrayFormatter<RectInt?>() },
             { typeof(BoundsInt?[]),       new ArrayFormatter<BoundsInt?>() },
+            { typeof(Pose?[]),            new ArrayFormatter<Pose?>() },
 
             // unity 2017.2 + list
             { typeof(List<Vector2Int>),       new ListFormatter<Vector2Int>() },
@@ -208,11 +212,13 @@ namespace MessagePack.Unity
             { typeof(List<RangeInt>),         new ListFormatter<RangeInt>() },
             { typeof(List<RectInt>),          new ListFormatter<RectInt>() },
             { typeof(List<BoundsInt>),        new ListFormatter<BoundsInt>() },
+            { typeof(List<Pose>),             new ListFormatter<Pose>() },
             { typeof(List<Vector2Int?>),      new ListFormatter<Vector2Int?>() },
             { typeof(List<Vector3Int?>),      new ListFormatter<Vector3Int?>() },
             { typeof(List<RangeInt?>),        new ListFormatter<RangeInt?>() },
             { typeof(List<RectInt?>),         new ListFormatter<RectInt?>() },
             { typeof(List<BoundsInt?>),       new ListFormatter<BoundsInt?>() },
+            { typeof(List<Pose?>),            new ListFormatter<Pose?>() },
         };
 
         internal static object? GetFormatter(Type t)


### PR DESCRIPTION
Pose (https://docs.unity3d.com/ScriptReference/Pose.html) was introduced in Unity 2017.2, is a part of CoreModule and is quite useful in XR. I think it would be nice to add its formatter and extend the Unity resolver.