### PR TITLE
perf: drop redundant char* fixed in MessagePackWriter.Write(string)

### DIFF
--- a/src/MessagePack/MessagePackWriter.cs
+++ b/src/MessagePack/MessagePackWriter.cs
@@ -625,7 +625,7 @@ namespace MessagePack
 #else
                 fixed (char* pValue = value)
                 {
-                    byteCount = StringEncoding.UTF8.GetBytes(pValue, value.Length, pBuffer + useOffset, bufferSize);
+                    byteCount = StringEncoding.UTF8.GetBytes(pValue, value.Length, pBuffer + useOffset, bufferSize - useOffset);
                 }
 #endif
                 this.WriteString_PostEncoding(pBuffer, useOffset, byteCount);

--- a/src/MessagePack/MessagePackWriter.cs
+++ b/src/MessagePack/MessagePackWriter.cs
@@ -599,7 +599,7 @@ namespace MessagePack
 #else
                 fixed (char* pValue = value)
                 {
-                    byteCount = StringEncoding.UTF8.GetBytes(pValue, value.Length, pBuffer + useOffset, bufferSize);
+                    byteCount = StringEncoding.UTF8.GetBytes(pValue, value.Length, pBuffer + useOffset, bufferSize - useOffset);
                 }
 #endif
                 this.WriteString_PostEncoding(pBuffer, useOffset, byteCount);

--- a/src/MessagePack/MessagePackWriter.cs
+++ b/src/MessagePack/MessagePackWriter.cs
@@ -591,10 +591,17 @@ namespace MessagePack
             }
 
             ref byte buffer = ref this.WriteString_PrepareSpan(value.Length, out int bufferSize, out int useOffset);
-            fixed (char* pValue = value)
             fixed (byte* pBuffer = &buffer)
             {
-                int byteCount = StringEncoding.UTF8.GetBytes(pValue, value.Length, pBuffer + useOffset, bufferSize);
+                int byteCount;
+#if SPAN_BUILTIN
+                byteCount = StringEncoding.UTF8.GetBytes(value.AsSpan(), new Span<byte>(pBuffer + useOffset, bufferSize - useOffset));
+#else
+                fixed (char* pValue = value)
+                {
+                    byteCount = StringEncoding.UTF8.GetBytes(pValue, value.Length, pBuffer + useOffset, bufferSize);
+                }
+#endif
                 this.WriteString_PostEncoding(pBuffer, useOffset, byteCount);
             }
         }
@@ -610,10 +617,17 @@ namespace MessagePack
         public unsafe void Write(ReadOnlySpan<char> value)
         {
             ref byte buffer = ref this.WriteString_PrepareSpan(value.Length, out int bufferSize, out int useOffset);
-            fixed (char* pValue = value)
             fixed (byte* pBuffer = &buffer)
             {
-                int byteCount = StringEncoding.UTF8.GetBytes(pValue, value.Length, pBuffer + useOffset, bufferSize);
+                int byteCount;
+#if SPAN_BUILTIN
+                byteCount = StringEncoding.UTF8.GetBytes(value, new Span<byte>(pBuffer + useOffset, bufferSize - useOffset));
+#else
+                fixed (char* pValue = value)
+                {
+                    byteCount = StringEncoding.UTF8.GetBytes(pValue, value.Length, pBuffer + useOffset, bufferSize);
+                }
+#endif
                 this.WriteString_PostEncoding(pBuffer, useOffset, byteCount);
             }
         }


### PR DESCRIPTION
On `SPAN_BUILTIN` targets (`netstandard2.1`/`net8.0`/`net9.0`), use the span-based `Encoding.GetBytes(ReadOnlySpan<char>, Span<byte>)` overload so the `fixed (char* pValue = value)` pin can go away. The `Encoding` API pins the source itself for the duration of the encode, which is shorter than holding the pin across `WriteString_PostEncoding`.

Legacy targets (`netstandard2.0`/`net472`) keep the original `fixed (char* …)` path under `#else`.

The `fixed (byte* pBuffer = &buffer)` stays for now — `WriteString_PostEncoding` still takes `byte*` and uses `Buffer.MemoryCopy` for the overlapping prefix shift. Dropping that pin too would mean rewriting `WriteString_PostEncoding` to `ref byte` + `MemoryMarshal.CreateSpan(...).CopyTo(...)`, but `MemoryMarshal.CreateSpan` is `netstandard2.1+` only (not in the `System.Memory` backport for `netstandard2.0`/`net472`), so that's a bigger refactor for another PR.

## Test plan

- [x] Builds clean on all 5 TFMs (`netstandard2.0;netstandard2.1;net8.0;net9.0;net472`)
- [x] `MessagePack.Tests` — 999/999 pass on `net9.0`, 968/968 on `net472`