### PR TITLE
Revert DateTimeOffset encoding change

### DIFF
--- a/src/MessagePack/Formatters/StandardClassLibraryFormatter.cs
+++ b/src/MessagePack/Formatters/StandardClassLibraryFormatter.cs
@@ -257,7 +257,10 @@ namespace MessagePack.Formatters
         public void Serialize(ref MessagePackWriter writer, DateTimeOffset value, MessagePackSerializerOptions options)
         {
             writer.WriteArrayHeader(2);
-            writer.Write(new DateTime(value.UtcTicks, DateTimeKind.Utc)); // current ticks as is
+
+            // We're writing a *local* DateTime value in msgpack encoding as if it were UTC time.
+            // That's incorrect msgpack encoding, but fixing it now would compromise backward compatibility.
+            writer.Write(new DateTime(value.Ticks, DateTimeKind.Utc)); // current ticks as is
             writer.Write((short)value.Offset.TotalMinutes); // offset is normalized in minutes
             return;
         }

--- a/tests/MessagePack.Tests/FormatterTest.cs
+++ b/tests/MessagePack.Tests/FormatterTest.cs
@@ -227,8 +227,12 @@ namespace MessagePack.Tests
         {
             string id = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Tokyo Standard Time" : "Cuba";
             DateTimeOffset now = new DateTime(DateTime.UtcNow.Ticks + TimeZoneInfo.FindSystemTimeZoneById(id).BaseUtcOffset.Ticks, DateTimeKind.Local);
-            var binary = MessagePackSerializer.Serialize(now);
-            MessagePackSerializer.Deserialize<DateTimeOffset>(binary).Is(now);
+            AssertRoundtrip(now);
+
+            AssertRoundtrip(DateTimeOffset.Now);
+
+            // Try specific offset values because CI/PR builds run on agents that run on the UTC time zone.
+            AssertRoundtrip(DateTimeOffset.Now.ToOffset(TimeSpan.FromHours(4)));
         }
 
         [Fact]
@@ -323,5 +327,21 @@ namespace MessagePack.Tests
         }
 
 #endif
+
+        private static DateTimeOffset AssertRoundtrip(DateTimeOffset value)
+        {
+            var result = MessagePackSerializer.Deserialize<DateTimeOffset>(MessagePackSerializer.Serialize(value));
+            result.Is(value, DateTimeOffsetEqualityComparer.Instance);
+            return result;
+        }
+
+        private class DateTimeOffsetEqualityComparer : IEqualityComparer<DateTimeOffset>
+        {
+            internal static readonly DateTimeOffsetEqualityComparer Instance = new();
+
+            public bool Equals(DateTimeOffset x, DateTimeOffset y) => x.EqualsExact(y);
+
+            public int GetHashCode(DateTimeOffset obj) => obj.UtcDateTime.GetHashCode();
+        }
     }
 }


### PR DESCRIPTION
Revert #2225 which broke our tests.

Fixing the original issue *properly* is possible but would be a wire protocol breaking change for MessagePack-CSharp at this point, even if it would more properly conform to the msgpack encoding spec.