### PR TITLE
Fix security issues in master

### DIFF
--- a/src/MessagePack.AspNetCoreMvcFormatter/MessagePackInputFormatter.cs
+++ b/src/MessagePack.AspNetCoreMvcFormatter/MessagePackInputFormatter.cs
@@ -9,16 +9,17 @@ namespace MessagePack.AspNetCoreMvcFormatter
     public class MessagePackInputFormatter : InputFormatter
     {
         private const string ContentType = "application/x-msgpack";
-        private readonly MessagePackSerializerOptions? options;
+        private static readonly MessagePackSerializerOptions DefaultOptions = MessagePackSerializerOptions.Standard.WithSecurity(MessagePackSecurity.UntrustedData);
+        private readonly MessagePackSerializerOptions options;
 
         public MessagePackInputFormatter()
-            : this(null)
+            : this(DefaultOptions)
         {
         }
 
         public MessagePackInputFormatter(MessagePackSerializerOptions? options)
         {
-            this.options = options;
+            this.options = options ?? DefaultOptions;
 
             SupportedMediaTypes.Add(ContentType);
         }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Extension/UnsafeBlitFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Extension/UnsafeBlitFormatter.cs
@@ -55,19 +55,25 @@ namespace MessagePack.Unity.Extension
                 return null;
             }
 
-            ExtensionHeader header = reader.ReadExtensionFormatHeader();
-            if (header.TypeCode != this.TypeCode)
+            ExtensionResult extension = reader.ReadExtensionFormat();
+            if (extension.TypeCode != this.TypeCode)
             {
                 throw new InvalidOperationException("Invalid typeCode.");
             }
 
-            var byteLength = reader.ReadInt32();
-            var isLittleEndian = reader.ReadBoolean();
+            MessagePackReader extensionReader = reader.Clone(extension.Data);
+            var byteLength = extensionReader.ReadInt32();
+            var isLittleEndian = extensionReader.ReadBoolean();
+            long remainingBytes = extensionReader.Sequence.Length - extensionReader.Consumed;
+            if (byteLength < 0 || byteLength % sizeof(T) != 0 || byteLength != remainingBytes)
+            {
+                throw new MessagePackSerializationException("Invalid Unity blit extension length.");
+            }
 
             // Allocate a T[] that we will return. We'll then cast the T[] as byte[] so we can copy the byte sequence directly into it.
             var result = new T[byteLength / sizeof(T)];
             Span<byte> resultAsBytes = MemoryMarshal.Cast<T, byte>(result);
-            reader.ReadRaw(byteLength).CopyTo(resultAsBytes);
+            extensionReader.ReadRaw(byteLength).CopyTo(resultAsBytes);
 
             // Reverse the byte order if necessary.
             if (isLittleEndian != BitConverter.IsLittleEndian && result.Length > 0)

--- a/src/MessagePack/Formatters/CollectionFormatter.cs
+++ b/src/MessagePack/Formatters/CollectionFormatter.cs
@@ -928,7 +928,7 @@ namespace MessagePack.Formatters
 
         protected override Dictionary<TKey, IGrouping<TKey, TElement>> Create(int count, MessagePackSerializerOptions options)
         {
-            return new Dictionary<TKey, IGrouping<TKey, TElement>>(count);
+            return new Dictionary<TKey, IGrouping<TKey, TElement>>(count, options.Security.GetEqualityComparer<TKey>());
         }
     }
 

--- a/src/MessagePack/Formatters/ExpandoObjectFormatter.cs
+++ b/src/MessagePack/Formatters/ExpandoObjectFormatter.cs
@@ -8,6 +8,8 @@ namespace MessagePack.Formatters
 {
     public class ExpandoObjectFormatter : IMessagePackFormatter<ExpandoObject?>
     {
+        internal const int MaximumUntrustedDataMemberCount = 1024;
+
         public static readonly IMessagePackFormatter<ExpandoObject?> Instance = new ExpandoObjectFormatter();
 
         private ExpandoObjectFormatter()
@@ -23,6 +25,7 @@ namespace MessagePack.Formatters
 
             var result = new ExpandoObject();
             int count = reader.ReadMapHeader();
+            ThrowIfMapTooLargeForUntrustedData(count, options);
             if (count > 0)
             {
                 IFormatterResolver resolver = options.Resolver;
@@ -47,6 +50,14 @@ namespace MessagePack.Formatters
             }
 
             return result;
+        }
+
+        internal static void ThrowIfMapTooLargeForUntrustedData(int count, MessagePackSerializerOptions options)
+        {
+            if (options.Security.HashCollisionResistant && count > MaximumUntrustedDataMemberCount)
+            {
+                throw new MessagePackSerializationException($"ExpandoObject map size exceeds the limit of {MaximumUntrustedDataMemberCount} entries allowed under untrusted data security mode.");
+            }
         }
 
         public void Serialize(ref MessagePackWriter writer, ExpandoObject? value, MessagePackSerializerOptions options)

--- a/src/MessagePack/Formatters/MultiDimensionalArrayFormatter.cs
+++ b/src/MessagePack/Formatters/MultiDimensionalArrayFormatter.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Buffers;
-using System.Collections.Generic;
-using System.Text;
+using System.Diagnostics.CodeAnalysis;
 using MessagePack.Internal;
 
 #pragma warning disable SA1402 // File may only contain a single type
@@ -64,6 +62,7 @@ namespace MessagePack.Formatters
                 var iLength = reader.ReadInt32();
                 var jLength = reader.ReadInt32();
                 var maxLen = reader.ReadArrayHeader();
+                MultiDimensionalArrayFormatterHelper.ThrowIfLengthsDontMatch("T[,]", maxLen, iLength, jLength);
 
                 var array = new T[iLength, jLength];
 
@@ -151,6 +150,7 @@ namespace MessagePack.Formatters
                 var jLength = reader.ReadInt32();
                 var kLength = reader.ReadInt32();
                 var maxLen = reader.ReadArrayHeader();
+                MultiDimensionalArrayFormatterHelper.ThrowIfLengthsDontMatch("T[,,]", maxLen, iLength, jLength, kLength);
 
                 var array = new T[iLength, jLength, kLength];
 
@@ -248,6 +248,8 @@ namespace MessagePack.Formatters
                 var kLength = reader.ReadInt32();
                 var lLength = reader.ReadInt32();
                 var maxLen = reader.ReadArrayHeader();
+                MultiDimensionalArrayFormatterHelper.ThrowIfLengthsDontMatch("T[,,,]", maxLen, iLength, jLength, kLength, lLength);
+
                 var array = new T[iLength, jLength, kLength, lLength];
 
                 var i = 0;
@@ -294,5 +296,35 @@ namespace MessagePack.Formatters
                 return array;
             }
         }
+    }
+
+    internal static class MultiDimensionalArrayFormatterHelper
+    {
+        internal static void ThrowIfLengthsDontMatch(string format, int actualLength, int firstLength, int secondLength, int thirdLength = 1, int fourthLength = 1)
+        {
+            if (firstLength < 0 || secondLength < 0 || thirdLength < 0 || fourthLength < 0)
+            {
+                ThrowInvalidFormat(format);
+            }
+
+            int expectedLength;
+            try
+            {
+                expectedLength = checked(firstLength * secondLength * thirdLength * fourthLength);
+            }
+            catch (OverflowException)
+            {
+                ThrowInvalidFormat(format);
+                return;
+            }
+
+            if (expectedLength != actualLength)
+            {
+                ThrowInvalidFormat(format);
+            }
+        }
+
+        [DoesNotReturn]
+        private static void ThrowInvalidFormat(string format) => throw new MessagePackSerializationException($"Invalid {format} format");
     }
 }

--- a/src/MessagePack/Formatters/StandardClassLibraryFormatter.cs
+++ b/src/MessagePack/Formatters/StandardClassLibraryFormatter.cs
@@ -837,9 +837,14 @@ namespace MessagePack.Formatters
 
         public T? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            return reader.ReadString() is string value
-                ? (T?)Type.GetType(value, throwOnError: true)
-                : null;
+            if (reader.ReadString() is not string value)
+            {
+                return null;
+            }
+
+            Type type = options.LoadType(value) ?? throw new TypeLoadException(value);
+            options.ThrowIfDeserializingTypeIsDisallowed(type);
+            return (T?)type;
         }
     }
 

--- a/src/MessagePack/Internal/TinyJsonReader.cs
+++ b/src/MessagePack/Internal/TinyJsonReader.cs
@@ -137,62 +137,64 @@ namespace MessagePack
 
         private void ReadNextToken()
         {
-            this.SkipWhiteSpace();
-
-            var intChar = this.reader.Peek();
-            if (intChar == -1)
+            while (true)
             {
-                this.TokenType = TinyJsonToken.None;
-                return;
-            }
+                this.SkipWhiteSpace();
 
-            var c = (char)intChar;
-            switch (c)
-            {
-                case '{':
-                    this.TokenType = TinyJsonToken.StartObject;
+                var intChar = this.reader.Peek();
+                if (intChar == -1)
+                {
+                    this.TokenType = TinyJsonToken.None;
                     return;
-                case '}':
-                    this.TokenType = TinyJsonToken.EndObject;
-                    return;
-                case '[':
-                    this.TokenType = TinyJsonToken.StartArray;
-                    return;
-                case ']':
-                    this.TokenType = TinyJsonToken.EndArray;
-                    return;
-                case '"':
-                    this.TokenType = TinyJsonToken.String;
-                    return;
-                case '0':
-                case '1':
-                case '2':
-                case '3':
-                case '4':
-                case '5':
-                case '6':
-                case '7':
-                case '8':
-                case '9':
-                case '-':
-                    this.TokenType = TinyJsonToken.Number;
-                    return;
-                case 't':
-                    this.TokenType = TinyJsonToken.True;
-                    return;
-                case 'f':
-                    this.TokenType = TinyJsonToken.False;
-                    return;
-                case 'n':
-                    this.TokenType = TinyJsonToken.Null;
-                    return;
-                case ',':
-                case ':':
-                    this.reader.Read();
-                    this.ReadNextToken();
-                    return;
-                default:
-                    throw new TinyJsonException("Invalid String:" + c);
+                }
+
+                var c = (char)intChar;
+                switch (c)
+                {
+                    case '{':
+                        this.TokenType = TinyJsonToken.StartObject;
+                        return;
+                    case '}':
+                        this.TokenType = TinyJsonToken.EndObject;
+                        return;
+                    case '[':
+                        this.TokenType = TinyJsonToken.StartArray;
+                        return;
+                    case ']':
+                        this.TokenType = TinyJsonToken.EndArray;
+                        return;
+                    case '"':
+                        this.TokenType = TinyJsonToken.String;
+                        return;
+                    case '0':
+                    case '1':
+                    case '2':
+                    case '3':
+                    case '4':
+                    case '5':
+                    case '6':
+                    case '7':
+                    case '8':
+                    case '9':
+                    case '-':
+                        this.TokenType = TinyJsonToken.Number;
+                        return;
+                    case 't':
+                        this.TokenType = TinyJsonToken.True;
+                        return;
+                    case 'f':
+                        this.TokenType = TinyJsonToken.False;
+                        return;
+                    case 'n':
+                        this.TokenType = TinyJsonToken.Null;
+                        return;
+                    case ',':
+                    case ':':
+                        this.reader.Read();
+                        continue;
+                    default:
+                        throw new TinyJsonException("Invalid String:" + c);
+                }
             }
         }
 

--- a/src/MessagePack/Internal/UnsafeMemory.Low.cs
+++ b/src/MessagePack/Internal/UnsafeMemory.Low.cs
@@ -15,12 +15,20 @@ namespace MessagePack.Internal
         public static readonly bool Is32Bit = IntPtr.Size == 4;
     }
 
+    /// <summary>
+    /// Highly tuned method for writing raw bytes to a <see cref="MessagePackWriter"/>.
+    /// </summary>
+    /// <remarks>
+    /// The methods on this class are <em>not</em> safe, in that they use pointer arithmetic
+    /// and assume that the caller has provided a <see cref="ReadOnlySpan{Byte}"/> with a length
+    /// of at least the number of bytes being written. The caller must ensure that this is the case.
+    /// </remarks>
     public static partial class UnsafeMemory32
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw1(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(1);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -28,13 +36,13 @@ namespace MessagePack.Internal
                 *(byte*)pDst = *(byte*)pSrc;
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(1);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw2(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(2);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -42,13 +50,13 @@ namespace MessagePack.Internal
                 *(short*)pDst = *(short*)pSrc;
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(2);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw3(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(3);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -57,16 +65,24 @@ namespace MessagePack.Internal
                 *(short*)(pDst + 1) = *(short*)(pSrc + 1);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(3);
         }
     }
 
+    /// <summary>
+    /// Highly tuned method for writing raw bytes to a <see cref="MessagePackWriter"/>.
+    /// </summary>
+    /// <remarks>
+    /// The methods on this class are <em>not</em> safe, in that they use pointer arithmetic
+    /// and assume that the caller has provided a <see cref="ReadOnlySpan{Byte}"/> with a length
+    /// of at least the number of bytes being written. The caller must ensure that this is the case.
+    /// </remarks>
     public static partial class UnsafeMemory64
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw1(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(1);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -74,13 +90,13 @@ namespace MessagePack.Internal
                 *(byte*)pDst = *(byte*)pSrc;
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(1);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw2(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(2);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -88,13 +104,13 @@ namespace MessagePack.Internal
                 *(short*)pDst = *(short*)pSrc;
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(2);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw3(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(3);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -103,13 +119,13 @@ namespace MessagePack.Internal
                 *(short*)(pDst + 1) = *(short*)(pSrc + 1);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(3);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw4(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(4);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -117,13 +133,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 0) = *(int*)(pSrc + 0);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(4);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw5(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(5);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -132,13 +148,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 1) = *(int*)(pSrc + 1);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(5);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw6(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(6);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -147,13 +163,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 2) = *(int*)(pSrc + 2);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(6);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw7(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(7);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -162,7 +178,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 3) = *(int*)(pSrc + 3);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(7);
         }
     }
 }

--- a/src/MessagePack/Internal/UnsafeMemory.cs
+++ b/src/MessagePack/Internal/UnsafeMemory.cs
@@ -18,7 +18,7 @@ namespace MessagePack.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw4(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(4);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -26,13 +26,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 0) = *(int*)(pSrc + 0);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(4);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw5(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(5);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -41,13 +41,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 1) = *(int*)(pSrc + 1);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(5);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw6(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(6);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -56,13 +56,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 2) = *(int*)(pSrc + 2);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(6);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw7(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(7);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -71,13 +71,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 3) = *(int*)(pSrc + 3);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(7);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw8(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(8);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -86,13 +86,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 4) = *(int*)(pSrc + 4);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(8);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw9(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(9);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -102,13 +102,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 5) = *(int*)(pSrc + 5);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(9);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw10(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(10);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -118,13 +118,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 6) = *(int*)(pSrc + 6);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(10);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw11(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(11);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -134,13 +134,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 7) = *(int*)(pSrc + 7);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(11);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw12(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(12);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -150,13 +150,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 8) = *(int*)(pSrc + 8);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(12);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw13(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(13);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -167,13 +167,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 9) = *(int*)(pSrc + 9);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(13);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw14(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(14);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -184,13 +184,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 10) = *(int*)(pSrc + 10);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(14);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw15(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(15);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -201,13 +201,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 11) = *(int*)(pSrc + 11);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(15);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw16(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(16);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -218,13 +218,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 12) = *(int*)(pSrc + 12);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(16);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw17(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(17);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -236,13 +236,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 13) = *(int*)(pSrc + 13);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(17);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw18(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(18);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -254,13 +254,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 14) = *(int*)(pSrc + 14);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(18);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw19(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(19);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -272,13 +272,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 15) = *(int*)(pSrc + 15);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(19);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw20(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(20);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -290,13 +290,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 16) = *(int*)(pSrc + 16);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(20);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw21(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(21);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -309,13 +309,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 17) = *(int*)(pSrc + 17);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(21);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw22(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(22);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -328,13 +328,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 18) = *(int*)(pSrc + 18);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(22);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw23(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(23);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -347,13 +347,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 19) = *(int*)(pSrc + 19);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(23);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw24(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(24);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -366,13 +366,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 20) = *(int*)(pSrc + 20);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(24);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw25(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(25);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -386,13 +386,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 21) = *(int*)(pSrc + 21);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(25);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw26(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(26);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -406,13 +406,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 22) = *(int*)(pSrc + 22);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(26);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw27(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(27);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -426,13 +426,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 23) = *(int*)(pSrc + 23);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(27);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw28(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(28);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -446,13 +446,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 24) = *(int*)(pSrc + 24);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(28);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw29(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(29);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -467,13 +467,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 25) = *(int*)(pSrc + 25);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(29);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw30(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(30);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -488,13 +488,13 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 26) = *(int*)(pSrc + 26);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(30);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw31(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(31);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -509,7 +509,7 @@ namespace MessagePack.Internal
                 *(int*)(pDst + 27) = *(int*)(pSrc + 27);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(31);
         }
     }
 
@@ -518,7 +518,7 @@ namespace MessagePack.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw8(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(8);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -526,13 +526,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 0) = *(long*)(pSrc + 0);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(8);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw9(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(9);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -541,13 +541,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 1) = *(long*)(pSrc + 1);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(9);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw10(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(10);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -556,13 +556,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 2) = *(long*)(pSrc + 2);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(10);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw11(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(11);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -571,13 +571,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 3) = *(long*)(pSrc + 3);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(11);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw12(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(12);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -586,13 +586,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 4) = *(long*)(pSrc + 4);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(12);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw13(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(13);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -601,13 +601,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 5) = *(long*)(pSrc + 5);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(13);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw14(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(14);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -616,13 +616,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 6) = *(long*)(pSrc + 6);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(14);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw15(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(15);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -631,13 +631,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 7) = *(long*)(pSrc + 7);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(15);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw16(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(16);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -646,13 +646,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 8) = *(long*)(pSrc + 8);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(16);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw17(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(17);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -662,13 +662,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 9) = *(long*)(pSrc + 9);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(17);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw18(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(18);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -678,13 +678,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 10) = *(long*)(pSrc + 10);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(18);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw19(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(19);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -694,13 +694,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 11) = *(long*)(pSrc + 11);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(19);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw20(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(20);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -710,13 +710,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 12) = *(long*)(pSrc + 12);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(20);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw21(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(21);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -726,13 +726,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 13) = *(long*)(pSrc + 13);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(21);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw22(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(22);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -742,13 +742,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 14) = *(long*)(pSrc + 14);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(22);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw23(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(23);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -758,13 +758,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 15) = *(long*)(pSrc + 15);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(23);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw24(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(24);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -774,13 +774,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 16) = *(long*)(pSrc + 16);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(24);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw25(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(25);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -791,13 +791,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 17) = *(long*)(pSrc + 17);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(25);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw26(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(26);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -808,13 +808,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 18) = *(long*)(pSrc + 18);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(26);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw27(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(27);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -825,13 +825,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 19) = *(long*)(pSrc + 19);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(27);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw28(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(28);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -842,13 +842,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 20) = *(long*)(pSrc + 20);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(28);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw29(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(29);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -859,13 +859,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 21) = *(long*)(pSrc + 21);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(29);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw30(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(30);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -876,13 +876,13 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 22) = *(long*)(pSrc + 22);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(30);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw31(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(31);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -893,7 +893,7 @@ namespace MessagePack.Internal
                 *(long*)(pDst + 23) = *(long*)(pSrc + 23);
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(31);
         }
     }
 }

--- a/src/MessagePack/Internal/UnsafeMemory.tt
+++ b/src/MessagePack/Internal/UnsafeMemory.tt
@@ -28,7 +28,7 @@ namespace MessagePack.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw<#= i #>(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(<#= i #>);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -41,7 +41,7 @@ namespace MessagePack.Internal
 <# } #>
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(<#= i #>);
         }
 <# } #>
     }
@@ -52,7 +52,7 @@ namespace MessagePack.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void WriteRaw<#= i #>(ref MessagePackWriter writer, ReadOnlySpan<byte> src)
         {
-            Span<byte> dst = writer.GetSpan(src.Length);
+            Span<byte> dst = writer.GetSpan(<#= i #>);
 
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
@@ -65,7 +65,7 @@ namespace MessagePack.Internal
 <# } #>
             }
 
-            writer.Advance(src.Length);
+            writer.Advance(<#= i #>);
         }
 <# } #>
     }

--- a/src/MessagePack/LZ4/LZ4Codec.Unsafe.cs
+++ b/src/MessagePack/LZ4/LZ4Codec.Unsafe.cs
@@ -99,11 +99,11 @@ namespace MessagePack.LZ4
                 int length;
                 if (IntPtr.Size == 4)
                 {
-                    length = LZ4_uncompress_32(inputPtr, outputPtr, output.Length);
+                    length = LZ4_uncompress_32(inputPtr, input.Length, outputPtr, output.Length);
                 }
                 else
                 {
-                    length = LZ4_uncompress_64(inputPtr, outputPtr, output.Length);
+                    length = LZ4_uncompress_64(inputPtr, input.Length, outputPtr, output.Length);
                 }
 
                 if (length != input.Length)

--- a/src/MessagePack/LZ4/LZ4Codec.Unsafe32.Dirty.cs
+++ b/src/MessagePack/LZ4/LZ4Codec.Unsafe32.Dirty.cs
@@ -600,6 +600,7 @@ _last_literals:
 
         private static unsafe int LZ4_uncompress_32(
             byte* src,
+            int src_len,
             byte* dst,
             int dst_len)
         {
@@ -609,6 +610,7 @@ _last_literals:
                 {
                     // r93
                     var src_p = src;
+                    var src_end = src + src_len;
                     byte* xxx_ref;
 
                     var dst_p = dst;
@@ -627,16 +629,26 @@ _last_literals:
                         int length;
 
                         // get runlength
+                        if (src_p >= src_end)
+                        {
+                            goto _output_error;
+                        }
+
                         xxx_token = *src_p++;
                         if ((length = (int)(xxx_token >> ML_BITS)) == RUN_MASK)
                         {
                             int len;
-                            for (; (len = *src_p++) == 255; length += 255)
+                            do
                             {
-                                /* do nothing */
-                            }
+                                if (src_p >= src_end)
+                                {
+                                    goto _output_error;
+                                }
 
-                            length += len;
+                                len = *src_p++;
+                                length += len;
+                            }
+                            while (len == 255);
                         }
 
                         // copy literals
@@ -649,9 +661,19 @@ _last_literals:
                                 goto _output_error; // Error : not enough place for another match (min 4) + 5 literals
                             }
 
+                            if (length > src_end - src_p)
+                            {
+                                goto _output_error;
+                            }
+
                             BlockCopy32(src_p, dst_p, length);
                             src_p += length;
                             break; // EOF
+                        }
+
+                        if (length > src_end - src_p)
+                        {
+                            goto _output_error;
                         }
 
                         do
@@ -668,6 +690,11 @@ _last_literals:
                         dst_p = dst_cpy;
 
                         // get offset
+                        if (src_end - src_p < 2)
+                        {
+                            goto _output_error;
+                        }
+
                         xxx_ref = dst_cpy - (*(ushort*)src_p);
                         src_p += 2;
                         if (xxx_ref < dst)
@@ -678,12 +705,18 @@ _last_literals:
                         // get matchlength
                         if ((length = (int)(xxx_token & ML_MASK)) == ML_MASK)
                         {
-                            for (; *src_p == 255; length += 255)
+                            int len;
+                            do
                             {
-                                src_p++;
-                            }
+                                if (src_p >= src_end)
+                                {
+                                    goto _output_error;
+                                }
 
-                            length += *src_p++;
+                                len = *src_p++;
+                                length += len;
+                            }
+                            while (len == 255);
                         }
 
                         // copy repeated sequence

--- a/src/MessagePack/LZ4/LZ4Codec.Unsafe64.Dirty.cs
+++ b/src/MessagePack/LZ4/LZ4Codec.Unsafe64.Dirty.cs
@@ -612,6 +612,7 @@ _last_literals:
 
         private static unsafe int LZ4_uncompress_64(
             byte* src,
+            int src_len,
             byte* dst,
             int dst_len)
         {
@@ -622,6 +623,7 @@ _last_literals:
                 {
                     // r93
                     var src_p = src;
+                    var src_end = src + src_len;
                     byte* dst_ref;
 
                     var dst_p = dst;
@@ -640,16 +642,26 @@ _last_literals:
                         int length;
 
                         // get runlength
+                        if (src_p >= src_end)
+                        {
+                            goto _output_error;
+                        }
+
                         token = *src_p++;
                         if ((length = token >> ML_BITS) == RUN_MASK)
                         {
                             int len;
-                            for (; (len = *src_p++) == 255; length += 255)
+                            do
                             {
-                                /* do nothing */
-                            }
+                                if (src_p >= src_end)
+                                {
+                                    goto _output_error;
+                                }
 
-                            length += len;
+                                len = *src_p++;
+                                length += len;
+                            }
+                            while (len == 255);
                         }
 
                         // copy literals
@@ -662,9 +674,19 @@ _last_literals:
                                 goto _output_error; // Error : not enough place for another match (min 4) + 5 literals
                             }
 
+                            if (length > src_end - src_p)
+                            {
+                                goto _output_error;
+                            }
+
                             BlockCopy64(src_p, dst_p, length);
                             src_p += length;
                             break; // EOF
+                        }
+
+                        if (length > src_end - src_p)
+                        {
+                            goto _output_error;
                         }
 
                         do
@@ -678,6 +700,11 @@ _last_literals:
                         dst_p = dst_cpy;
 
                         // get offset
+                        if (src_end - src_p < 2)
+                        {
+                            goto _output_error;
+                        }
+
                         dst_ref = dst_cpy - (*(ushort*)src_p);
                         src_p += 2;
                         if (dst_ref < dst)
@@ -688,12 +715,18 @@ _last_literals:
                         // get matchlength
                         if ((length = token & ML_MASK) == ML_MASK)
                         {
-                            for (; *src_p == 255; length += 255)
+                            int len;
+                            do
                             {
-                                src_p++;
-                            }
+                                if (src_p >= src_end)
+                                {
+                                    goto _output_error;
+                                }
 
-                            length += *src_p++;
+                                len = *src_p++;
+                                length += len;
+                            }
+                            while (len == 255);
                         }
 
                         // copy repeated sequence

--- a/src/MessagePack/MessagePackPrimitives.Readers.cs
+++ b/src/MessagePack/MessagePackPrimitives.Readers.cs
@@ -342,6 +342,12 @@ partial class MessagePackPrimitives
             return DecodeResult.TokenMismatch;
         }
 
+        if (header.Length is not (4 or 8 or 12))
+        {
+            value = default;
+            return DecodeResult.TokenMismatch;
+        }
+
         if (source.Length < tokenSize)
         {
             value = default;

--- a/src/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack/MessagePackReader.cs
@@ -371,7 +371,7 @@ namespace MessagePack
             // Protect against corrupted or mischievous data that may lead to allocating way too much memory.
             // We allow for each primitive to be the minimal 1 byte in size, and we have a key=value map, so that's 2 bytes.
             // Formatters that know each element is larger can optionally add a stronger check.
-            ThrowInsufficientBufferUnless(this.reader.Remaining >= count * 2);
+            ThrowInsufficientBufferUnless(this.reader.Remaining >= (long)count * 2);
 
             return count;
         }

--- a/src/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack/MessagePackReader.cs
@@ -153,64 +153,123 @@ namespace MessagePack
         /// </remarks>
         internal bool TrySkip()
         {
-            if (this.reader.Remaining == 0)
+            long remainingStructures = 1;
+            while (remainingStructures > 0)
             {
-                return false;
+                if (this.reader.Remaining == 0)
+                {
+                    return false;
+                }
+
+                remainingStructures--;
+                byte code = this.NextCode;
+                switch (code)
+                {
+                    case byte x when MessagePackCode.IsPositiveFixInt(x) || MessagePackCode.IsNegativeFixInt(x):
+                    case MessagePackCode.Nil:
+                    case MessagePackCode.True:
+                    case MessagePackCode.False:
+                        if (!this.reader.TryAdvance(1))
+                        {
+                            return false;
+                        }
+
+                        break;
+                    case MessagePackCode.Int8:
+                    case MessagePackCode.UInt8:
+                        if (!this.reader.TryAdvance(2))
+                        {
+                            return false;
+                        }
+
+                        break;
+                    case MessagePackCode.Int16:
+                    case MessagePackCode.UInt16:
+                        if (!this.reader.TryAdvance(3))
+                        {
+                            return false;
+                        }
+
+                        break;
+                    case MessagePackCode.Int32:
+                    case MessagePackCode.UInt32:
+                    case MessagePackCode.Float32:
+                        if (!this.reader.TryAdvance(5))
+                        {
+                            return false;
+                        }
+
+                        break;
+                    case MessagePackCode.Int64:
+                    case MessagePackCode.UInt64:
+                    case MessagePackCode.Float64:
+                        if (!this.reader.TryAdvance(9))
+                        {
+                            return false;
+                        }
+
+                        break;
+                    case byte x when MessagePackCode.IsFixMap(x):
+                    case MessagePackCode.Map16:
+                    case MessagePackCode.Map32:
+                        if (!this.TryReadMapHeader(out int count))
+                        {
+                            return false;
+                        }
+
+                        remainingStructures = checked(remainingStructures + ((long)count * 2));
+                        break;
+                    case byte x when MessagePackCode.IsFixArray(x):
+                    case MessagePackCode.Array16:
+                    case MessagePackCode.Array32:
+                        if (!this.TryReadArrayHeader(out count))
+                        {
+                            return false;
+                        }
+
+                        remainingStructures = checked(remainingStructures + count);
+                        break;
+                    case byte x when MessagePackCode.IsFixStr(x):
+                    case MessagePackCode.Str8:
+                    case MessagePackCode.Str16:
+                    case MessagePackCode.Str32:
+                        if (!this.TryGetStringLengthInBytes(out uint length) || !this.reader.TryAdvance(length))
+                        {
+                            return false;
+                        }
+
+                        break;
+                    case MessagePackCode.Bin8:
+                    case MessagePackCode.Bin16:
+                    case MessagePackCode.Bin32:
+                        if (!this.TryGetBytesLength(out length) || !this.reader.TryAdvance(length))
+                        {
+                            return false;
+                        }
+
+                        break;
+                    case MessagePackCode.FixExt1:
+                    case MessagePackCode.FixExt2:
+                    case MessagePackCode.FixExt4:
+                    case MessagePackCode.FixExt8:
+                    case MessagePackCode.FixExt16:
+                    case MessagePackCode.Ext8:
+                    case MessagePackCode.Ext16:
+                    case MessagePackCode.Ext32:
+                        if (!this.TryReadExtensionFormatHeader(out ExtensionHeader header) || !this.reader.TryAdvance(header.Length))
+                        {
+                            return false;
+                        }
+
+                        break;
+                    default:
+                        // We don't actually expect to ever hit this point, since every code is supported.
+                        Debug.Fail("Missing handler for code: " + code);
+                        throw ThrowInvalidCode(code);
+                }
             }
 
-            byte code = this.NextCode;
-            switch (code)
-            {
-                case byte x when MessagePackCode.IsPositiveFixInt(x) || MessagePackCode.IsNegativeFixInt(x):
-                case MessagePackCode.Nil:
-                case MessagePackCode.True:
-                case MessagePackCode.False:
-                    return this.reader.TryAdvance(1);
-                case MessagePackCode.Int8:
-                case MessagePackCode.UInt8:
-                    return this.reader.TryAdvance(2);
-                case MessagePackCode.Int16:
-                case MessagePackCode.UInt16:
-                    return this.reader.TryAdvance(3);
-                case MessagePackCode.Int32:
-                case MessagePackCode.UInt32:
-                case MessagePackCode.Float32:
-                    return this.reader.TryAdvance(5);
-                case MessagePackCode.Int64:
-                case MessagePackCode.UInt64:
-                case MessagePackCode.Float64:
-                    return this.reader.TryAdvance(9);
-                case byte x when MessagePackCode.IsFixMap(x):
-                case MessagePackCode.Map16:
-                case MessagePackCode.Map32:
-                    return this.TrySkipNextMap();
-                case byte x when MessagePackCode.IsFixArray(x):
-                case MessagePackCode.Array16:
-                case MessagePackCode.Array32:
-                    return this.TrySkipNextArray();
-                case byte x when MessagePackCode.IsFixStr(x):
-                case MessagePackCode.Str8:
-                case MessagePackCode.Str16:
-                case MessagePackCode.Str32:
-                    return this.TryGetStringLengthInBytes(out uint length) && this.reader.TryAdvance(length);
-                case MessagePackCode.Bin8:
-                case MessagePackCode.Bin16:
-                case MessagePackCode.Bin32:
-                    return this.TryGetBytesLength(out length) && this.reader.TryAdvance(length);
-                case MessagePackCode.FixExt1:
-                case MessagePackCode.FixExt2:
-                case MessagePackCode.FixExt4:
-                case MessagePackCode.FixExt8:
-                case MessagePackCode.FixExt16:
-                case MessagePackCode.Ext8:
-                case MessagePackCode.Ext16:
-                case MessagePackCode.Ext32:
-                    return this.TryReadExtensionFormatHeader(out ExtensionHeader header) && this.reader.TryAdvance(header.Length);
-                default:
-                    // We don't actually expect to ever hit this point, since every code is supported.
-                    Debug.Fail("Missing handler for code: " + code);
-                    throw ThrowInvalidCode(code);
-            }
+            return true;
         }
 
         /// <summary>
@@ -1099,21 +1158,5 @@ namespace MessagePack
             return value;
         }
 
-        private bool TrySkipNextArray() => this.TryReadArrayHeader(out int count) && this.TrySkip(count);
-
-        private bool TrySkipNextMap() => this.TryReadMapHeader(out int count) && this.TrySkip(count * 2);
-
-        private bool TrySkip(int count)
-        {
-            for (int i = 0; i < count; i++)
-            {
-                if (!this.TrySkip())
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
     }
 }

--- a/src/MessagePack/MessagePackSecurity.cs
+++ b/src/MessagePack/MessagePackSecurity.cs
@@ -19,6 +19,8 @@ namespace MessagePack
     /// </summary>
     public class MessagePackSecurity
     {
+        private const int DefaultUntrustedDataMaximumDecompressedSize = 64 * 1024 * 1024;
+
         /// <summary>
         /// Gets an instance preconfigured with settings that omit hash collision resistance protections.
         /// Useful for deserializing fully-trusted and valid msgpack sequences.
@@ -27,6 +29,7 @@ namespace MessagePack
         {
             HashCollisionResistant = false,
             MaximumObjectGraphDepth = 500,
+            MaximumDecompressedSize = int.MaxValue,
         };
 
         /// <summary>
@@ -36,6 +39,7 @@ namespace MessagePack
         {
             HashCollisionResistant = true,
             MaximumObjectGraphDepth = 500,
+            MaximumDecompressedSize = DefaultUntrustedDataMaximumDecompressedSize,
         };
 
         private static readonly SipHash Hash = new();
@@ -62,6 +66,7 @@ namespace MessagePack
 
             this.HashCollisionResistant = copyFrom.HashCollisionResistant;
             this.MaximumObjectGraphDepth = copyFrom.MaximumObjectGraphDepth;
+            this.MaximumDecompressedSize = copyFrom.MaximumDecompressedSize;
         }
 
         /// <summary>
@@ -87,6 +92,12 @@ namespace MessagePack
         public int MaximumObjectGraphDepth { get; private set; } = 500;
 
         /// <summary>
+        /// Gets the maximum decompressed size in bytes allowed when deserializing compressed payloads.
+        /// </summary>
+        /// <value>The default value is <see cref="int.MaxValue"/> for <see cref="TrustedData"/> and 64MB for <see cref="UntrustedData"/>.</value>
+        public int MaximumDecompressedSize { get; private set; } = int.MaxValue;
+
+        /// <summary>
         /// Gets a copy of these options with the <see cref="MaximumObjectGraphDepth"/> property set to a new value.
         /// </summary>
         /// <param name="maximumObjectGraphDepth">The new value for the <see cref="MaximumObjectGraphDepth"/> property.</param>
@@ -100,6 +111,28 @@ namespace MessagePack
 
             var clone = this.Clone();
             clone.MaximumObjectGraphDepth = maximumObjectGraphDepth;
+            return clone;
+        }
+
+        /// <summary>
+        /// Gets a copy of these options with the <see cref="MaximumDecompressedSize"/> property set to a new value.
+        /// </summary>
+        /// <param name="maximumDecompressedSize">The new value for the <see cref="MaximumDecompressedSize"/> property. Must not be negative.</param>
+        /// <returns>The new instance; or the original if the value is unchanged.</returns>
+        public MessagePackSecurity WithMaximumDecompressedSize(int maximumDecompressedSize)
+        {
+            if (this.MaximumDecompressedSize == maximumDecompressedSize)
+            {
+                return this;
+            }
+
+            if (maximumDecompressedSize < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maximumDecompressedSize));
+            }
+
+            var clone = this.Clone();
+            clone.MaximumDecompressedSize = maximumDecompressedSize;
             return clone;
         }
 

--- a/src/MessagePack/MessagePackSerializer.Json.cs
+++ b/src/MessagePack/MessagePackSerializer.Json.cs
@@ -395,46 +395,54 @@ namespace MessagePack
                     }
                     else if (extHeader.TypeCode == ReservedExtensionTypeCodes.TypelessFormatter)
                     {
-                        // prepare type name token
-                        var privateBuilder = new StringBuilder();
-                        var typeNameTokenBuilder = new StringBuilder();
-                        SequencePosition positionBeforeTypeNameRead = reader.Position;
-                        ToJsonCore(ref reader, new StringWriter(typeNameTokenBuilder), options);
-                        int typeNameReadSize = (int)reader.Sequence.Slice(positionBeforeTypeNameRead, reader.Position).Length;
-                        if (extHeader.Length > typeNameReadSize)
+                        options.Security.DepthStep(ref reader);
+                        try
                         {
-                            // object map or array
-                            MessagePackType typeInside = reader.NextMessagePackType;
-                            if (typeInside != MessagePackType.Array && typeInside != MessagePackType.Map)
+                            // prepare type name token
+                            var privateBuilder = new StringBuilder();
+                            var typeNameTokenBuilder = new StringBuilder();
+                            SequencePosition positionBeforeTypeNameRead = reader.Position;
+                            ToJsonCore(ref reader, new StringWriter(typeNameTokenBuilder), options);
+                            int typeNameReadSize = (int)reader.Sequence.Slice(positionBeforeTypeNameRead, reader.Position).Length;
+                            if (extHeader.Length > typeNameReadSize)
                             {
-                                privateBuilder.Append("{");
+                                // object map or array
+                                MessagePackType typeInside = reader.NextMessagePackType;
+                                if (typeInside != MessagePackType.Array && typeInside != MessagePackType.Map)
+                                {
+                                    privateBuilder.Append("{");
+                                }
+
+                                ToJsonCore(ref reader, new StringWriter(privateBuilder), options);
+
+                                // insert type name token to start of object map or array
+                                if (typeInside != MessagePackType.Array)
+                                {
+                                    typeNameTokenBuilder.Insert(0, "\"$type\":");
+                                }
+
+                                if (typeInside != MessagePackType.Array && typeInside != MessagePackType.Map)
+                                {
+                                    privateBuilder.Append("}");
+                                }
+
+                                if (privateBuilder.Length > 2)
+                                {
+                                    typeNameTokenBuilder.Append(",");
+                                }
+
+                                privateBuilder.Insert(1, typeNameTokenBuilder.ToString());
+
+                                writer.Write(privateBuilder.ToString());
                             }
-
-                            ToJsonCore(ref reader, new StringWriter(privateBuilder), options);
-
-                            // insert type name token to start of object map or array
-                            if (typeInside != MessagePackType.Array)
+                            else
                             {
-                                typeNameTokenBuilder.Insert(0, "\"$type\":");
+                                writer.Write("{\"$type\":" + typeNameTokenBuilder.ToString() + "}");
                             }
-
-                            if (typeInside != MessagePackType.Array && typeInside != MessagePackType.Map)
-                            {
-                                privateBuilder.Append("}");
-                            }
-
-                            if (privateBuilder.Length > 2)
-                            {
-                                typeNameTokenBuilder.Append(",");
-                            }
-
-                            privateBuilder.Insert(1, typeNameTokenBuilder.ToString());
-
-                            writer.Write(privateBuilder.ToString());
                         }
-                        else
+                        finally
                         {
-                            writer.Write("{\"$type\":" + typeNameTokenBuilder.ToString() + "}");
+                            reader.Depth--;
                         }
                     }
                     else

--- a/src/MessagePack/MessagePackSerializer.Json.cs
+++ b/src/MessagePack/MessagePackSerializer.Json.cs
@@ -92,7 +92,7 @@ namespace MessagePack
                 {
                     using (var scratchRental = options.SequencePool.Rent())
                     {
-                        if (TryDecompress(ref reader, scratchRental.Value))
+                        if (TryDecompress(ref reader, scratchRental.Value, options))
                         {
                             var scratchReader = new MessagePackReader(scratchRental.Value)
                             {

--- a/src/MessagePack/MessagePackSerializer.Json.cs
+++ b/src/MessagePack/MessagePackSerializer.Json.cs
@@ -188,6 +188,11 @@ namespace MessagePack
 
         private static uint FromJsonCore(TinyJsonReader jr, ref MessagePackWriter writer, MessagePackSerializerOptions options)
         {
+            return FromJsonCore(jr, ref writer, options, 0);
+        }
+
+        private static uint FromJsonCore(TinyJsonReader jr, ref MessagePackWriter writer, MessagePackSerializerOptions options, int depth)
+        {
             uint count = 0;
             while (jr.Read())
             {
@@ -196,11 +201,13 @@ namespace MessagePack
                     case TinyJsonToken.None:
                         break;
                     case TinyJsonToken.StartObject:
+                        VerifyJsonObjectGraphDepth(options, depth);
+
                         // Set up a scratch area to serialize the collection since we don't know its length yet, which must be written first.
                         using (var scratchRental = options.SequencePool.Rent())
                         {
                             MessagePackWriter scratchWriter = writer.Clone(scratchRental.Value);
-                            var mapCount = FromJsonCore(jr, ref scratchWriter, options);
+                            var mapCount = FromJsonCore(jr, ref scratchWriter, options, depth + 1);
                             scratchWriter.Flush();
 
                             mapCount = mapCount / 2; // remove propertyname string count.
@@ -213,11 +220,13 @@ namespace MessagePack
                     case TinyJsonToken.EndObject:
                         return count; // break
                     case TinyJsonToken.StartArray:
+                        VerifyJsonObjectGraphDepth(options, depth);
+
                         // Set up a scratch area to serialize the collection since we don't know its length yet, which must be written first.
                         using (var scratchRental = options.SequencePool.Rent())
                         {
                             MessagePackWriter scratchWriter = writer.Clone(scratchRental.Value);
-                            var arrayCount = FromJsonCore(jr, ref scratchWriter, options);
+                            var arrayCount = FromJsonCore(jr, ref scratchWriter, options, depth + 1);
                             scratchWriter.Flush();
 
                             writer.WriteArrayHeader(arrayCount);
@@ -271,6 +280,14 @@ namespace MessagePack
             }
 
             return count;
+        }
+
+        private static void VerifyJsonObjectGraphDepth(MessagePackSerializerOptions options, int depth)
+        {
+            if (depth >= options.Security.MaximumObjectGraphDepth)
+            {
+                throw new InsufficientExecutionStackException($"This JSON sequence has an object graph that exceeds the maximum depth allowed of {options.Security.MaximumObjectGraphDepth}.");
+            }
         }
 
         private static void ToJsonCore(ref MessagePackReader reader, TextWriter writer, MessagePackSerializerOptions options)

--- a/src/MessagePack/MessagePackSerializer.cs
+++ b/src/MessagePack/MessagePackSerializer.cs
@@ -233,7 +233,7 @@ namespace MessagePack
                     using (var msgPackUncompressedRental = options.SequencePool.Rent())
                     {
                         var msgPackUncompressed = msgPackUncompressedRental.Value;
-                        if (TryDecompress(ref reader, msgPackUncompressed))
+                        if (TryDecompress(ref reader, msgPackUncompressed, options))
                         {
                             MessagePackReader uncompressedReader = reader.Clone(msgPackUncompressed.AsReadOnlySequence);
                             return options.Resolver.GetFormatterWithVerify<T>().Deserialize(ref uncompressedReader, options);
@@ -481,7 +481,7 @@ namespace MessagePack
             }
         }
 
-        private static bool TryDecompress(ref MessagePackReader reader, IBufferWriter<byte> writer)
+        private static bool TryDecompress(ref MessagePackReader reader, IBufferWriter<byte> writer, MessagePackSerializerOptions options)
         {
             if (!reader.End)
             {
@@ -503,6 +503,7 @@ namespace MessagePack
                         // The rest of the payload is the compressed data itself.
                         ReadOnlySequence<byte> compressedData = extReader.Sequence.Slice(extReader.Position);
 
+                        ThrowIfInvalidLz4BlockLength(uncompressedLength, options.Security.MaximumDecompressedSize);
                         Span<byte> uncompressedSpan = writer.GetSpan(uncompressedLength).Slice(0, uncompressedLength);
                         int actualUncompressedLength = LZ4Operation(compressedData, uncompressedSpan, LZ4CodecDecode);
                         Debug.Assert(actualUncompressedLength == uncompressedLength, "Unexpected length of uncompressed data.");
@@ -529,6 +530,7 @@ namespace MessagePack
                             var uncompressedLengths = ArrayPool<int>.Shared.Rent(sequenceCount);
                             try
                             {
+                                long remainingMaxDecompressedSize = options.Security.MaximumDecompressedSize;
                                 for (int i = 0; i < sequenceCount; i++)
                                 {
                                     uncompressedLengths[i] = reader.ReadInt32();
@@ -538,6 +540,8 @@ namespace MessagePack
                                 {
                                     var uncompressedLength = uncompressedLengths[i];
                                     ReadOnlySequence<byte> lz4Block = reader.ReadBytes() ?? throw MessagePackSerializationException.ThrowUnexpectedNilWhileDeserializing<ReadOnlySequence<byte>>();
+                                    ThrowIfInvalidLz4BlockLength(uncompressedLength, remainingMaxDecompressedSize);
+                                    remainingMaxDecompressedSize -= uncompressedLength;
                                     Span<byte> uncompressedSpan = writer.GetSpan(uncompressedLength).Slice(0, uncompressedLength);
                                     var actualUncompressedLength = LZ4Operation(lz4Block, uncompressedSpan, LZ4CodecDecode);
                                     Debug.Assert(actualUncompressedLength == uncompressedLength, "Unexpected length of uncompressed data.");
@@ -556,6 +560,14 @@ namespace MessagePack
             }
 
             return false;
+        }
+
+        private static void ThrowIfInvalidLz4BlockLength(int uncompressedLength, long remainingMaxDecompressedSize)
+        {
+            if (uncompressedLength < 0 || uncompressedLength > remainingMaxDecompressedSize)
+            {
+                throw new MessagePackSerializationException("LZ4 block declares a decompressed length that exceeds the configured maximum.");
+            }
         }
 
         private static void ToLZ4BinaryCore(in ReadOnlySequence<byte> msgpackUncompressedData, ref MessagePackWriter writer, MessagePackCompression compression, int minCompressionSize)

--- a/src/MessagePack/MessagePackSerializerOptions.cs
+++ b/src/MessagePack/MessagePackSerializerOptions.cs
@@ -175,16 +175,32 @@ namespace MessagePack
         /// <param name="type">The type to be instantiated.</param>
         /// <exception cref="TypeAccessException">Thrown if the <paramref name="type"/> is not allowed to be deserialized.</exception>
         /// <remarks>
+        /// <para>
         /// This method provides a means for an important security mitigation when using the Typeless formatter to prevent untrusted messagepack from
         /// deserializing objects that may be harmful if instantiated, disposed or finalized.
-        /// The default implementation throws for only a few known dangerous types.
+        /// The default implementation throws for only a few known dangerous types, or types that nest those dangerous types as generic type arguments or array element types.
         /// Applications that deserialize from untrusted sources should override this method and throw if the type is not among the expected set.
+        /// </para>
+        /// <para>
+        /// This method is <see langword="virtual" /> for backward compatibility reasons.
+        /// For better security, the preferred method to override is <see cref="ThrowIfDeserializingTypeIsDisallowedCore(Type)"/>.
+        /// </para>
         /// </remarks>
         public virtual void ThrowIfDeserializingTypeIsDisallowed(Type type)
         {
-            if (type.FullName is string fullName && DisallowedTypes.Contains(fullName))
+            this.ThrowIfDeserializingTypeIsDisallowedCore(type);
+
+            if (type.HasElementType && type.GetElementType() is Type elementType)
             {
-                throw new MessagePackSerializationException($"Deserialization attempted to create the type {fullName} which is not allowed.");
+                this.ThrowIfDeserializingTypeIsDisallowed(elementType);
+            }
+
+            if (type.IsConstructedGenericType)
+            {
+                foreach (Type genericTypeArgument in type.GenericTypeArguments)
+                {
+                    this.ThrowIfDeserializingTypeIsDisallowed(genericTypeArgument);
+                }
             }
         }
 
@@ -359,6 +375,31 @@ namespace MessagePack
             var result = this.Clone();
             result.SequencePool = pool;
             return result;
+        }
+
+        /// <summary>
+        /// Checks whether a specific given type may be deserialized, disregarding generic type arguments or array element types.
+        /// </summary>
+        /// <param name="type">The type to be instantiated.</param>
+        /// <exception cref="TypeAccessException">Thrown if the <paramref name="type"/> is not allowed to be deserialized.</exception>
+        /// <remarks>
+        /// <para>
+        /// This method provides a means for an important security mitigation when using the Typeless formatter to prevent untrusted messagepack from
+        /// deserializing objects that may be harmful if instantiated, disposed or finalized.
+        /// The default implementation throws for only a few known dangerous types.
+        /// Applications that deserialize from untrusted sources should override this method and throw if the type is not among the expected set.
+        /// </para>
+        /// <para>
+        /// This method is called from the default implementation of <see cref="ThrowIfDeserializingTypeIsDisallowed(Type)"/>
+        /// for the top-level type and again for each generic type argument or array element type.
+        /// </para>
+        /// </remarks>
+        protected virtual void ThrowIfDeserializingTypeIsDisallowedCore(Type type)
+        {
+            if (type.FullName is string fullName && DisallowedTypes.Contains(fullName))
+            {
+                throw new MessagePackSerializationException($"Deserialization attempted to create the type {fullName} which is not allowed.");
+            }
         }
 
         /// <summary>

--- a/src/MessagePack/Resolvers/DynamicUnionResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicUnionResolver.cs
@@ -321,6 +321,14 @@ namespace MessagePack.Resolvers
 
             il.MarkLabel(falseLabel);
 
+            var reader = new ArgumentField(il, 1);
+
+            // options.Security.DepthStep(ref reader);
+            il.EmitLdarg(2);
+            il.EmitCall(getSecurityFromOptions);
+            reader.EmitLdarg();
+            il.EmitCall(securityDepthStep);
+
             // IFormatterResolver resolver = options.Resolver;
             LocalBuilder localResolver = il.DeclareLocal(typeof(IFormatterResolver));
             il.EmitLdarg(2);
@@ -329,7 +337,6 @@ namespace MessagePack.Resolvers
 
             // read-array header and validate, reader.ReadArrayHeader() != 2) throw;
             Label rightLabel = il.DefineLabel();
-            var reader = new ArgumentField(il, 1);
             reader.EmitLdarg();
             il.EmitCall(MessagePackReaderTypeInfo.ReadArrayHeader);
             il.EmitLdc_I4(2);
@@ -396,6 +403,14 @@ namespace MessagePack.Resolvers
 
             il.MarkLabel(loopEnd);
 
+            // reader.Depth--;
+            reader.EmitLdarg();
+            il.Emit(OpCodes.Dup);
+            il.EmitCall(readerDepthGet);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Sub_Ovf);
+            il.EmitCall(readerDepthSet);
+
             il.Emit(OpCodes.Ldloc, result);
             il.Emit(OpCodes.Ret);
         }
@@ -420,6 +435,10 @@ namespace MessagePack.Resolvers
         private static readonly Type refKvp = typeof(KeyValuePair<int, int>).MakeByRefType();
         private static readonly MethodInfo getFormatterWithVerify = typeof(FormatterResolverExtensions).GetRuntimeMethods().First(x => x.Name == "GetFormatterWithVerify");
         private static readonly MethodInfo getResolverFromOptions = typeof(MessagePackSerializerOptions).GetRuntimeProperty(nameof(MessagePackSerializerOptions.Resolver))!.GetMethod!;
+        private static readonly MethodInfo getSecurityFromOptions = typeof(MessagePackSerializerOptions).GetRuntimeProperty(nameof(MessagePackSerializerOptions.Security))!.GetMethod!;
+        private static readonly MethodInfo securityDepthStep = typeof(MessagePackSecurity).GetRuntimeMethod(nameof(MessagePackSecurity.DepthStep), new[] { typeof(MessagePackReader).MakeByRefType() })!;
+        private static readonly MethodInfo readerDepthGet = typeof(MessagePackReader).GetRuntimeProperty(nameof(MessagePackReader.Depth))!.GetMethod!;
+        private static readonly MethodInfo readerDepthSet = typeof(MessagePackReader).GetRuntimeProperty(nameof(MessagePackReader.Depth))!.SetMethod!;
 
         private static readonly Func<Type, MethodInfo> getSerialize = t => typeof(IMessagePackFormatter<>).MakeGenericType(t).GetRuntimeMethod("Serialize", new[] { typeof(MessagePackWriter).MakeByRefType(), t, typeof(MessagePackSerializerOptions) })!;
         private static readonly Func<Type, MethodInfo> getDeserialize = t => typeof(IMessagePackFormatter<>).MakeGenericType(t).GetRuntimeMethod("Deserialize", new[] { typeof(MessagePackReader).MakeByRefType(), typeof(MessagePackSerializerOptions) })!;

--- a/src/MessagePack/Resolvers/ExpandoObjectResolver.cs
+++ b/src/MessagePack/Resolvers/ExpandoObjectResolver.cs
@@ -40,6 +40,7 @@ namespace MessagePack.Resolvers
         {
             protected override object DeserializeMap(ref MessagePackReader reader, int length, MessagePackSerializerOptions options)
             {
+                ExpandoObjectFormatter.ThrowIfMapTooLargeForUntrustedData(length, options);
                 IMessagePackFormatter<string> keyFormatter = options.Resolver.GetFormatterWithVerify<string>();
                 IMessagePackFormatter<object>? objectFormatter = options.Resolver.GetFormatterWithVerify<object>();
                 IDictionary<string, object?> dictionary = new ExpandoObject();

--- a/tests/MessagePack.AspNetCoreMvcFormatter.Tests/AspNetCoreMvcFormatterTest.cs
+++ b/tests/MessagePack.AspNetCoreMvcFormatter.Tests/AspNetCoreMvcFormatterTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -193,6 +194,34 @@ namespace MessagePack.Tests.ExtensionTests
         {
             var inputFormatter = new MessagePackInputFormatter();
             inputFormatter.SupportedMediaTypes.Is(MsgPackContentType);
+        }
+
+        [Fact]
+        public async Task MessagePackInputFormatterDefaultsToUntrustedData()
+        {
+            const long value1 = 0x100000001;
+            const long value2 = 0x200000002;
+
+            var messagePackBinary = MessagePackSerializer.Serialize(new Dictionary<long, int>
+            {
+                [value1] = 1,
+                [value2] = 2,
+            });
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Features.Set<IHttpResponseFeature>(new TestResponseFeature());
+            httpContext.Request.Body = new NonSeekableReadStream(messagePackBinary);
+            httpContext.Request.ContentType = MsgPackContentType;
+
+            InputFormatterContext inputFormatterContext = this.CreateInputFormatterContext(typeof(Dictionary<long, int>), httpContext);
+            var inputFormatter = new MessagePackInputFormatter();
+
+            InputFormatterResult result = await inputFormatter.ReadAsync(inputFormatterContext);
+
+            Assert.False(result.HasError);
+            var dictionary = Assert.IsType<Dictionary<long, int>>(result.Model);
+            Assert.Equal(EqualityComparer<long>.Default.GetHashCode(value1), EqualityComparer<long>.Default.GetHashCode(value2));
+            Assert.NotEqual(dictionary.Comparer.GetHashCode(value1), dictionary.Comparer.GetHashCode(value2));
         }
 
         /// <summary>

--- a/tests/MessagePack.Tests/ExpandoObjectTests.cs
+++ b/tests/MessagePack.Tests/ExpandoObjectTests.cs
@@ -3,6 +3,7 @@
 
 #if !UNITY_2018_3_OR_NEWER
 
+using System.Collections.Generic;
 using System.Dynamic;
 using System.Runtime.Serialization;
 using MessagePack.Resolvers;
@@ -76,6 +77,24 @@ namespace MessagePack.Tests
             Assert.Equal(expando.Other.OtherProperty, expando2.Other.OtherProperty);
         }
 
+        [Fact]
+        [Trait("CWE", "407")]
+        public void ExpandoObject_UntrustedDataRejectsLargeMaps()
+        {
+            byte[] msgpack = CreateMapWithNilValues(1025);
+
+            Assert.Throws<MessagePackSerializationException>(() => MessagePackSerializer.Deserialize<ExpandoObject>(msgpack, ExpandoObjectResolver.Options));
+        }
+
+        [Fact]
+        [Trait("CWE", "407")]
+        public void ExpandoObjectNestedMap_UntrustedDataRejectsLargeMaps()
+        {
+            byte[] msgpack = CreateMapWithNilValues(1025);
+
+            Assert.Throws<MessagePackSerializationException>(() => MessagePackSerializer.Deserialize<object>(msgpack, ExpandoObjectResolver.Options));
+        }
+
 #if !UNITY_2018_3_OR_NEWER
 
         [Fact]
@@ -105,6 +124,17 @@ namespace MessagePack.Tests
         {
             [DataMember]
             public string OtherProperty { get; set; }
+        }
+
+        private static byte[] CreateMapWithNilValues(int count)
+        {
+            var dictionary = new Dictionary<string, object>();
+            for (int index = 0; index < count; index++)
+            {
+                dictionary.Add("k" + index.ToString(System.Globalization.CultureInfo.InvariantCulture), null);
+            }
+
+            return MessagePackSerializer.Serialize(dictionary, MessagePackSerializerOptions.Standard);
         }
     }
 }

--- a/tests/MessagePack.Tests/ExtensionTests/UnityShimTest.cs
+++ b/tests/MessagePack.Tests/ExtensionTests/UnityShimTest.cs
@@ -94,6 +94,18 @@ namespace MessagePack.Tests.ExtensionTests
             EnsureSpecCompatibility(data.Array);
         }
 
+        [Fact]
+        [Trait("CWE", "789")]
+        public void BlitRejectsByteLengthThatExceedsExtensionBody()
+        {
+            MessagePackSerializerOptions options = MessagePackSerializerOptions.Standard.WithResolver(new WithUnityBlitResolver());
+            byte[] payload = { 0xC7, 0x06, unchecked((byte)ReservedExtensionTypeCodes.UnityInt), 0xCE, 0x00, 0x00, 0x00, 0x08, 0xC3 };
+
+            var ex = Assert.Throws<MessagePackSerializationException>(() => MessagePackSerializer.Deserialize<int[]>(payload, options));
+            var inner = Assert.IsType<MessagePackSerializationException>(ex.InnerException);
+            Assert.Contains("Invalid Unity blit extension length", inner.Message);
+        }
+
         public class WithUnityBlitResolver : IFormatterResolver
         {
             public IMessagePackFormatter<T> GetFormatter<T>()

--- a/tests/MessagePack.Tests/LZ4Test.cs
+++ b/tests/MessagePack.Tests/LZ4Test.cs
@@ -32,6 +32,47 @@ namespace MessagePack.Tests
             Execute(10000);
         }
 
+        [Fact]
+        [Trait("CWE", "125")]
+        public void Lz4BlockRejectsTruncatedLiteralRun()
+        {
+            const int extensionByteCount = 1024;
+            int uncompressedLength = 15 + (255 * extensionByteCount) + 16;
+
+            byte[] sizeHeader =
+            {
+                0xCE,
+                (byte)(uncompressedLength >> 24),
+                (byte)(uncompressedLength >> 16),
+                (byte)(uncompressedLength >> 8),
+                (byte)uncompressedLength,
+            };
+
+            byte[] lz4 = new byte[1 + extensionByteCount];
+            lz4[0] = 0xF0;
+            for (int i = 1; i < lz4.Length; i++)
+            {
+                lz4[i] = 0xFF;
+            }
+
+            int bodyLength = sizeHeader.Length + lz4.Length;
+            byte[] payload = new byte[6 + bodyLength];
+            int offset = 0;
+            payload[offset++] = 0xC9;
+            payload[offset++] = (byte)(bodyLength >> 24);
+            payload[offset++] = (byte)(bodyLength >> 16);
+            payload[offset++] = (byte)(bodyLength >> 8);
+            payload[offset++] = (byte)bodyLength;
+            payload[offset++] = 99;
+            System.Array.Copy(sizeHeader, 0, payload, offset, sizeHeader.Length);
+            offset += sizeHeader.Length;
+            System.Array.Copy(lz4, 0, payload, offset, lz4.Length);
+
+            var options = MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4Block);
+
+            Assert.Throws<MessagePackSerializationException>(() => MessagePackSerializer.Deserialize<object>(payload, options));
+        }
+
         private void Execute(int count)
         {
             // Large

--- a/tests/MessagePack.Tests/LZ4Test.cs
+++ b/tests/MessagePack.Tests/LZ4Test.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -21,6 +22,64 @@ namespace MessagePack.Tests
         }
 
 #endif
+
+        [Theory]
+        [InlineData(MessagePackCompression.Lz4Block)]
+        [InlineData(MessagePackCompression.Lz4BlockArray)]
+        [Trait("CWE", "409")]
+        public void Lz4RejectsDeclaredOutputOverMaximumBeforeAllocating(MessagePackCompression compression)
+        {
+            byte[] payload = compression == MessagePackCompression.Lz4Block
+                ? [0xC7, 0x06, 0x63, 0xD2, 0x7F, 0xFF, 0xFF, 0xFF, 0x00]
+                : [0x92, 0xC7, 0x05, 0x62, 0xD2, 0x7F, 0xFF, 0xFF, 0xFF, 0xC4, 0x01, 0x00];
+            var arrayPool = new ThrowingArrayPool(1024);
+            var options = MessagePackSerializerOptions.Standard
+                .WithCompression(compression)
+                .WithSecurity(MessagePackSecurity.UntrustedData)
+                .WithPool(new SequencePool(1, arrayPool));
+
+            MessagePackSerializationException ex = Assert.Throws<MessagePackSerializationException>(() => MessagePackSerializer.Deserialize<object>(payload, options));
+
+            Assert.Contains("exceeds the configured maximum", FlattenMessages(ex));
+            Assert.Null(arrayPool.LargestRequestedLength);
+        }
+
+        [Fact]
+        [Trait("CWE", "409")]
+        public void Lz4BlockArrayRejectsTotalDeclaredOutputOverMaximum()
+        {
+            byte[] payload =
+            [
+                0x93,
+                0xC7, 0x02, 0x62, 0x04, 0x04,
+                0xC4, 0x05, 0x40, 0x20, 0x20, 0x20, 0x20,
+                0xC4, 0x05, 0x40, 0x20, 0x20, 0x20, 0x20,
+            ];
+            var options = MessagePackSerializerOptions.Standard
+                .WithCompression(MessagePackCompression.Lz4BlockArray)
+                .WithSecurity(MessagePackSecurity.UntrustedData.WithMaximumDecompressedSize(7));
+
+            MessagePackSerializationException ex = Assert.Throws<MessagePackSerializationException>(() => MessagePackSerializer.Deserialize<object>(payload, options));
+
+            Assert.Contains("exceeds the configured maximum", FlattenMessages(ex));
+        }
+
+        [Theory]
+        [InlineData(MessagePackCompression.Lz4Block)]
+        [InlineData(MessagePackCompression.Lz4BlockArray)]
+        [Trait("CWE", "409")]
+        public void Lz4AllowsHighlyCompressiblePayloadWithinMaximum(MessagePackCompression compression)
+        {
+            string data = new string(' ', 100_000);
+            var options = MessagePackSerializerOptions.Standard
+                .WithCompression(compression)
+                .WithSecurity(MessagePackSecurity.UntrustedData.WithMaximumDecompressedSize(200_000));
+
+            byte[] payload = MessagePackSerializer.Serialize(data, options);
+            string actual = MessagePackSerializer.Deserialize<string>(payload, options);
+
+            Assert.Equal(data, actual);
+        }
 
         [Fact]
         public void Lz4Compress()
@@ -80,6 +139,38 @@ namespace MessagePack.Tests
                 actual[i].Prop1.Is(expected[i].Prop1);
                 actual[i].Prop2.Is(expected[i].Prop2);
                 actual[i].Prop3.Is(expected[i].Prop3);
+            }
+        }
+
+        private static string FlattenMessages(System.Exception ex)
+        {
+            return ex.InnerException is null ? ex.Message : ex.Message + " " + FlattenMessages(ex.InnerException);
+        }
+
+        private class ThrowingArrayPool : ArrayPool<byte>
+        {
+            private readonly int maximumLength;
+
+            internal ThrowingArrayPool(int maximumLength)
+            {
+                this.maximumLength = maximumLength;
+            }
+
+            internal int? LargestRequestedLength { get; private set; }
+
+            public override byte[] Rent(int minimumLength)
+            {
+                this.LargestRequestedLength = this.LargestRequestedLength.HasValue ? System.Math.Max(this.LargestRequestedLength.Value, minimumLength) : minimumLength;
+                if (minimumLength > this.maximumLength)
+                {
+                    throw new System.InvalidOperationException("Unexpected decompression allocation request: " + minimumLength);
+                }
+
+                return new byte[minimumLength];
+            }
+
+            public override void Return(byte[] array, bool clearArray = false)
+            {
             }
         }
     }

--- a/tests/MessagePack.Tests/MessagePackReaderTests.cs
+++ b/tests/MessagePack.Tests/MessagePackReaderTests.cs
@@ -401,6 +401,15 @@ namespace MessagePack.Tests
         }
 
         [Fact]
+        [Trait("CWE", "789")]
+        public void ReadDateTime_RejectsInvalidExtensionLengthBeforeBuffering()
+        {
+            byte[] payload = [MessagePackCode.Ext32, 0x00, 0x10, 0x00, 0x00, 0xff];
+
+            Assert.Throws<MessagePackSerializationException>(() => new MessagePackReader(new ReadOnlySequence<byte>(payload)).ReadDateTime());
+        }
+
+        [Fact]
         public void CreatePeekReader()
         {
             var cts = new CancellationTokenSource();

--- a/tests/MessagePack.Tests/MessagePackReaderTests.cs
+++ b/tests/MessagePack.Tests/MessagePackReaderTests.cs
@@ -102,6 +102,32 @@ namespace MessagePack.Tests
         }
 
         [Fact]
+        [Trait("CWE", "190")]
+        public void ReadMapHeader_MitigatesLargeAllocations_WhenMinimumPayloadLengthOverflowsInt32()
+        {
+            byte[] msgpack = { MessagePackCode.Map32, 0x40, 0, 0, 0 };
+
+            Assert.Throws<EndOfStreamException>(() =>
+            {
+                var reader = new MessagePackReader(msgpack);
+                reader.ReadMapHeader();
+            });
+        }
+
+        [Fact]
+        [Trait("CWE", "190")]
+        public void SkipMap_MitigatesLargeAllocations_WhenMinimumPayloadLengthOverflowsInt32()
+        {
+            byte[] msgpack = { MessagePackCode.Map32, 0x40, 0, 0, 0 };
+
+            Assert.Throws<EndOfStreamException>(() =>
+            {
+                var reader = new MessagePackReader(msgpack);
+                reader.Skip();
+            });
+        }
+
+        [Fact]
         public void TryReadMapHeader()
         {
             var sequence = new Sequence<byte>();

--- a/tests/MessagePack.Tests/MessagePackReaderTests.cs
+++ b/tests/MessagePack.Tests/MessagePackReaderTests.cs
@@ -331,6 +331,49 @@ namespace MessagePack.Tests
         }
 
         [Fact]
+        [Trait("CWE", "674")]
+        public void Skip_DeeplyNestedArrays_DoesNotOverflowStack()
+        {
+            const int depth = 100_000;
+            byte[] msgpack = new byte[depth + 1];
+
+            for (int i = 0; i < depth; i++)
+            {
+                msgpack[i] = MessagePackCode.MinFixArray + 1;
+            }
+
+            msgpack[^1] = MessagePackCode.Nil;
+
+            MessagePackReader reader = new(msgpack);
+
+            reader.Skip();
+
+            Assert.True(reader.End);
+        }
+
+        [Fact]
+        [Trait("CWE", "674")]
+        public void Skip_DeeplyNestedMaps_DoesNotOverflowStack()
+        {
+            const int depth = 100_000;
+            byte[] msgpack = new byte[(depth * 2) + 1];
+
+            for (int i = 0; i < depth; i++)
+            {
+                msgpack[i * 2] = MessagePackCode.MinFixMap + 1;
+                msgpack[(i * 2) + 1] = MessagePackCode.Nil;
+            }
+
+            msgpack[^1] = MessagePackCode.Nil;
+
+            MessagePackReader reader = new(msgpack);
+
+            reader.Skip();
+
+            Assert.True(reader.End);
+        }
+
+        [Fact]
         public void Depth()
         {
             var reader = new MessagePackReader(Encode((ref MessagePackWriter w) => w.Write(1.23)));

--- a/tests/MessagePack.Tests/MessagePackSecurityTests.cs
+++ b/tests/MessagePack.Tests/MessagePackSecurityTests.cs
@@ -22,12 +22,14 @@ public class MessagePackSecurityTests
     public void Untrusted()
     {
         Assert.True(MessagePackSecurity.UntrustedData.HashCollisionResistant);
+        Assert.Equal(64 * 1024 * 1024, MessagePackSecurity.UntrustedData.MaximumDecompressedSize);
     }
 
     [Fact]
     public void Trusted()
     {
         Assert.False(MessagePackSecurity.TrustedData.HashCollisionResistant);
+        Assert.Equal(int.MaxValue, MessagePackSecurity.TrustedData.MaximumDecompressedSize);
     }
 
     [Fact]
@@ -35,6 +37,15 @@ public class MessagePackSecurityTests
     {
         Assert.Same(MessagePackSecurity.TrustedData, MessagePackSecurity.TrustedData.WithHashCollisionResistant(false));
         Assert.True(MessagePackSecurity.TrustedData.WithHashCollisionResistant(true).HashCollisionResistant);
+    }
+
+    [Fact]
+    [Trait("CWE", "409")]
+    public void WithMaximumDecompressedSize()
+    {
+        Assert.Same(MessagePackSecurity.UntrustedData, MessagePackSecurity.UntrustedData.WithMaximumDecompressedSize(64 * 1024 * 1024));
+        Assert.Throws<ArgumentOutOfRangeException>(() => MessagePackSecurity.UntrustedData.WithMaximumDecompressedSize(-1));
+        Assert.Equal(1024, MessagePackSecurity.UntrustedData.WithMaximumDecompressedSize(1024).MaximumDecompressedSize);
     }
 
     [Fact]

--- a/tests/MessagePack.Tests/MessagePackSerializerTest.cs
+++ b/tests/MessagePack.Tests/MessagePackSerializerTest.cs
@@ -209,6 +209,18 @@ namespace MessagePack.Tests
             Assert.Equal(3, await MessagePackSerializer.DeserializeAsync<int>(stream));
         }
 
+        [Fact]
+        [Trait("CWE", "674")]
+        public void StackDepthCheck_ConvertToJsonTypelessExtension()
+        {
+            const int maxDepth = 3;
+            byte[] msgpack = BuildNestedTypelessExtension(maxDepth + 1);
+            var options = MessagePackSerializerOptions.Standard
+                .WithSecurity(MessagePackSecurity.UntrustedData.WithMaximumObjectGraphDepth(maxDepth));
+
+            AssertConvertToJsonRecursionCheckThrows(new ReadOnlySequence<byte>(msgpack), options);
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -316,6 +328,28 @@ namespace MessagePack.Tests
                 MessagePackSerializer.ConvertToJson(ref reader, new StringWriter(), options);
             });
             Assert.IsType<InsufficientExecutionStackException>(ex.InnerException);
+        }
+
+        private static byte[] BuildNestedTypelessExtension(int levels)
+        {
+            byte[] msgpack = new byte[(levels * 6) + 2];
+            int offset = msgpack.Length;
+            msgpack[--offset] = (byte)'x';
+            msgpack[--offset] = 0xa1;
+            int innerLength = 2;
+
+            for (int level = 0; level < levels; level++)
+            {
+                msgpack[--offset] = unchecked((byte)ReservedExtensionTypeCodes.TypelessFormatter);
+                msgpack[--offset] = (byte)innerLength;
+                msgpack[--offset] = (byte)(innerLength >> 8);
+                msgpack[--offset] = (byte)(innerLength >> 16);
+                msgpack[--offset] = (byte)(innerLength >> 24);
+                msgpack[--offset] = 0xc9;
+                innerLength += 6;
+            }
+
+            return msgpack;
         }
 
         [DataContract]

--- a/tests/MessagePack.Tests/MessagePackSerializerTest.cs
+++ b/tests/MessagePack.Tests/MessagePackSerializerTest.cs
@@ -275,6 +275,18 @@ namespace MessagePack.Tests
             Assert.IsType<InsufficientExecutionStackException>(ex.InnerException);
         }
 
+        [Fact]
+        [Trait("CWE", "674")]
+        public void StackDepthCheck_DynamicUnionResolver()
+        {
+            byte[] msgpack = MessagePackSerializer.Serialize<IDepthCheckedUnionNode>(new DepthCheckedUnionBranch());
+            var options = MessagePackSerializerOptions.Standard
+                .WithSecurity(MessagePackSecurity.UntrustedData.WithMaximumObjectGraphDepth(1));
+
+            var ex = Assert.Throws<MessagePackSerializationException>(() => MessagePackSerializer.Deserialize<IDepthCheckedUnionNode>(msgpack, options));
+            Assert.IsType<InsufficientExecutionStackException>(ex.InnerException);
+        }
+
 #endif
 
         private delegate void WriterHelper(ref MessagePackWriter writer);
@@ -413,5 +425,31 @@ namespace MessagePack.Tests
 
             base.Dispose(disposing);
         }
+    }
+
+    [MessagePackObject(keyAsPropertyName: true)]
+    public class SkipUnknownMemberTarget
+    {
+        public int Known { get; set; }
+    }
+
+    [Union(0, typeof(DepthCheckedUnionLeaf))]
+    [Union(999, typeof(DepthCheckedUnionBranch))]
+    public interface IDepthCheckedUnionNode
+    {
+    }
+
+    [MessagePackObject]
+    public class DepthCheckedUnionLeaf : IDepthCheckedUnionNode
+    {
+        [Key(0)]
+        public int Value { get; set; }
+    }
+
+    [MessagePackObject]
+    public class DepthCheckedUnionBranch : IDepthCheckedUnionNode
+    {
+        [Key(0)]
+        public IDepthCheckedUnionNode Child { get; set; }
     }
 }

--- a/tests/MessagePack.Tests/MessagePackSerializerTypelessTests.cs
+++ b/tests/MessagePack.Tests/MessagePackSerializerTypelessTests.cs
@@ -4,12 +4,10 @@
 #if !UNITY_2018_3_OR_NEWER
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
-using MessagePack;
 using MessagePack.Formatters;
 using MessagePack.Resolvers;
-using Xunit;
-using Xunit.Abstractions;
 
 public class MessagePackSerializerTypelessTests
 {
@@ -45,6 +43,24 @@ public class MessagePackSerializerTypelessTests
         this.logger.WriteLine(MessagePackSerializer.ConvertToJson(msgpack, myOptions));
         var ex = Assert.Throws<MessagePackSerializationException>(() => MessagePackSerializer.Typeless.Deserialize(msgpack, myOptions));
         Assert.IsType<TypeAccessException>(ex.InnerException);
+    }
+
+    [Theory]
+    [MemberData(nameof(DisallowedNestedTypeData))]
+    [Trait("CWE", "502")]
+    public void SerializationOfDisallowedNestedType(object value)
+    {
+        var myOptions = new MyTypelessOptions();
+        byte[] msgpack = MessagePackSerializer.Typeless.Serialize(value, myOptions);
+        this.logger.WriteLine(MessagePackSerializer.ConvertToJson(msgpack, myOptions));
+        var ex = Assert.Throws<MessagePackSerializationException>(() => MessagePackSerializer.Typeless.Deserialize(msgpack, myOptions));
+        Assert.IsType<TypeAccessException>(ex.InnerException);
+    }
+
+    public static IEnumerable<object[]> DisallowedNestedTypeData()
+    {
+        yield return new object[] { new MyObject[] { new() { SomeValue = 5 } } };
+        yield return new object[] { new List<MyObject> { new() { SomeValue = 5 } } };
     }
 
     [Fact(Skip = "Known bug https://github.com/neuecc/MessagePack-CSharp/issues/651")]
@@ -137,7 +153,7 @@ public class MessagePackSerializerTypelessTests
         {
         }
 
-        public override void ThrowIfDeserializingTypeIsDisallowed(Type type)
+        protected override void ThrowIfDeserializingTypeIsDisallowedCore(Type type)
         {
             if (type == typeof(MyObject))
             {

--- a/tests/MessagePack.Tests/MultiDimensionalArrayTest.cs
+++ b/tests/MessagePack.Tests/MultiDimensionalArrayTest.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace MessagePack.Tests
 {
-    public class MultiDimensionalArrayTest
+    public class MultiDimensionalArrayTest(ITestOutputHelper logger)
     {
         private T Convert<T>(T value)
         {
@@ -66,6 +66,62 @@ namespace MessagePack.Tests
                     }
                 }
             }
+        }
+
+        [Fact]
+        [Trait("CWE", "789")]
+        public void RejectsTwoDimensionalArrayWithMismatchedElementCount()
+        {
+            byte[] payload =
+            {
+                0x93,
+                0xCE, 0x00, 0x00, 0x07, 0xD0,
+                0xCE, 0x00, 0x00, 0x07, 0xD0,
+                0x90,
+            };
+
+            AssertRejects<byte[,]>(payload);
+        }
+
+        [Fact]
+        [Trait("CWE", "789")]
+        public void RejectsThreeDimensionalArrayWithMismatchedElementCount()
+        {
+            byte[] payload =
+            {
+                0x94,
+                0xCC, 0x80,
+                0xCC, 0x80,
+                0xCC, 0x80,
+                0x90,
+            };
+
+            AssertRejects<byte[,,]>(payload);
+        }
+
+        [Fact]
+        [Trait("CWE", "789")]
+        public void RejectsFourDimensionalArrayWithMismatchedElementCount()
+        {
+            byte[] payload =
+            {
+                0x95,
+                0x20,
+                0x20,
+                0x20,
+                0x20,
+                0x90,
+            };
+
+            AssertRejects<byte[,,,]>(payload);
+        }
+
+        private void AssertRejects<T>(byte[] payload)
+        {
+            var options = MessagePackSerializerOptions.Standard.WithSecurity(MessagePackSecurity.UntrustedData);
+
+            var ex = Assert.Throws<MessagePackSerializationException>(() => MessagePackSerializer.Deserialize<T>(payload, options));
+            logger.WriteLine(ex.ToString());
         }
     }
 }

--- a/tests/MessagePack.Tests/StandardClassLibraryFormatterTests.cs
+++ b/tests/MessagePack.Tests/StandardClassLibraryFormatterTests.cs
@@ -37,6 +37,27 @@ namespace MessagePack.Tests
         }
 
         [Fact]
+        public void SystemType_DeserializeUsesLoadType()
+        {
+            byte[] msgpack = MessagePackSerializer.Serialize(new TypeHolder { Type = typeof(Uri) }, MessagePackSerializerOptions.Standard);
+            var options = new RejectingTypeLoadOptions(typeof(Uri));
+
+            var ex = Assert.Throws<MessagePackSerializationException>(() => MessagePackSerializer.Deserialize<TypeHolder>(msgpack, options));
+            Assert.IsType<TypeLoadException>(ex.InnerException);
+            Assert.Equal(1, options.LoadTypeCalls);
+        }
+
+        [Fact]
+        public void SystemType_DeserializeRejectsDisallowedType()
+        {
+            byte[] msgpack = MessagePackSerializer.Serialize(new TypeHolder { Type = typeof(Uri) }, MessagePackSerializerOptions.Standard);
+            var options = new DisallowingTypeOptions(typeof(Uri));
+
+            var ex = Assert.Throws<MessagePackSerializationException>(() => MessagePackSerializer.Deserialize<TypeHolder>(msgpack, options));
+            Assert.IsType<TypeAccessException>(ex.InnerException);
+        }
+
+        [Fact]
         public void DeserializeByteArrayFromFixArray()
         {
             var input = new byte[] { 0x93, 0x01, 0x02, 0x03 };
@@ -144,6 +165,69 @@ namespace MessagePack.Tests
             {
                 return MessagePackSerializer.Deserialize<T>(msgpack, MessagePackSerializerOptions.Standard);
             }
+        }
+
+        [MessagePackObject]
+        public class TypeHolder
+        {
+            [Key(0)]
+            public Type Type { get; set; }
+        }
+
+        private class RejectingTypeLoadOptions : MessagePackSerializerOptions
+        {
+            private readonly Type rejectedType;
+
+            internal RejectingTypeLoadOptions(Type rejectedType)
+                : base(MessagePackSerializerOptions.Standard)
+            {
+                this.rejectedType = rejectedType;
+            }
+
+            private RejectingTypeLoadOptions(RejectingTypeLoadOptions copyFrom)
+                : base(copyFrom)
+            {
+                this.rejectedType = copyFrom.rejectedType;
+                this.LoadTypeCalls = copyFrom.LoadTypeCalls;
+            }
+
+            public int LoadTypeCalls { get; private set; }
+
+            public override Type LoadType(string typeName)
+            {
+                Type type = base.LoadType(typeName);
+                this.LoadTypeCalls++;
+                return type == this.rejectedType ? null : type;
+            }
+
+            protected override MessagePackSerializerOptions Clone() => new RejectingTypeLoadOptions(this);
+        }
+
+        private class DisallowingTypeOptions : MessagePackSerializerOptions
+        {
+            private readonly Type rejectedType;
+
+            internal DisallowingTypeOptions(Type rejectedType)
+                : base(MessagePackSerializerOptions.Standard)
+            {
+                this.rejectedType = rejectedType;
+            }
+
+            private DisallowingTypeOptions(DisallowingTypeOptions copyFrom)
+                : base(copyFrom)
+            {
+                this.rejectedType = copyFrom.rejectedType;
+            }
+
+            public override void ThrowIfDeserializingTypeIsDisallowed(Type type)
+            {
+                if (type == this.rejectedType)
+                {
+                    throw new TypeAccessException();
+                }
+            }
+
+            protected override MessagePackSerializerOptions Clone() => new DisallowingTypeOptions(this);
         }
     }
 }

--- a/tests/MessagePack.Tests/ToJsonTest.cs
+++ b/tests/MessagePack.Tests/ToJsonTest.cs
@@ -47,6 +47,19 @@ namespace MessagePack.Tests
             this.JsonConvert(json, LZ4Standard).Is(json);
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        [Trait("CWE", "674")]
+        public void ConvertFromJsonRejectsExcessiveNesting(bool compression)
+        {
+            var options = MessagePackSerializerOptions.Standard
+                .WithCompression(compression ? MessagePackCompression.Lz4Block : MessagePackCompression.None)
+                .WithSecurity(MessagePackSecurity.UntrustedData.WithMaximumObjectGraphDepth(3));
+
+            Assert.Throws<InsufficientExecutionStackException>(() => MessagePackSerializer.ConvertFromJson("[[[[1]]]]", options));
+        }
+
         [Fact]
         public void FloatJson()
         {

--- a/tests/MessagePack.Tests/ToJsonTest.cs
+++ b/tests/MessagePack.Tests/ToJsonTest.cs
@@ -48,6 +48,16 @@ namespace MessagePack.Tests
         }
 
         [Fact]
+        [Trait("CWE", "674")]
+        public void ConvertFromJsonSkipsLongSeparatorRunIteratively()
+        {
+            var json = new string(',', 200_000) + "null";
+            var msgpack = MessagePackSerializer.ConvertFromJson(json);
+
+            MessagePackSerializer.ConvertToJson(msgpack).Is("null");
+        }
+
+        [Fact]
         public void FloatJson()
         {
             var f = 3.33f;

--- a/tests/MessagePack.Tests/UnsafeMemoryTest.cs
+++ b/tests/MessagePack.Tests/UnsafeMemoryTest.cs
@@ -3,15 +3,9 @@
 
 using System;
 using System.Buffers;
-using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
-using MessagePack.Formatters;
 using MessagePack.Internal;
 using Nerdbank.Streams;
-using Xunit;
 
 namespace MessagePack.Tests
 {
@@ -67,6 +61,35 @@ namespace MessagePack.Tests
                 dstWriter.Flush();
                 dst.Length.Is(i);
                 src.AsSpan().SequenceEqual(CodeGenHelpers.GetSpanFromSequence(dst.AsReadOnlySequence)).IsTrue();
+            }
+        }
+
+        [Fact]
+        public void WriteRaw_LargerSpan()
+        {
+            ReadOnlySpan<byte> src = new byte[MessagePackRange.MaxFixStringLength + 15];
+            Sequence<byte> dst = new();
+
+            // x86
+            for (int i = 1; i <= MessagePackRange.MaxFixStringLength; i++)
+            {
+                dst.Reset();
+                MessagePackWriter dstWriter = new(dst);
+                (typeof(UnsafeMemory32).GetMethod("WriteRaw" + i).CreateDelegate(typeof(WriteDelegate)) as WriteDelegate).Invoke(ref dstWriter, src);
+                dstWriter.Flush();
+                dst.Length.Is(i);
+                src[0..i].SequenceEqual(CodeGenHelpers.GetSpanFromSequence(dst.AsReadOnlySequence)).IsTrue();
+            }
+
+            // x64
+            for (int i = 1; i <= MessagePackRange.MaxFixStringLength; i++)
+            {
+                dst.Reset();
+                var dstWriter = new MessagePackWriter(dst);
+                (typeof(UnsafeMemory64).GetMethod("WriteRaw" + i).CreateDelegate(typeof(WriteDelegate)) as WriteDelegate).Invoke(ref dstWriter, src);
+                dstWriter.Flush();
+                dst.Length.Is(i);
+                src[0..i].SequenceEqual(CodeGenHelpers.GetSpanFromSequence(dst.AsReadOnlySequence)).IsTrue();
             }
         }
 


### PR DESCRIPTION
- **Fix WriteRawX methods to advance by written length**
- **Bound LZ4 input reads for CWE-125**
- **Reject nested typeless blocklist bypass for CWE-502**
- **Use iteration for skipping msgpack structures for CWE-674**
- **Reject invalid DateTime ext lengths for CWE-789**
- **Fix CWE-789 multidimensional array allocation validation**
- **Guard dynamic union depth for CWE-674**
- **Use secure lookup comparer for CWE-407**
- **Validate Unity blit lengths for CWE-789**
- **Guard JSON conversion depth for CWE-674**
- **Avoid JSON separator recursion for CWE-674**
- **Guard typeless JSON depth for CWE-674**
- **Fix CWE-190 map header length overflow**
- **Limit untrusted ExpandoObject maps for CWE-407**
- **Default MVC input formatter to UntrustedData for CWE-1188**
- **Guard LZ4 decompression length for CWE-409**
- **Honor TypeFormatter options hooks for CWE-470**
